### PR TITLE
Fix 6 LiveView wiring bugs from Phase 3

### DIFF
--- a/lib/loom/repo_intel/repo_map.ex
+++ b/lib/loom/repo_intel/repo_map.ex
@@ -36,7 +36,12 @@ defmodule Loom.RepoIntel.RepoMap do
     mentioned_files = Keyword.get(opts, :mentioned_files, [])
     keywords = Keyword.get(opts, :keywords, [])
 
-    entries = Index.list_files()
+    entries =
+      try do
+        Index.list_files()
+      catch
+        :exit, _ -> []
+      end
 
     ranked =
       rank_files(entries,

--- a/lib/loom/session/context_window.ex
+++ b/lib/loom/session/context_window.ex
@@ -55,6 +55,7 @@ defmodule Loom.Session.ContextWindow do
   def inject_decision_context(system_parts, nil), do: system_parts
 
   def inject_decision_context(system_parts, session_id) do
+    # build/2 has a default arg, so Elixir generates build/1 as well — checking arity 1 is correct
     if Code.ensure_loaded?(Loom.Decisions.ContextBuilder) &&
          function_exported?(Loom.Decisions.ContextBuilder, :build, 1) do
       case Loom.Decisions.ContextBuilder.build(session_id) do


### PR DESCRIPTION
## Summary
- **Bug 1 (P1)**: File selection no longer crashes — `{:select_file, path}` handled in WorkspaceLive with split-pane file preview
- **Bug 2 (P1)**: Model dropdown changes now propagate to session GenServer via new `Session.update_model/2` API
- **Bug 3 (P1)**: Diff and Terminal tabs are wired — `tool_complete` results parsed into `@diffs` / `@shell_commands` assigns
- **Bug 4 (P1)**: Permission flow is async through LiveView — replaces blocking `Prompt.ask` with PubSub-based `PermissionComponent` modal
- **Bug 5 (P2)**: Clarifying comment on `ContextBuilder` arity check (false positive, no code change)
- **Bug 6 (P2)**: `RepoIntel.Index` lazy-started for web sessions; `RepoMap.generate` has defense-in-depth `try/catch`

## Test plan
- [x] `mix compile` — zero warnings
- [x] `mix test` — 226 tests, 0 failures
- [ ] Manual: click file in tree → preview pane appears (no crash)
- [ ] Manual: change model dropdown → session GenServer updates
- [ ] Manual: run shell command → Terminal tab populates
- [ ] Manual: run file edit → Diff tab populates
- [ ] Manual: permission modal appears for tool execution when `auto_approve: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)