### PR TITLE
Epic 5.8: Smart Context Retrieval

### DIFF
--- a/lib/loom/models.ex
+++ b/lib/loom/models.ex
@@ -1,0 +1,71 @@
+defmodule Loom.Models do
+  @moduledoc """
+  Dynamic model discovery based on configured API keys and LLMDB catalog.
+
+  Checks which provider API keys are present in the environment,
+  then queries LLMDB for chat-capable models from those providers.
+  Users can also type any `provider:model` string directly.
+  """
+
+  # Provider atom → {display name, env var name}
+  @providers %{
+    anthropic: {"Anthropic", "ANTHROPIC_API_KEY"},
+    openai: {"OpenAI", "OPENAI_API_KEY"},
+    google: {"Google", "GOOGLE_API_KEY"},
+    zai: {"Z.AI", "ZAI_API_KEY"},
+    xai: {"xAI", "XAI_API_KEY"},
+    groq: {"Groq", "GROQ_API_KEY"},
+    deepseek: {"DeepSeek", "DEEPSEEK_API_KEY"},
+    openrouter: {"OpenRouter", "OPENROUTER_API_KEY"},
+    mistral: {"Mistral", "MISTRAL_API_KEY"},
+    cerebras: {"Cerebras", "CEREBRAS_API_KEY"},
+    togetherai: {"Together AI", "TOGETHER_API_KEY"},
+    fireworks_ai: {"Fireworks AI", "FIREWORKS_API_KEY"},
+    cohere: {"Cohere", "COHERE_API_KEY"},
+    perplexity: {"Perplexity", "PERPLEXITY_API_KEY"},
+    nvidia: {"NVIDIA", "NVIDIA_API_KEY"},
+    azure: {"Azure", "AZURE_API_KEY"}
+  }
+
+  @doc """
+  Returns `[{provider_name, [{model_label, "provider:model_id"}, ...]}]`
+  for all providers that have an API key set in the environment.
+  """
+  def available_models do
+    @providers
+    |> Enum.filter(fn {_provider, {_name, env_var}} ->
+      key = System.get_env(env_var)
+      key != nil and key != ""
+    end)
+    |> Enum.map(fn {provider, {display_name, _env_var}} ->
+      models = fetch_provider_models(provider)
+      {display_name, models}
+    end)
+    |> Enum.reject(fn {_name, models} -> models == [] end)
+    |> Enum.sort_by(fn {name, _} -> name end)
+  end
+
+  @doc "Returns the list of all known provider atoms and their env var names."
+  def known_providers, do: @providers
+
+  defp fetch_provider_models(provider) do
+    LLMDB.models(provider)
+    |> Enum.filter(&chat_capable?/1)
+    |> Enum.reject(fn m -> m.deprecated || m.retired end)
+    |> Enum.sort_by(&model_sort_key/1, :desc)
+    |> Enum.map(fn m ->
+      {m.name || m.id, "#{provider}:#{m.id}"}
+    end)
+  rescue
+    _ -> []
+  end
+
+  defp chat_capable?(%{capabilities: %{chat: true}}), do: true
+  defp chat_capable?(_), do: false
+
+  defp model_sort_key(model) do
+    # Sort by release date descending (newest first), then name
+    date = model.release_date || "0000-00-00"
+    {date, model.id}
+  end
+end

--- a/lib/loom/teams/context_retrieval.ex
+++ b/lib/loom/teams/context_retrieval.ex
@@ -61,36 +61,63 @@ defmodule Loom.Teams.ContextRetrieval do
   Options:
     - `:keeper_id` - retrieve from a specific keeper
     - `:max_tokens` - maximum tokens to return (default 8000)
+    - `:mode` - `:smart` for LLM-summarized answers, `:raw` for raw messages.
+      When omitted, auto-detected from query (questions → :smart, keywords → :raw).
 
   Returns `{:ok, messages}` or `{:error, :not_found}`.
   """
   def retrieve(team_id, query, opts \\ []) do
     keeper_id = Keyword.get(opts, :keeper_id)
     _max_tokens = Keyword.get(opts, :max_tokens, @default_max_tokens)
+    mode = Keyword.get(opts, :mode, detect_mode(query))
 
     if keeper_id do
-      retrieve_from_keeper(team_id, keeper_id, query)
+      retrieve_from_keeper(team_id, keeper_id, query, mode)
     else
-      retrieve_from_best(team_id, query)
+      retrieve_from_best(team_id, query, mode)
     end
+  end
+
+  @doc "Smart retrieval — asks keepers a question and gets a focused answer."
+  def smart_retrieve(team_id, question, opts \\ []) do
+    retrieve(team_id, question, Keyword.put(opts, :mode, :smart))
   end
 
   # --- Private ---
 
-  defp retrieve_from_keeper(team_id, keeper_id, query) do
+  @question_starters ~w(what how why where when who which did does is are was were can could should would)
+
+  @doc false
+  def detect_mode(query) do
+    downcased = String.downcase(String.trim(query))
+
+    cond do
+      String.contains?(query, "?") -> :smart
+      Enum.any?(@question_starters, &String.starts_with?(downcased, &1 <> " ")) -> :smart
+      true -> :raw
+    end
+  end
+
+  defp retrieve_from_keeper(team_id, keeper_id, query, mode) do
     case Registry.lookup(Loom.Teams.AgentRegistry, {team_id, "keeper:#{keeper_id}"}) do
       [{pid, _meta}] ->
-        ContextKeeper.retrieve(pid, query)
+        case mode do
+          :smart -> ContextKeeper.smart_retrieve(pid, query)
+          :raw -> ContextKeeper.retrieve(pid, query)
+        end
 
       [] ->
         {:error, :not_found}
     end
   end
 
-  defp retrieve_from_best(team_id, query) do
-    case search(team_id, query) do
+  defp retrieve_from_best(team_id, query, mode) do
+    case search(team_id, query) |> Enum.filter(&(&1.relevance > 0)) do
       [best | _rest] ->
-        ContextKeeper.retrieve(best.pid, query)
+        case mode do
+          :smart -> ContextKeeper.smart_retrieve(best.pid, query)
+          :raw -> ContextKeeper.retrieve(best.pid, query)
+        end
 
       [] ->
         {:error, :not_found}

--- a/lib/loom_web/live/model_selector_component.ex
+++ b/lib/loom_web/live/model_selector_component.ex
@@ -1,56 +1,100 @@
 defmodule LoomWeb.ModelSelectorComponent do
   use LoomWeb, :live_component
 
-  @models [
-    {"Anthropic", [
-      {"claude-opus-4-6", "anthropic:claude-opus-4-6"},
-      {"claude-sonnet-4-6", "anthropic:claude-sonnet-4-6"},
-      {"claude-haiku-4-5", "anthropic:claude-haiku-4-5"}
-    ]},
-    {"OpenAI", [
-      {"gpt-4o", "openai:gpt-4o"},
-      {"gpt-4o-mini", "openai:gpt-4o-mini"}
-    ]},
-    {"Google", [
-      {"gemini-2.0-flash", "google:gemini-2.0-flash"}
-    ]}
-  ]
-
   def update(assigns, socket) do
+    models = Loom.Models.available_models()
+
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(models: @models)}
+     |> assign(models: models, custom_mode: false, custom_value: "")}
   end
 
   def render(assigns) do
     ~H"""
-    <div>
-      <select
-        phx-change="change_model"
-        phx-target={@myself}
-        class="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-      >
-        <optgroup :for={{provider, models} <- @models} label={provider}>
-          <option :for={{label, value} <- models} value={value} selected={value == @model}>
-            {label}
-          </option>
-        </optgroup>
-      </select>
+    <div class="flex items-center gap-1">
+      <%= if @custom_mode do %>
+        <form phx-submit="apply_custom" phx-target={@myself} class="flex items-center gap-1">
+          <input
+            type="text"
+            name="model"
+            value={@custom_value}
+            placeholder="provider:model-id"
+            autofocus
+            phx-keydown="custom_key"
+            phx-target={@myself}
+            class="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded-md px-2 py-1 w-48 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          />
+          <button
+            type="submit"
+            class="text-xs text-indigo-400 hover:text-indigo-300 px-1"
+          >
+            OK
+          </button>
+          <button
+            type="button"
+            phx-click="cancel_custom"
+            phx-target={@myself}
+            class="text-xs text-gray-500 hover:text-gray-300 px-1"
+          >
+            &times;
+          </button>
+        </form>
+      <% else %>
+        <select
+          phx-change="change_model"
+          phx-target={@myself}
+          class="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        >
+          <%= if @models == [] do %>
+            <option value={@model} selected>{@model}</option>
+          <% else %>
+            <%= if not model_in_list?(@model, @models) do %>
+              <option value={@model} selected>{@model}</option>
+            <% end %>
+            <optgroup :for={{provider, models} <- @models} label={provider}>
+              <option :for={{label, value} <- models} value={value} selected={value == @model}>
+                {label}
+              </option>
+            </optgroup>
+          <% end %>
+          <option value="__custom__">Custom model...</option>
+        </select>
+      <% end %>
     </div>
     """
   end
 
-  def handle_event("change_model", %{"_target" => _, "model" => model}, socket) do
+  def handle_event("change_model", params, socket) do
+    model = extract_model_value(params)
+
+    if model == "__custom__" do
+      {:noreply, assign(socket, custom_mode: true, custom_value: socket.assigns.model)}
+    else
+      if model, do: send(self(), {:change_model, model})
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("apply_custom", %{"model" => model}, socket) when model != "" do
     send(self(), {:change_model, model})
+    {:noreply, assign(socket, custom_mode: false, custom_value: "")}
+  end
+
+  def handle_event("apply_custom", _params, socket) do
     {:noreply, socket}
   end
 
-  def handle_event("change_model", params, socket) do
-    # The select value comes in the params map — extract it
-    model = extract_model_value(params)
-    if model, do: send(self(), {:change_model, model})
+  def handle_event("custom_key", %{"key" => "Escape"}, socket) do
+    {:noreply, assign(socket, custom_mode: false)}
+  end
+
+  def handle_event("custom_key", _params, socket) do
     {:noreply, socket}
+  end
+
+  def handle_event("cancel_custom", _params, socket) do
+    {:noreply, assign(socket, custom_mode: false)}
   end
 
   defp extract_model_value(params) do
@@ -58,5 +102,11 @@ defmodule LoomWeb.ModelSelectorComponent do
     |> Map.drop(["_target"])
     |> Map.values()
     |> List.first()
+  end
+
+  defp model_in_list?(model, groups) do
+    Enum.any?(groups, fn {_provider, models} ->
+      Enum.any?(models, fn {_label, value} -> value == model end)
+    end)
   end
 end


### PR DESCRIPTION
## Summary

- **Smart query mode** for Context Keepers — single cheap LLM call to answer questions about stored context instead of returning raw message dumps
- **Auto-detecting retrieval API** — questions default to smart mode, keywords to raw mode, with explicit override
- **QueryRouter integration** — knowledge routing auto-queries keepers before forwarding to agents, injecting focused context as enrichments
- **Head-of-line blocking fix** — keeper retrieval runs in async Task with 5s timeout, never blocks router GenServer
- **Zero-relevance filtering** — irrelevant keepers (0 topic overlap) are skipped, reducing noise and LLM cost
- **Dynamic model selector** — `Loom.Models` discovers available providers from API keys + LLMDB catalog

## Key files

| File | Change |
|------|--------|
| `context_keeper.ex` | `smart_retrieve/2`, LLM call + keyword fallback (always returns binary) |
| `context_retrieval.ex` | `mode: :smart/:raw`, `detect_mode/1` heuristic, relevance filtering |
| `query_router.ex` | `fetch_keeper_context/2` via `Task.Supervisor.async_nolink` |
| `models.ex` | Dynamic model discovery from env keys |
| `model_selector_component.ex` | Custom model input, dynamic provider groups |

## Known open items (not in this PR)

1. **`context_retrieve` tool missing** — no agent-facing tool for context retrieval exists yet; agents can't explicitly query keepers via tool calls. Protocol-level gap from 5.3/5.4.
2. **Agent `{:query, ...}` handling** — `Teams.Agent` has no `handle_info` for query/query_answer messages (hits catch-all). Same 5.3/5.4 gap.
3. **Sandbox flakiness** — `async_persist` spawns tasks outside Ecto Sandbox ownership. Pre-existing, intermittent.

## Test plan

- [x] `mix test test/loom/teams/context_keeper_test.exs` — 15 tests (smart_retrieve fallback, state immutability, keyword matching)
- [x] `mix test test/loom/teams/context_retrieval_test.exs` — 20 tests (detect_mode heuristic, smart/raw routing, relevance filtering)
- [x] `mix test test/loom/teams/query_router_test.exs` — 14 tests (keeper enrichment injection, empty keepers, graceful degradation, content assertions)
- [x] 49 total tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)