### PR TITLE
UI polish: warm cozy dark-mode redesign with API key guidance

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -25,3 +25,202 @@ body {
 .phx-submit-loading .phx-submit-loading-hide {
   display: none;
 }
+
+/* ── Custom Scrollbar ── */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #4f46e5;
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #6366f1;
+}
+
+/* ── Focus Ring Override ── */
+*:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.3);
+  border-radius: inherit;
+}
+
+/* ── Tab Content Transition ── */
+.tab-content-enter {
+  animation: fadeIn 0.2s ease-out;
+}
+
+/* ── Keyframes ── */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes scaleIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes pulse-soft {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% center; }
+  100% { background-position: 200% center; }
+}
+
+/* ── Header Bottom Glow ── */
+.header-glow {
+  box-shadow: 0 1px 0 0 rgba(129, 140, 248, 0.15),
+              0 4px 12px -4px rgba(129, 140, 248, 0.08);
+}
+
+/* ── Chevron Rotation ── */
+.chevron-rotate {
+  transition: transform 0.2s ease;
+}
+
+.chevron-rotate.expanded {
+  transform: rotate(90deg);
+}
+
+/* ── Status Dot Pulse ── */
+.status-dot-idle {
+  box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.4);
+  animation: dot-pulse-green 2s ease-in-out infinite;
+}
+
+@keyframes dot-pulse-green {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.4); }
+  50% { box-shadow: 0 0 0 4px rgba(74, 222, 128, 0); }
+}
+
+.status-dot-thinking {
+  animation: pulse-soft 1.5s ease-in-out infinite;
+}
+
+/* ── Mode Toggle Pill ── */
+.mode-toggle {
+  position: relative;
+}
+
+.mode-toggle .mode-slider {
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Send Button Pulse ── */
+.send-btn-ready {
+  animation: send-pulse 2.5s ease-in-out infinite;
+}
+
+@keyframes send-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.3); }
+  50% { box-shadow: 0 0 0 6px rgba(99, 102, 241, 0); }
+}
+
+/* ── Bounce Dots (Thinking) ── */
+@keyframes bounceDot {
+  0%, 80%, 100% {
+    transform: scale(0);
+    opacity: 0.3;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.animate-fade-in-up {
+  animation: fadeInUp 0.3s ease-out;
+}
+
+.thinking-dot {
+  animation: bounceDot 1.4s infinite ease-in-out both;
+}
+
+.thinking-dot:nth-child(1) {
+  animation-delay: -0.32s;
+}
+
+.thinking-dot:nth-child(2) {
+  animation-delay: -0.16s;
+}
+
+.thinking-dot:nth-child(3) {
+  animation-delay: 0s;
+}
+
+/* ── Tool Cards ── */
+
+.tool-card .tool-card-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease-out, padding 0.25s ease-out;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.tool-card.tool-expanded .tool-card-body {
+  max-height: 500px;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  transition: max-height 0.35s ease-in, padding 0.2s ease-in;
+}
+
+.tool-card .tool-card-chevron {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.tool-card.tool-expanded .tool-card-chevron {
+  transform: rotate(90deg);
+}
+
+.tool-file-paths {
+  word-break: break-all;
+}
+
+/* ── Chat Markdown Styling ── */
+
+.chat-markdown pre {
+  @apply bg-gray-950 rounded-lg border border-gray-800/60 p-3 my-2 overflow-x-auto;
+}
+
+.chat-markdown pre code {
+  @apply text-xs leading-relaxed;
+}
+
+.chat-markdown code:not(pre code) {
+  @apply bg-gray-800 rounded px-1.5 py-0.5 text-xs text-indigo-300;
+}
+
+.chat-markdown a {
+  @apply text-indigo-400 hover:text-indigo-300 underline underline-offset-2;
+  transition: color 0.15s ease;
+}
+
+.chat-markdown p {
+  @apply leading-relaxed;
+}
+
+.chat-markdown ul, .chat-markdown ol {
+  @apply ml-4 space-y-1;
+}
+
+.chat-markdown blockquote {
+  @apply border-l-2 border-indigo-500/30 pl-3 text-gray-400 italic;
+}

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -15,7 +15,31 @@ module.exports = {
     extend: {
       colors: {
         brand: "#818cf8",
-      }
+      },
+      animation: {
+        'fade-in': 'fadeIn 0.2s ease-out',
+        'fade-in-up': 'fadeInUp 0.3s ease-out',
+        'scale-in': 'scaleIn 0.2s ease-out',
+        'pulse-soft': 'pulse-soft 2s ease-in-out infinite',
+      },
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: '0', transform: 'translateY(4px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        fadeInUp: {
+          '0%': { opacity: '0', transform: 'translateY(8px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        scaleIn: {
+          '0%': { opacity: '0', transform: 'scale(0.95)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
+        },
+        'pulse-soft': {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0.5' },
+        },
+      },
     },
   },
   plugins: [

--- a/lib/loom_web/live/chat_component.ex
+++ b/lib/loom_web/live/chat_component.ex
@@ -11,47 +11,70 @@ defmodule LoomWeb.ChatComponent do
     ~H"""
     <div class="flex-1 overflow-auto" id="chat-messages" phx-hook="ScrollToBottom">
       <div class="flex flex-col gap-4 p-4">
-        <div :if={@messages == []} class="flex items-center justify-center h-64 text-gray-500">
-          <div class="text-center">
-            <p class="text-lg font-medium">Welcome to Loom</p>
-            <p class="text-sm mt-1">Send a message to start your coding session.</p>
+        <%!-- Empty State --%>
+        <div :if={@messages == []} class="flex items-center justify-center h-64">
+          <div class="text-center space-y-4">
+            <div class="w-12 h-12 mx-auto rounded-2xl bg-indigo-600/20 flex items-center justify-center shadow-lg shadow-indigo-500/10">
+              <span class="text-xl font-bold text-indigo-400">L</span>
+            </div>
+            <div>
+              <p class="text-lg font-medium text-gray-300">What shall we build today?</p>
+              <p class="text-sm text-gray-500 mt-1">Send a message to start your coding session.</p>
+            </div>
+            <div class="flex flex-wrap gap-2 justify-center pt-2">
+              <span class="px-3 py-1.5 text-xs bg-gray-800/80 text-gray-400 rounded-full border border-gray-700/50 hover:border-indigo-500/30 hover:text-gray-300 transition-all duration-200 cursor-default">
+                Explore this codebase
+              </span>
+              <span class="px-3 py-1.5 text-xs bg-gray-800/80 text-gray-400 rounded-full border border-gray-700/50 hover:border-indigo-500/30 hover:text-gray-300 transition-all duration-200 cursor-default">
+                Fix a bug
+              </span>
+              <span class="px-3 py-1.5 text-xs bg-gray-800/80 text-gray-400 rounded-full border border-gray-700/50 hover:border-indigo-500/30 hover:text-gray-300 transition-all duration-200 cursor-default">
+                Add a feature
+              </span>
+            </div>
           </div>
         </div>
 
-        <div :for={msg <- @messages} class={message_container_class(msg)}>
+        <%!-- Messages --%>
+        <div :for={msg <- @messages} class="animate-fade-in-up">
           <%= case msg.role do %>
             <% :user -> %>
-              <div class="flex items-start gap-2 justify-end max-w-[80%] ml-auto">
-                <div class="bg-gray-700 rounded-lg px-3 py-2 text-sm">
-                  <p class="whitespace-pre-wrap">{msg.content}</p>
+              <div class="flex items-start gap-3 justify-end max-w-[80%] ml-auto">
+                <div class="bg-gray-700/80 rounded-2xl px-4 py-2.5 text-sm shadow-sm">
+                  <p class="whitespace-pre-wrap leading-relaxed">{msg.content}</p>
                 </div>
-                <div class="w-7 h-7 rounded-full bg-gray-600 flex items-center justify-center flex-shrink-0">
-                  <span class="text-xs font-medium">U</span>
+                <div class="w-7 h-7 rounded-full bg-gradient-to-br from-amber-500 to-orange-600 flex items-center justify-center flex-shrink-0 shadow-sm">
+                  <span class="text-xs font-bold text-white">U</span>
                 </div>
               </div>
 
             <% :assistant -> %>
-              <div class="flex items-start gap-2 max-w-[80%]">
-                <div class="w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center flex-shrink-0">
-                  <span class="text-xs font-bold">L</span>
+              <div class="flex items-start gap-3 max-w-[85%]">
+                <div class="w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center flex-shrink-0 shadow-lg shadow-indigo-500/30">
+                  <span class="text-xs font-bold text-white">L</span>
                 </div>
-                <div class="bg-gray-800 rounded-lg px-3 py-2 text-sm">
-                  <div class="prose prose-invert prose-sm max-w-none">
+                <div class="border-l-2 border-indigo-500/40 pl-3 py-0.5">
+                  <div class="prose prose-invert prose-sm max-w-none chat-markdown">
                     {render_markdown(msg.content)}
                   </div>
                 </div>
               </div>
 
             <% :tool -> %>
-              <div class="max-w-[80%] ml-8">
-                <details class="bg-gray-800/50 border border-gray-700 rounded-lg overflow-hidden">
-                  <summary class="px-3 py-2 text-xs text-gray-400 cursor-pointer hover:bg-gray-800 select-none">
-                    Tool result: {msg[:tool_call_id] || "unknown"}
-                  </summary>
-                  <div class="px-3 py-2 border-t border-gray-700">
-                    <pre class="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto font-mono">{truncate_result(msg.content)}</pre>
+              <div class="max-w-[85%] ml-10 animate-fade-in-up">
+                <div class={"tool-card rounded-xl overflow-hidden border transition-all duration-200 #{tool_card_border(msg)}"}>
+                  <div
+                    class={"flex items-center gap-2 px-3 py-2 cursor-pointer select-none text-xs font-medium #{tool_card_header(msg)}"}
+                    onclick="this.parentElement.classList.toggle('tool-expanded')"
+                  >
+                    <span class="tool-card-icon">{tool_icon(msg)}</span>
+                    <span>{tool_display_name(msg)}</span>
+                    <span class="ml-auto text-gray-500 tool-card-chevron transition-transform duration-200">&#9656;</span>
                   </div>
-                </details>
+                  <div class="tool-card-body px-3 py-2 border-t border-gray-800/50 bg-gray-900/30">
+                    <pre class="text-xs text-gray-400 whitespace-pre-wrap overflow-x-auto font-mono leading-relaxed tool-file-paths">{truncate_result(msg.content)}</pre>
+                  </div>
+                </div>
               </div>
 
             <% _ -> %>
@@ -61,34 +84,34 @@ defmodule LoomWeb.ChatComponent do
           <% end %>
         </div>
 
-        <div :if={@status == :thinking} class="flex items-start gap-2 max-w-[80%]">
-          <div class="w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center flex-shrink-0">
-            <span class="text-xs font-bold">L</span>
+        <%!-- Thinking State --%>
+        <div :if={@status == :thinking} class="flex items-start gap-3 max-w-[80%] animate-fade-in-up">
+          <div class="w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center flex-shrink-0 shadow-lg shadow-indigo-500/30">
+            <span class="text-xs font-bold text-white">L</span>
           </div>
-          <div class="bg-gray-800 rounded-lg px-3 py-2">
-            <div class="flex items-center gap-2 text-sm text-gray-400">
-              <span class="inline-block w-2 h-2 bg-indigo-400 rounded-full animate-pulse"></span>
-              Thinking...
+          <div class="bg-gray-800/60 rounded-xl px-4 py-3 shadow-sm shadow-indigo-500/5 border border-indigo-500/10">
+            <div class="flex items-center gap-1.5">
+              <span class="thinking-dot w-2 h-2 bg-indigo-400 rounded-full"></span>
+              <span class="thinking-dot w-2 h-2 bg-indigo-400 rounded-full"></span>
+              <span class="thinking-dot w-2 h-2 bg-indigo-400 rounded-full"></span>
             </div>
           </div>
         </div>
 
-        <div :if={@current_tool} class="flex items-center gap-2 ml-9 text-xs text-gray-400">
-          <svg class="animate-spin h-3 w-3 text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-          </svg>
-          Running {@current_tool}...
+        <%!-- Tool Executing State --%>
+        <div :if={@current_tool} class="flex items-center gap-2 ml-10 animate-fade-in-up">
+          <div class="flex items-center gap-2 px-3 py-1.5 bg-gray-800/40 rounded-lg border border-indigo-500/10 shadow-sm shadow-indigo-500/5">
+            <svg class="animate-spin h-3.5 w-3.5 text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+            </svg>
+            <span class="text-xs text-gray-400">Running <span class="text-indigo-400 font-medium">{@current_tool}</span></span>
+          </div>
         </div>
       </div>
     </div>
     """
   end
-
-  defp message_container_class(%{role: :user}), do: ""
-  defp message_container_class(%{role: :assistant}), do: ""
-  defp message_container_class(%{role: :tool}), do: ""
-  defp message_container_class(_), do: ""
 
   defp render_markdown(nil), do: ""
 
@@ -107,4 +130,55 @@ defmodule LoomWeb.ChatComponent do
   end
 
   defp truncate_result(text), do: text
+
+  # Tool card styling helpers
+
+  defp tool_call_id(msg), do: msg[:tool_call_id] || ""
+
+  defp tool_type(msg) do
+    id = tool_call_id(msg)
+
+    cond do
+      String.contains?(id, "file") or String.contains?(id, "read") or String.contains?(id, "write") or String.contains?(id, "edit") -> :file
+      String.contains?(id, "shell") or String.contains?(id, "bash") or String.contains?(id, "exec") -> :shell
+      String.contains?(id, "search") or String.contains?(id, "grep") or String.contains?(id, "glob") -> :search
+      String.contains?(id, "decision") or String.contains?(id, "plan") -> :decision
+      true -> :default
+    end
+  end
+
+  defp tool_card_header(msg) do
+    case tool_type(msg) do
+      :file -> "bg-indigo-500/10 text-indigo-300"
+      :shell -> "bg-emerald-500/10 text-emerald-300"
+      :search -> "bg-amber-500/10 text-amber-300"
+      :decision -> "bg-purple-500/10 text-purple-300"
+      :default -> "bg-gray-800/50 text-gray-400"
+    end
+  end
+
+  defp tool_card_border(msg) do
+    case tool_type(msg) do
+      :file -> "border-indigo-500/20"
+      :shell -> "border-emerald-500/20"
+      :search -> "border-amber-500/20"
+      :decision -> "border-purple-500/20"
+      :default -> "border-gray-700/50"
+    end
+  end
+
+  defp tool_icon(msg) do
+    case tool_type(msg) do
+      :file -> "&#128196;"
+      :shell -> "&#9002;"
+      :search -> "&#128269;"
+      :decision -> "&#9670;"
+      :default -> "&#9881;"
+    end
+  end
+
+  defp tool_display_name(msg) do
+    id = tool_call_id(msg)
+    if id == "", do: "Tool result", else: id
+  end
 end

--- a/lib/loom_web/live/diff_component.ex
+++ b/lib/loom_web/live/diff_component.ex
@@ -39,39 +39,53 @@ defmodule LoomWeb.DiffComponent do
       </div>
 
       <div class="flex-1 overflow-y-auto">
+        <%!-- Empty State --%>
         <%= if @parsed_diffs == [] do %>
           <div class="flex items-center justify-center h-full">
-            <p class="text-gray-500">No changes to display</p>
+            <div class="text-center space-y-2">
+              <div class="text-gray-600 text-2xl">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 mx-auto text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+                </svg>
+              </div>
+              <p class="text-gray-500 text-xs">No changes to review</p>
+            </div>
           </div>
         <% else %>
-          <div :for={{diff, idx} <- Enum.with_index(@parsed_diffs)} class="border-b border-gray-800">
+          <div :for={{diff, idx} <- Enum.with_index(@parsed_diffs)} class="border-b border-gray-800/60 animate-fade-in-up">
+            <%!-- File Header --%>
             <div
-              class="flex items-center gap-2 px-3 py-2 bg-gray-900/50 cursor-pointer hover:bg-gray-800/60 sticky top-0 z-10"
+              class="flex items-center gap-2 px-3 py-2.5 bg-gray-900/40 cursor-pointer hover:bg-gray-800/50 sticky top-0 z-10 transition-colors duration-200 border-b border-gray-800/40"
               phx-click="toggle_diff"
               phx-value-index={idx}
               phx-target={@myself}
             >
-              <span class="text-gray-500">
+              <span class="text-gray-500 transition-transform duration-200">
                 <%= if MapSet.member?(@collapsed, idx) do %>&#9656;<% else %>&#9662;<% end %>
               </span>
-              <span class="text-indigo-400 truncate">{diff.file_path}</span>
-              <span class="ml-auto text-xs text-gray-500">
-                <span :if={diff.additions > 0} class="text-green-400">+{diff.additions}</span>
-                <span :if={diff.deletions > 0} class="text-red-400 ml-1">-{diff.deletions}</span>
-              </span>
+              <%!-- File Icon --%>
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-gray-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+              </svg>
+              <span class="text-indigo-400 truncate text-xs">{diff.file_path}</span>
+              <div class="ml-auto flex items-center gap-1.5">
+                <span :if={diff.additions > 0} class="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-400 font-medium">+{diff.additions}</span>
+                <span :if={diff.deletions > 0} class="text-[10px] px-1.5 py-0.5 rounded-full bg-rose-500/10 text-rose-400 font-medium">-{diff.deletions}</span>
+              </div>
             </div>
 
+            <%!-- Diff Lines --%>
             <div :if={not MapSet.member?(@collapsed, idx)} class="overflow-x-auto">
               <table class="w-full border-collapse">
                 <tbody>
-                  <tr :for={line <- diff.lines}>
-                    <td class={["w-12 text-right pr-2 select-none text-xs", line_number_class(line.type)]}>
+                  <tr :for={line <- diff.lines} class={line_row_class(line.type)}>
+                    <td class={["w-10 text-right pr-2 select-none text-[10px] border-r border-gray-800/30", line_number_class(line.type)]}>
                       {line.old_num || ""}
                     </td>
-                    <td class={["w-12 text-right pr-2 select-none text-xs", line_number_class(line.type)]}>
+                    <td class={["w-10 text-right pr-2 select-none text-[10px] border-r border-gray-800/30", line_number_class(line.type)]}>
                       {line.new_num || ""}
                     </td>
-                    <td class={["px-3 py-0 whitespace-pre", line_class(line.type)]}>
+                    <td class={["px-3 py-0 whitespace-pre text-xs", line_class(line.type)]}>
                       <span class={["select-none mr-2", line_marker_class(line.type)]}>{line_marker(line.type)}</span>{line.text}
                     </td>
                   </tr>
@@ -110,7 +124,6 @@ defmodule LoomWeb.DiffComponent do
   end
 
   def parse_diff(%{file_path: file_path} = entry) do
-    # Fallback: show description or raw text
     text = Map.get(entry, :description, Map.get(entry, :text, ""))
 
     lines =
@@ -223,7 +236,6 @@ defmodule LoomWeb.DiffComponent do
     old_lines = String.split(old_text, "\n")
     new_lines = String.split(new_text, "\n")
 
-    # Simple line-by-line diff: show removed then added
     old_set = MapSet.new(old_lines)
     new_set = MapSet.new(new_lines)
 
@@ -239,7 +251,6 @@ defmodule LoomWeb.DiffComponent do
       |> Enum.reject(fn {line, _} -> MapSet.member?(old_set, line) end)
       |> Enum.map(fn {line, num} -> %{type: :add, text: line, old_num: nil, new_num: num} end)
 
-    # Interleave context lines
     context =
       new_lines
       |> Enum.with_index(1)
@@ -249,13 +260,16 @@ defmodule LoomWeb.DiffComponent do
     removed ++ added ++ context
   end
 
-  defp line_class(:add), do: "bg-green-900/30"
-  defp line_class(:del), do: "bg-red-900/30"
-  defp line_class(:hunk_header), do: "bg-indigo-900/20 text-indigo-400"
+  defp line_row_class(:hunk_header), do: "border-l-2 border-indigo-500/30"
+  defp line_row_class(_), do: ""
+
+  defp line_class(:add), do: "bg-emerald-500/10"
+  defp line_class(:del), do: "bg-rose-500/10"
+  defp line_class(:hunk_header), do: "bg-indigo-900/10 text-indigo-400 text-[11px]"
   defp line_class(:context), do: ""
 
-  defp line_number_class(:add), do: "text-green-700 bg-green-900/20"
-  defp line_number_class(:del), do: "text-red-700 bg-red-900/20"
+  defp line_number_class(:add), do: "text-emerald-600 bg-emerald-500/5"
+  defp line_number_class(:del), do: "text-rose-600 bg-rose-500/5"
   defp line_number_class(_), do: "text-gray-600"
 
   defp line_marker(:add), do: "+"
@@ -263,7 +277,7 @@ defmodule LoomWeb.DiffComponent do
   defp line_marker(:hunk_header), do: ""
   defp line_marker(:context), do: " "
 
-  defp line_marker_class(:add), do: "text-green-400"
-  defp line_marker_class(:del), do: "text-red-400"
+  defp line_marker_class(:add), do: "text-emerald-400"
+  defp line_marker_class(:del), do: "text-rose-400"
   defp line_marker_class(_), do: "text-gray-600"
 end

--- a/lib/loom_web/live/file_tree_component.ex
+++ b/lib/loom_web/live/file_tree_component.ex
@@ -76,32 +76,54 @@ defmodule LoomWeb.FileTreeComponent do
     {:noreply, assign(socket, filter: value, tree: filtered_tree)}
   end
 
+  def handle_event("clear_filter", _params, socket) do
+    project_path = socket.assigns.project_path
+    {tree, _count, _size} = build_tree(project_path)
+    {:noreply, assign(socket, filter: "", tree: tree)}
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
     <div class="flex flex-col h-full bg-gray-950 text-gray-100">
-      <div class="px-3 py-2 border-b border-gray-800">
-        <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Explorer</h3>
-        <input
-          type="text"
-          placeholder="Filter files..."
-          value={@filter}
-          phx-keyup="filter"
-          phx-target={@myself}
-          class="w-full px-2 py-1 text-sm bg-gray-900 border border-gray-700 rounded text-gray-200 placeholder-gray-600 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-        />
+      <div class="px-3 py-2.5 border-b border-gray-800">
+        <h3 class="text-[10px] font-semibold text-gray-500 uppercase tracking-widest mb-2">Explorer</h3>
+        <div class="relative">
+          <.icon name="hero-magnifying-glass-mini" class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500" />
+          <input
+            type="text"
+            placeholder="Filter files..."
+            value={@filter}
+            phx-keyup="filter"
+            phx-target={@myself}
+            class="w-full pl-8 pr-8 py-1.5 text-xs bg-gray-800/60 border border-gray-700/50 rounded-lg text-gray-200 placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500/30 focus:border-indigo-500/50 transition-shadow"
+          />
+          <button
+            :if={@filter != ""}
+            phx-click="clear_filter"
+            phx-target={@myself}
+            class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            <.icon name="hero-x-mark-mini" class="w-3.5 h-3.5" />
+          </button>
+        </div>
       </div>
 
       <div class="flex-1 overflow-y-auto px-1 py-1 text-sm font-mono">
         <%= if @tree == [] do %>
-          <p class="px-3 py-4 text-gray-500 text-center">No files indexed</p>
+          <p class="px-3 py-4 text-gray-500 text-center text-xs">No files indexed</p>
         <% else %>
           <.tree_entries entries={@tree} expanded_dirs={@expanded_dirs} depth={0} myself={@myself} />
         <% end %>
       </div>
 
-      <div class="px-3 py-2 border-t border-gray-800 text-xs text-gray-500">
-        {@file_count} files &middot; {format_size(@total_size)}
+      <div class="px-3 py-2 border-t border-gray-800">
+        <div class="flex items-center gap-2 text-[10px] text-gray-600">
+          <.icon name="hero-document-text-mini" class="w-3 h-3" />
+          <span>{@file_count} files</span>
+          <span class="text-gray-700">&middot;</span>
+          <span>{format_size(@total_size)}</span>
+        </div>
       </div>
     </div>
     """
@@ -113,16 +135,17 @@ defmodule LoomWeb.FileTreeComponent do
       <div :for={entry <- @entries}>
         <%= if entry.type == :dir do %>
           <div
-            class="flex items-center gap-1 px-1 py-0.5 rounded cursor-pointer hover:bg-gray-800/60 select-none"
+            class="flex items-center gap-1.5 px-1.5 py-1 rounded-md cursor-pointer hover:bg-gray-800/60 select-none group transition-colors duration-150"
             style={"padding-left: #{@depth * 16 + 4}px"}
             phx-click="toggle_dir"
             phx-value-path={entry.path}
             phx-target={@myself}
           >
-            <span class="text-gray-500 w-4 text-center">
-              <%= if MapSet.member?(@expanded_dirs, entry.path) do %>&#9662;<% else %>&#9656;<% end %>
+            <span class={"text-gray-500 w-3.5 text-center text-[10px] chevron-rotate " <> if(MapSet.member?(@expanded_dirs, entry.path), do: "expanded", else: "")}>
+              &#9654;
             </span>
-            <span class="text-indigo-400">{entry.name}</span>
+            <.icon name="hero-folder-mini" class={"w-3.5 h-3.5 flex-shrink-0 transition-colors " <> if(MapSet.member?(@expanded_dirs, entry.path), do: "text-indigo-400", else: "text-indigo-500/60 group-hover:text-indigo-400")} />
+            <span class="text-gray-300 group-hover:text-gray-200 text-xs transition-colors">{entry.name}</span>
           </div>
           <%= if MapSet.member?(@expanded_dirs, entry.path) do %>
             <.tree_entries
@@ -134,13 +157,14 @@ defmodule LoomWeb.FileTreeComponent do
           <% end %>
         <% else %>
           <div
-            class="flex items-center gap-1 px-1 py-0.5 rounded cursor-pointer hover:bg-gray-800/60 select-none"
+            class="flex items-center gap-1.5 px-1.5 py-1 rounded-md cursor-pointer hover:bg-indigo-500/5 select-none group transition-colors duration-150"
             style={"padding-left: #{@depth * 16 + 20}px"}
             phx-click="select_file"
             phx-value-path={entry.path}
             phx-target={@myself}
           >
-            <span class={file_color(entry.name)}>{entry.name}</span>
+            <span class={"w-1.5 h-1.5 rounded-full flex-shrink-0 " <> file_dot_color(entry.name)} />
+            <span class={"text-xs transition-colors group-hover:text-gray-200 " <> file_color(entry.name)}>{entry.name}</span>
           </div>
         <% end %>
       </div>
@@ -245,6 +269,20 @@ defmodule LoomWeb.FileTreeComponent do
       e when e in [".html", ".heex"] -> "text-orange-400"
       e when e in [".css", ".scss"] -> "text-blue-400"
       _ -> "text-gray-400"
+    end
+  end
+
+  defp file_dot_color(name) do
+    ext = Path.extname(name)
+
+    case ext do
+      e when e in [".ex", ".exs"] -> "bg-violet-400"
+      e when e in [".js", ".jsx", ".mjs", ".ts", ".tsx"] -> "bg-yellow-400"
+      e when e in [".md", ".markdown"] -> "bg-gray-500"
+      e when e in [".json", ".toml", ".yaml", ".yml"] -> "bg-green-400"
+      e when e in [".html", ".heex"] -> "bg-orange-400"
+      e when e in [".css", ".scss"] -> "bg-blue-400"
+      _ -> "bg-gray-500"
     end
   end
 

--- a/lib/loom_web/live/model_selector_component.ex
+++ b/lib/loom_web/live/model_selector_component.ex
@@ -2,83 +2,271 @@ defmodule LoomWeb.ModelSelectorComponent do
   use LoomWeb, :live_component
 
   def update(assigns, socket) do
-    models = Loom.Models.available_models()
+    models = Loom.Models.available_models_enriched()
 
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(models: models, custom_mode: false, custom_value: "")}
+     |> assign(
+       models: models,
+       all_providers: Loom.Models.all_providers_enriched(),
+       custom_mode: false,
+       custom_value: "",
+       open: false,
+       search: ""
+     )}
   end
 
   def render(assigns) do
     ~H"""
-    <div class="flex items-center gap-1">
-      <%= if @custom_mode do %>
-        <form phx-submit="apply_custom" phx-target={@myself} class="flex items-center gap-1">
-          <input
-            type="text"
-            name="model"
-            value={@custom_value}
-            placeholder="provider:model-id"
-            autofocus
-            phx-keydown="custom_key"
-            phx-target={@myself}
-            class="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded-md px-2 py-1 w-48 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-          />
-          <button
-            type="submit"
-            class="text-xs text-indigo-400 hover:text-indigo-300 px-1"
-          >
-            OK
-          </button>
-          <button
-            type="button"
-            phx-click="cancel_custom"
-            phx-target={@myself}
-            class="text-xs text-gray-500 hover:text-gray-300 px-1"
-          >
-            &times;
-          </button>
-        </form>
-      <% else %>
-        <select
-          phx-change="change_model"
-          phx-target={@myself}
-          class="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+    <div id="model-selector" phx-hook="ModelSelector" class="relative">
+      <%!-- Trigger Button --%>
+      <button
+        type="button"
+        phx-click="toggle_dropdown"
+        phx-target={@myself}
+        class="flex items-center gap-2 px-3 py-1.5 bg-gray-800/80 border border-gray-700/50 rounded-lg text-sm text-gray-300 hover:bg-gray-800 hover:border-indigo-500/30 hover:shadow-lg hover:shadow-indigo-500/5 transition-all duration-200 cursor-pointer group"
+      >
+        <span class="text-xs opacity-70">{provider_emoji(current_provider(@model))}</span>
+        <span class="truncate max-w-[160px] text-gray-200 group-hover:text-gray-100">
+          {current_model_label(@model, @all_providers)}
+        </span>
+        <svg
+          class={"w-3.5 h-3.5 text-gray-500 transition-transform duration-200 #{if @open, do: "rotate-180"}"}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
         >
-          <%= if @models == [] do %>
-            <option value={@model} selected>{@model}</option>
-          <% else %>
-            <%= if not model_in_list?(@model, @models) do %>
-              <option value={@model} selected>{@model}</option>
-            <% end %>
-            <optgroup :for={{provider, models} <- @models} label={provider}>
-              <option :for={{label, value} <- models} value={value} selected={value == @model}>
-                {label}
-              </option>
-            </optgroup>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      <%!-- Dropdown Panel --%>
+      <div
+        :if={@open}
+        class="absolute top-full left-0 mt-2 w-80 bg-gray-900 border border-gray-700/50 rounded-xl shadow-2xl shadow-black/50 z-50 overflow-hidden"
+        phx-click-away="close_dropdown"
+        phx-target={@myself}
+      >
+        <%!-- Search Input --%>
+        <div class="p-2 border-b border-gray-800">
+          <div class="relative">
+            <svg
+              class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+            <input
+              type="text"
+              placeholder="Search models..."
+              value={@search}
+              phx-keyup="search_models"
+              phx-target={@myself}
+              id="model-search-input"
+              class="w-full bg-gray-800/60 border border-gray-700/50 text-gray-300 text-xs rounded-lg pl-8 pr-3 py-2 focus:outline-none focus:ring-1 focus:ring-indigo-500/50 focus:border-indigo-500/30 placeholder-gray-600"
+            />
+          </div>
+        </div>
+
+        <%!-- Model List --%>
+        <div class="max-h-72 overflow-y-auto overscroll-contain" id="model-list">
+          <%= for {provider_atom, display_name, key_status, models} <- filtered_providers(@all_providers, @search) do %>
+            <div class="px-2 pt-3 pb-1">
+              <%!-- Provider Header --%>
+              <div class="flex items-center justify-between px-2 mb-1">
+                <div class="flex items-center gap-1.5">
+                  <span class="text-xs">{provider_emoji(provider_atom)}</span>
+                  <span class="text-xs font-medium text-gray-400">{display_name}</span>
+                </div>
+                <div class="flex items-center gap-1.5">
+                  <%= case key_status do %>
+                    <% {:set, _env_var} -> %>
+                      <span class="flex items-center gap-1">
+                        <span class="w-1.5 h-1.5 rounded-full bg-emerald-400"></span>
+                        <span class="text-[10px] text-emerald-400/80">Ready</span>
+                      </span>
+                    <% {:missing, env_var} -> %>
+                      <span class="flex items-center gap-1">
+                        <span class="w-1.5 h-1.5 rounded-full bg-amber-400"></span>
+                        <span class="text-[10px] text-amber-400/80 font-mono">{env_var}</span>
+                      </span>
+                  <% end %>
+                </div>
+              </div>
+
+              <%!-- Models in this provider --%>
+              <%= if models == [] do %>
+                <div class="px-2 py-1.5 text-[10px] text-gray-600 italic">No models available</div>
+              <% else %>
+                <%= for {label, value, context_k} <- models do %>
+                  <button
+                    type="button"
+                    phx-click="select_model"
+                    phx-value-model={value}
+                    phx-target={@myself}
+                    class={"flex items-center justify-between w-full px-2 py-1.5 rounded-lg text-left transition-all duration-150 group/item #{if value == @model, do: "bg-indigo-500/20 ring-1 ring-indigo-500/30", else: "hover:bg-indigo-500/10 hover:ring-1 hover:ring-indigo-500/20"}"}
+                  >
+                    <div class="flex items-center gap-2 min-w-0">
+                      <%= if value == @model do %>
+                        <svg
+                          class="w-3 h-3 text-indigo-400 shrink-0"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          stroke-width="3"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                      <% else %>
+                        <div class="w-3 h-3 shrink-0"></div>
+                      <% end %>
+                      <span class={"text-xs truncate #{if value == @model, do: "text-indigo-300 font-medium", else: "text-gray-300 group-hover/item:text-gray-100"}"}>
+                        {label}
+                      </span>
+                    </div>
+                    <span
+                      :if={context_k}
+                      class="text-[10px] text-gray-600 font-mono shrink-0 ml-2"
+                    >
+                      {context_k}
+                    </span>
+                  </button>
+                <% end %>
+              <% end %>
+            </div>
           <% end %>
-          <option value="__custom__">Custom model...</option>
-        </select>
-      <% end %>
+        </div>
+
+        <%!-- API Key Warning Banner --%>
+        <.key_warning_banner model={@model} all_providers={@all_providers} />
+
+        <%!-- Custom Model Section --%>
+        <div class="border-t border-gray-800 p-2">
+          <%= if @custom_mode do %>
+            <form phx-submit="apply_custom" phx-target={@myself} class="flex items-center gap-1.5">
+              <input
+                type="text"
+                name="model"
+                value={@custom_value}
+                placeholder="provider:model-id"
+                autofocus
+                phx-keydown="custom_key"
+                phx-target={@myself}
+                class="flex-1 bg-gray-800/60 border border-gray-700/50 text-gray-300 text-xs rounded-lg px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-indigo-500/50 font-mono placeholder-gray-600"
+              />
+              <button
+                type="submit"
+                class="text-xs text-indigo-400 hover:text-indigo-300 px-2 py-1.5 rounded-md hover:bg-indigo-500/10 transition-colors duration-150"
+              >
+                Use
+              </button>
+              <button
+                type="button"
+                phx-click="cancel_custom"
+                phx-target={@myself}
+                class="text-xs text-gray-500 hover:text-gray-300 px-1.5 py-1.5 rounded-md hover:bg-gray-800 transition-colors duration-150"
+              >
+                &times;
+              </button>
+            </form>
+          <% else %>
+            <button
+              type="button"
+              phx-click="enter_custom"
+              phx-target={@myself}
+              class="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-xs text-gray-500 hover:text-gray-300 rounded-lg hover:bg-gray-800/60 transition-all duration-150"
+            >
+              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+              </svg>
+              Use custom model...
+            </button>
+          <% end %>
+        </div>
+      </div>
     </div>
     """
   end
 
-  def handle_event("change_model", params, socket) do
-    model = extract_model_value(params)
+  # --- Key Warning Banner Component ---
 
-    if model == "__custom__" do
-      {:noreply, assign(socket, custom_mode: true, custom_value: socket.assigns.model)}
-    else
-      if model, do: send(self(), {:change_model, model})
-      {:noreply, socket}
-    end
+  defp key_warning_banner(assigns) do
+    provider_atom = current_provider(assigns.model)
+
+    warning =
+      Enum.find_value(assigns.all_providers, fn {p, _name, status, _models} ->
+        if p == provider_atom do
+          case status do
+            {:missing, env_var} -> env_var
+            _ -> nil
+          end
+        end
+      end)
+
+    assigns = assign(assigns, :warning_env_var, warning)
+
+    ~H"""
+    <div
+      :if={@warning_env_var}
+      class="border-t border-amber-500/20 bg-amber-500/5 px-3 py-2.5"
+    >
+      <div class="flex items-start gap-2">
+        <span class="text-amber-400 text-xs mt-0.5">&#9888;</span>
+        <div class="text-xs">
+          <p class="text-amber-300/90 font-medium">
+            <span class="font-mono text-amber-400">{@warning_env_var}</span> not found
+          </p>
+          <p class="text-gray-500 mt-1">
+            Add to your <span class="font-mono text-gray-400">.env</span> file or export in your shell:
+          </p>
+          <p class="font-mono text-gray-400 mt-1 text-[11px] select-all">
+            export {@warning_env_var}=sk-...
+          </p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # --- Events ---
+
+  def handle_event("toggle_dropdown", _params, socket) do
+    {:noreply, assign(socket, open: !socket.assigns.open, search: "")}
+  end
+
+  def handle_event("close_dropdown", _params, socket) do
+    {:noreply, assign(socket, open: false, search: "", custom_mode: false)}
+  end
+
+  def handle_event("search_models", %{"value" => value}, socket) do
+    {:noreply, assign(socket, search: value)}
+  end
+
+  def handle_event("select_model", %{"model" => model}, socket) do
+    send(self(), {:change_model, model})
+    {:noreply, assign(socket, open: false, search: "")}
+  end
+
+  def handle_event("enter_custom", _params, socket) do
+    {:noreply, assign(socket, custom_mode: true, custom_value: socket.assigns.model)}
   end
 
   def handle_event("apply_custom", %{"model" => model}, socket) when model != "" do
     send(self(), {:change_model, model})
-    {:noreply, assign(socket, custom_mode: false, custom_value: "")}
+    {:noreply, assign(socket, custom_mode: false, custom_value: "", open: false)}
   end
 
   def handle_event("apply_custom", _params, socket) do
@@ -97,16 +285,69 @@ defmodule LoomWeb.ModelSelectorComponent do
     {:noreply, assign(socket, custom_mode: false)}
   end
 
-  defp extract_model_value(params) do
-    params
-    |> Map.drop(["_target"])
-    |> Map.values()
-    |> List.first()
+  # --- Helpers ---
+
+  defp current_provider(model) when is_binary(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, _] -> String.to_atom(provider)
+      _ -> nil
+    end
   end
 
-  defp model_in_list?(model, groups) do
-    Enum.any?(groups, fn {_provider, models} ->
-      Enum.any?(models, fn {_label, value} -> value == model end)
+  defp current_provider(_), do: nil
+
+  defp current_model_label(model, providers) do
+    Enum.find_value(providers, model_id_fallback(model), fn {_atom, _name, _status, models} ->
+      Enum.find_value(models, fn {label, value, _ctx} ->
+        if value == model, do: label
+      end)
     end)
   end
+
+  defp model_id_fallback(model) when is_binary(model) do
+    case String.split(model, ":", parts: 2) do
+      [_provider, id] -> id
+      _ -> model
+    end
+  end
+
+  defp model_id_fallback(model), do: model
+
+  defp filtered_providers(providers, search) when search in [nil, ""] do
+    providers
+  end
+
+  defp filtered_providers(providers, search) do
+    term = String.downcase(search)
+
+    providers
+    |> Enum.map(fn {provider_atom, display_name, key_status, models} ->
+      filtered =
+        Enum.filter(models, fn {label, value, _ctx} ->
+          String.contains?(String.downcase(label), term) ||
+            String.contains?(String.downcase(value), term)
+        end)
+
+      {provider_atom, display_name, key_status, filtered}
+    end)
+    |> Enum.reject(fn {_p, _n, _s, models} -> models == [] end)
+  end
+
+  defp provider_emoji(:anthropic), do: "\u{1F7E3}"
+  defp provider_emoji(:openai), do: "\u{1F7E2}"
+  defp provider_emoji(:google), do: "\u{1F535}"
+  defp provider_emoji(:xai), do: "\u{26AB}"
+  defp provider_emoji(:zai), do: "\u{1F7E0}"
+  defp provider_emoji(:groq), do: "\u{26A1}"
+  defp provider_emoji(:deepseek), do: "\u{1F30A}"
+  defp provider_emoji(:openrouter), do: "\u{1F310}"
+  defp provider_emoji(:mistral), do: "\u{1F4A8}"
+  defp provider_emoji(:cerebras), do: "\u{1F9E0}"
+  defp provider_emoji(:togetherai), do: "\u{1F91D}"
+  defp provider_emoji(:fireworks_ai), do: "\u{1F386}"
+  defp provider_emoji(:cohere), do: "\u{1F538}"
+  defp provider_emoji(:perplexity), do: "\u{1F50D}"
+  defp provider_emoji(:nvidia), do: "\u{1F4A0}"
+  defp provider_emoji(:azure), do: "\u{2601}"
+  defp provider_emoji(_), do: "\u{2B50}"
 end

--- a/lib/loom_web/live/permission_component.ex
+++ b/lib/loom_web/live/permission_component.ex
@@ -7,20 +7,44 @@ defmodule LoomWeb.PermissionComponent do
 
   def render(assigns) do
     ~H"""
-    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div class="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl p-6 max-w-md w-full mx-4">
-        <h3 class="text-sm font-semibold text-gray-100 mb-1">Permission Required</h3>
-        <p class="text-sm text-gray-400 mb-4">
-          Allow <span class="font-mono text-indigo-400">{@tool_name}</span>
-          on <span class="font-mono text-gray-300">{@tool_path}</span>?
-        </p>
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 animate-fade-in">
+      <div class="bg-gray-900 border border-gray-700/50 rounded-2xl shadow-2xl p-6 max-w-md w-full mx-4 animate-scale-in">
+        <%!-- Header --%>
+        <div class="flex items-center gap-3 mb-4">
+          <div class="w-10 h-10 rounded-xl bg-indigo-500/10 flex items-center justify-center flex-shrink-0">
+            <.icon name="hero-shield-check" class="w-5 h-5 text-indigo-400" />
+          </div>
+          <div>
+            <h3 class="text-sm font-semibold text-gray-100">Permission Required</h3>
+            <p class="text-[10px] text-gray-500 mt-0.5">Review this tool execution before proceeding</p>
+          </div>
+        </div>
 
+        <%!-- Tool info --%>
+        <div class="space-y-3 mb-5">
+          <div class="flex items-center gap-2">
+            <span class="text-[10px] text-gray-500 uppercase tracking-wider">Tool</span>
+            <span class="inline-flex items-center gap-1.5 bg-indigo-500/10 border border-indigo-500/20 rounded-full px-3 py-1 text-xs font-mono text-indigo-400">
+              <.icon name="hero-wrench-screwdriver-mini" class="w-3 h-3" />
+              {@tool_name}
+            </span>
+          </div>
+          <div class="flex items-start gap-2">
+            <span class="text-[10px] text-gray-500 uppercase tracking-wider mt-0.5">Path</span>
+            <div class="flex items-center gap-1.5 min-w-0">
+              <.icon name="hero-document-text-mini" class="w-3.5 h-3.5 text-gray-500 flex-shrink-0" />
+              <span class="text-xs font-mono text-gray-300 break-all">{@tool_path}</span>
+            </div>
+          </div>
+        </div>
+
+        <%!-- Action buttons --%>
         <div class="flex gap-2 justify-end">
           <button
             phx-click="permission_response"
             phx-value-action="deny"
             phx-target={@myself}
-            class="px-3 py-1.5 text-xs font-medium text-gray-300 bg-gray-800 hover:bg-gray-700 border border-gray-600 rounded-lg transition"
+            class="px-4 py-2 text-xs font-medium text-gray-400 bg-gray-800/60 hover:bg-gray-800 hover:text-gray-300 border border-gray-700/50 rounded-xl transition-all duration-200"
           >
             Deny
           </button>
@@ -28,7 +52,7 @@ defmodule LoomWeb.PermissionComponent do
             phx-click="permission_response"
             phx-value-action="allow_once"
             phx-target={@myself}
-            class="px-3 py-1.5 text-xs font-medium text-gray-100 bg-indigo-600 hover:bg-indigo-500 rounded-lg transition"
+            class="px-4 py-2 text-xs font-medium text-indigo-400 bg-indigo-500/10 hover:bg-indigo-500/20 border border-indigo-500/30 rounded-xl transition-all duration-200"
           >
             Allow Once
           </button>
@@ -36,7 +60,7 @@ defmodule LoomWeb.PermissionComponent do
             phx-click="permission_response"
             phx-value-action="allow_always"
             phx-target={@myself}
-            class="px-3 py-1.5 text-xs font-medium text-gray-100 bg-green-700 hover:bg-green-600 rounded-lg transition"
+            class="px-4 py-2 text-xs font-medium text-white bg-indigo-600 hover:bg-indigo-500 rounded-xl transition-all duration-200 shadow-lg shadow-indigo-500/20"
           >
             Allow Always
           </button>

--- a/lib/loom_web/live/session_switcher_component.ex
+++ b/lib/loom_web/live/session_switcher_component.ex
@@ -9,55 +9,101 @@ defmodule LoomWeb.SessionSwitcherComponent do
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(sessions: sessions)}
+     |> assign(sessions: sessions, dropdown_open: false)}
   end
 
   def render(assigns) do
     ~H"""
-    <div>
-      <select
-        phx-change="select_session"
+    <div class="relative" id="session-switcher-wrapper" phx-click-away="close_dropdown" phx-target={@myself}>
+      <%!-- Trigger button --%>
+      <button
+        phx-click="toggle_dropdown"
         phx-target={@myself}
-        class="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500 max-w-[180px]"
+        class="flex items-center gap-2 bg-gray-800/60 hover:bg-gray-800 border border-gray-700/50 rounded-lg px-3 py-1.5 text-xs text-gray-300 transition-all duration-200 max-w-[200px]"
       >
-        <option value="new">+ New Session</option>
-        <option
-          :for={session <- @sessions}
-          value={session.id}
-          selected={session.id == @session_id}
+        <.icon name="hero-clock-mini" class="w-3.5 h-3.5 text-gray-500 flex-shrink-0" />
+        <span class="truncate">{current_session_label(@session_id, @sessions)}</span>
+        <svg class={"w-3 h-3 text-gray-500 flex-shrink-0 transition-transform duration-200 " <> if(@dropdown_open, do: "rotate-180", else: "")} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      <%!-- Dropdown --%>
+      <div
+        :if={@dropdown_open}
+        class="absolute right-0 top-full mt-1 w-64 bg-gray-900 border border-gray-700/50 rounded-xl shadow-2xl z-30 overflow-hidden animate-scale-in"
+      >
+        <%!-- New session option --%>
+        <button
+          phx-click="new_session"
+          phx-target={@myself}
+          class="w-full flex items-center gap-2 px-4 py-2.5 text-xs text-indigo-400 hover:bg-indigo-500/10 transition-colors border-b border-gray-800"
         >
-          {session_label(session)}
-        </option>
-      </select>
+          <.icon name="hero-plus-mini" class="w-3.5 h-3.5" />
+          <span class="font-medium">New Session</span>
+        </button>
+
+        <%!-- Session list --%>
+        <div class="max-h-48 overflow-y-auto py-1">
+          <button
+            :for={session <- @sessions}
+            phx-click="select_session"
+            phx-value-id={session.id}
+            phx-target={@myself}
+            class={"w-full flex items-center gap-2 px-4 py-2 text-xs transition-colors " <>
+              if(session.id == @session_id,
+                do: "bg-indigo-500/10 text-indigo-400",
+                else: "text-gray-400 hover:bg-gray-800/60 hover:text-gray-300")}
+          >
+            <span :if={session.id == @session_id} class="flex-shrink-0">
+              <.icon name="hero-check-mini" class="w-3.5 h-3.5 text-indigo-400" />
+            </span>
+            <span :if={session.id != @session_id} class="w-3.5 flex-shrink-0" />
+            <span class="truncate flex-1 text-left">{session_label(session)}</span>
+            <span class="text-[10px] text-gray-600 flex-shrink-0">{relative_time(session)}</span>
+          </button>
+        </div>
+
+        <div :if={@sessions == []} class="px-4 py-3 text-xs text-gray-600 text-center">
+          No previous sessions
+        </div>
+      </div>
     </div>
     """
   end
 
-  def handle_event("select_session", params, socket) do
-    value = extract_select_value(params)
+  def handle_event("toggle_dropdown", _params, socket) do
+    {:noreply, assign(socket, dropdown_open: !socket.assigns.dropdown_open)}
+  end
 
-    case value do
-      "new" ->
-        send(self(), :new_session)
-        {:noreply, socket}
+  def handle_event("close_dropdown", _params, socket) do
+    {:noreply, assign(socket, dropdown_open: false)}
+  end
 
-      session_id when is_binary(session_id) ->
-        send(self(), {:select_session, session_id})
-        {:noreply, socket}
+  def handle_event("new_session", _params, socket) do
+    send(self(), :new_session)
+    {:noreply, assign(socket, dropdown_open: false)}
+  end
 
-      _ ->
-        {:noreply, socket}
-    end
+  def handle_event("select_session", %{"id" => session_id}, socket) do
+    send(self(), {:select_session, session_id})
+    {:noreply, assign(socket, dropdown_open: false)}
   end
 
   defp list_all_sessions do
-    # Get persisted sessions, ordered by most recent
     Persistence.list_sessions()
+  end
+
+  defp current_session_label(session_id, sessions) do
+    case Enum.find(sessions, &(&1.id == session_id)) do
+      nil -> "Session #{String.slice(session_id, 0, 8)}"
+      session -> session_label(session)
+    end
   end
 
   defp session_label(session) do
     title = session.title || "Untitled"
-    # Truncate long titles
+
     if String.length(title) > 24 do
       String.slice(title, 0, 24) <> "..."
     else
@@ -65,10 +111,22 @@ defmodule LoomWeb.SessionSwitcherComponent do
     end
   end
 
-  defp extract_select_value(params) do
-    params
-    |> Map.drop(["_target"])
-    |> Map.values()
-    |> List.first()
+  defp relative_time(session) do
+    case Map.get(session, :updated_at) || Map.get(session, :inserted_at) do
+      nil ->
+        ""
+
+      datetime ->
+        diff = DateTime.diff(DateTime.utc_now(), datetime, :second)
+
+        cond do
+          diff < 60 -> "now"
+          diff < 3600 -> "#{div(diff, 60)}m ago"
+          diff < 86400 -> "#{div(diff, 3600)}h ago"
+          true -> "#{div(diff, 86400)}d ago"
+        end
+    end
+  rescue
+    _ -> ""
   end
 end

--- a/lib/loom_web/live/terminal_component.ex
+++ b/lib/loom_web/live/terminal_component.ex
@@ -7,32 +7,52 @@ defmodule LoomWeb.TerminalComponent do
 
   def render(assigns) do
     ~H"""
-    <div class="bg-gray-950 rounded-lg border border-gray-800 overflow-hidden font-mono text-xs">
-      <div class="px-3 py-1.5 bg-gray-900 border-b border-gray-800 flex items-center gap-2">
-        <div class="flex gap-1">
-          <div class="w-2.5 h-2.5 rounded-full bg-red-500/70"></div>
-          <div class="w-2.5 h-2.5 rounded-full bg-yellow-500/70"></div>
-          <div class="w-2.5 h-2.5 rounded-full bg-green-500/70"></div>
+    <div class="bg-gray-950 rounded-xl border border-gray-800/80 overflow-hidden font-mono text-xs shadow-sm">
+      <%!-- Terminal Chrome --%>
+      <div class="px-3 py-2 bg-gradient-to-r from-gray-800 to-gray-800/80 border-b border-gray-800/80 flex items-center gap-2">
+        <div class="flex gap-1.5">
+          <div class="w-2.5 h-2.5 rounded-full bg-red-500/70 hover:bg-red-500 transition-colors duration-200"></div>
+          <div class="w-2.5 h-2.5 rounded-full bg-yellow-500/70 hover:bg-yellow-500 transition-colors duration-200"></div>
+          <div class="w-2.5 h-2.5 rounded-full bg-green-500/70 hover:bg-green-500 transition-colors duration-200"></div>
         </div>
-        <span class="text-gray-500 text-[10px]">Terminal</span>
+        <span class="text-gray-500 text-[10px] ml-1">Terminal</span>
       </div>
 
-      <div class="p-3 space-y-3 max-h-96 overflow-auto">
-        <div :if={@commands == []} class="text-gray-600">
-          No commands executed yet.
+      <%!-- Terminal Body --%>
+      <div class="p-3 space-y-4 max-h-96 overflow-auto">
+        <%!-- Empty State --%>
+        <div :if={@commands == []} class="flex items-center justify-center py-8">
+          <div class="text-center space-y-2">
+            <div class="text-gray-600 text-lg">&#9002;</div>
+            <p class="text-gray-600 text-[11px]">No commands executed yet</p>
+          </div>
         </div>
 
-        <div :for={cmd <- @commands} class="space-y-1">
-          <div class={["flex items-start gap-1", exit_code_color(cmd.exit_code)]}>
-            <span class="text-green-400 select-none">$</span>
-            <span class="text-gray-200">{cmd.command}</span>
+        <%!-- Command Blocks --%>
+        <div :for={cmd <- @commands} class="space-y-1 group" id={"cmd-#{:erlang.phash2(cmd)}"}>
+          <div class="flex items-start gap-1.5">
+            <span class="text-emerald-400 select-none leading-relaxed">$</span>
+            <span class="text-gray-200 leading-relaxed flex-1">{cmd.command}</span>
+            <button
+              class="opacity-0 group-hover:opacity-100 transition-opacity duration-200 text-gray-500 hover:text-gray-300 px-1.5 py-0.5 rounded bg-gray-800/50 text-[10px]"
+              phx-hook="CopyToClipboard"
+              id={"copy-#{:erlang.phash2(cmd)}"}
+              data-copy-text={cmd_copy_text(cmd)}
+            >
+              Copy
+            </button>
           </div>
           <pre
             :if={cmd.output && cmd.output != ""}
-            class={["pl-3 whitespace-pre-wrap break-all", output_color(cmd.exit_code)]}
+            class={["pl-4 whitespace-pre-wrap break-all leading-relaxed", output_color(cmd.exit_code)]}
           >{cmd.output}</pre>
-          <div :if={cmd.exit_code != 0} class="pl-3 text-red-400 text-[10px]">
-            exit code: {cmd.exit_code}
+          <div :if={cmd.exit_code == 0} class="pl-4 flex items-center gap-1 text-[10px] text-emerald-500/70">
+            <span>&#10003;</span>
+            <span>exit 0</span>
+          </div>
+          <div :if={cmd.exit_code != 0} class="pl-4 flex items-center gap-1 text-[10px] text-rose-400/80">
+            <span>&#10007;</span>
+            <span>exit {cmd.exit_code}</span>
           </div>
         </div>
       </div>
@@ -40,9 +60,11 @@ defmodule LoomWeb.TerminalComponent do
     """
   end
 
-  defp exit_code_color(0), do: ""
-  defp exit_code_color(_), do: ""
-
   defp output_color(0), do: "text-gray-400"
-  defp output_color(_), do: "text-red-300"
+  defp output_color(_), do: "text-rose-400/80"
+
+  defp cmd_copy_text(cmd) do
+    output = if cmd.output && cmd.output != "", do: "\n#{cmd.output}", else: ""
+    "$ #{cmd.command}#{output}"
+  end
 end


### PR DESCRIPTION
## Summary

Full UI enhancement pass across all 13 LiveView components, CSS, JS hooks, and Tailwind config. Design direction: **warm cozy dark-mode** (Warp terminal × Linear vibes) with indigo accent throughout.

### Model Selector Redesign (user-requested)
- **Rich custom dropdown** replacing plain `<select>` with search, provider groups, emoji icons
- **Dynamic API key status badges**: green "Ready" when key is set, amber warning with env var name when missing
- **Helper text banner**: shows exact env var and export command when selecting a provider without a key configured
- Keyboard navigation, context window labels, custom model entry

### Content Components
- **Chat**: Welcoming empty state with suggestion chips, warmer bubbles, gradient avatars, styled tool result cards with color-coded headers, bouncing dots thinking animation, code blocks with dark bg
- **Terminal**: Copy-to-clipboard per command, softer stderr, exit code icons, warmer chrome
- **Diff**: Softer emerald/rose colors, file headers with icons and change count pills, indigo hunk accents

### Workspace Chrome
- Gradient "Loom" branding, segmented pill mode toggle, cost pill with sparkle icon
- Pill-style sidebar tabs with heroicons and fade transitions
- Warm chat input with focus glow and pulsing send button
- Styled session switcher with relative timestamps
- File tree with animated chevrons, search input, folder heroicons
- Decision graph legend, softer node colors, animated detail panel
- Permission modal with scale-in animation and softer overlay

### Global Polish
- Custom indigo scrollbar, focus ring override
- CSS animations: fadeIn, fadeInUp, scaleIn, pulse-soft, shimmer
- JS hooks: ModelSelector, CopyToClipboard, TabTransition, AutoResizeTextarea
- Tailwind animation config extensions

### Stats
- 13 files changed, +1,327 / -301 lines
- 0 new compile warnings

## Test plan

- [ ] Open workspace at localhost:4200 — verify warm dark theme, gradient branding, status indicators
- [ ] Click model selector — verify custom dropdown opens with search, provider groups, API key badges
- [ ] Select a model from a provider without API key — verify amber warning banner with env var name
- [ ] Select a model from a provider with API key — verify green "Ready" badge, no warning
- [ ] Type in chat — verify warm input styling, focus glow, send button pulse
- [ ] Receive assistant response — verify fadeInUp animation, indigo left border, avatar glow
- [ ] Trigger tool execution — verify spinning gear + tool name, styled tool result card
- [ ] Switch sidebar tabs — verify pill tab styling, icons, fade transition
- [ ] Browse file tree — verify animated chevrons, search filter, folder icons
- [ ] View diffs — verify softer emerald/rose colors, file header pills
- [ ] View terminal output — verify copy button, exit code icons, stderr coloring
- [ ] Open decision graph — verify legend, softer colors, animated detail panel
- [ ] Trigger permission modal — verify scale-in animation, softer overlay, styled buttons
- [ ] Switch sessions — verify styled dropdown with timestamps
- [ ] Test keyboard: Escape closes dropdowns, arrow keys navigate model list, Enter selects

🤖 Generated with [Claude Code](https://claude.com/claude-code)