### PR TITLE
Fix team_id crash, recursive atomize_keys, CodeReloader listener

### DIFF
--- a/lib/loom/session/architect.ex
+++ b/lib/loom/session/architect.ex
@@ -688,12 +688,15 @@ defmodule Loom.Session.Architect do
 
   defp atomize_keys(map) when is_map(map) do
     Map.new(map, fn
-      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
-      {k, v} -> {k, v}
+      {k, v} when is_binary(k) -> {String.to_existing_atom(k), atomize_keys(v)}
+      {k, v} -> {k, atomize_keys(v)}
     end)
   rescue
     ArgumentError -> map
   end
+
+  defp atomize_keys(list) when is_list(list), do: Enum.map(list, &atomize_keys/1)
+  defp atomize_keys(value), do: value
 
   defp parse_model(model_string) do
     case String.split(model_string, ":", parts: 2) do

--- a/lib/loom/session/session.ex
+++ b/lib/loom/session/session.ex
@@ -157,7 +157,7 @@ defmodule Loom.Session do
 
   @impl true
   def handle_call(:get_team_id, _from, state) do
-    {:reply, state.team_id, state}
+    {:reply, Map.get(state, :team_id), state}
   end
 
   # --- handle_info ---

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,8 @@ defmodule Loom.MixProject do
       deps: deps(),
       escript: escript(),
       releases: releases(),
-      elixirc_paths: elixirc_paths(Mix.env())
+      elixirc_paths: elixirc_paths(Mix.env()),
+      listeners: [Phoenix.CodeReloader]
     ]
   end
 


### PR DESCRIPTION
## Summary

Fixes three runtime issues discovered while testing the teams-default experience:

- **Fix `:get_team_id` crash on stale sessions** — Sessions started before the `team_id` struct field was added crash with `KeyError` when the LiveView calls `:get_team_id`. Uses `Map.get(state, :team_id)` to survive hot-reloaded processes with old struct shapes
- **Make `Architect.atomize_keys/1` recursive** — LLM tool args with nested maps inside lists (e.g. `:roles` in `team_spawn`) weren't getting their string keys atomized. The function now walks into lists and nested maps, fixing `"invalid value for map key: expected atom, got: \"name\""` errors
- **Add `Phoenix.CodeReloader` listener** — Phoenix 1.8.4 requires `listeners: [Phoenix.CodeReloader]` in `mix.exs` project config. Silences the repeated warnings in dev

## Test plan
- [x] 792 tests pass (0 failures)
- [x] Clean compile with `--warnings-as-errors`
- [ ] Manual: resume a stale session from before the teams-default merge
- [ ] Manual: ask Architect to spawn a team and verify roles parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)