### PR TITLE
Epic 5.10: Team orchestration & visibility

### DIFF
--- a/lib/loom/session/architect.ex
+++ b/lib/loom/session/architect.ex
@@ -143,7 +143,7 @@ defmodule Loom.Session.Architect do
         if classified.type == :tool_calls do
           Logger.info("[Architect] Planning phase invoked tools — executing team operations")
           update_usage(state.id, response)
-          handle_planning_tool_calls(classified, response, provider, model_id, req_messages, state, opts)
+          handle_planning_tool_calls(classified, response, provider, model_id, req_messages, state, opts, user_text)
         else
           text = extract_text(response)
           Logger.debug("[Architect] Plan response received, parsing... (#{String.length(text)} chars)")
@@ -201,42 +201,97 @@ defmodule Loom.Session.Architect do
   # --- Private ---
 
   # Handle tool calls from the planning phase (e.g. team_spawn, team_assign).
-  # Executes tools and returns the result as a conversational response.
-  defp handle_planning_tool_calls(classified, _response, _provider, _model_id, _req_messages, state, _opts) do
+  # Executes tools, bootstraps lead agent with user request, notifies session.
+  defp handle_planning_tool_calls(classified, _response, _provider, _model_id, _req_messages, state, _opts, user_text) do
     tool_calls = classified.tool_calls
     tool_names = Enum.map(tool_calls, fn tc -> tc[:name] || tc["name"] end)
     Logger.info("[Architect] Planning tools: #{Enum.join(tool_names, ", ")}")
 
-    results =
-      Enum.map(tool_calls, fn tool_call ->
+    {results, spawned_team_ids} =
+      Enum.reduce(tool_calls, {[], []}, fn tool_call, {res, team_ids} ->
         tool_name = tool_call[:name] || tool_call["name"]
         tool_args = tool_call[:arguments] || tool_call["arguments"] || %{}
-        context = %{project_path: state.project_path, session_id: state.id}
+        context = %{project_path: state.project_path, session_id: state.id, parent_team_id: state.team_id}
 
         case Jido.AI.ToolAdapter.lookup_action(tool_name, @planning_tools) do
           {:ok, tool_module} ->
-            run_and_format_tool(tool_module, tool_args, context)
+            normalized_args = atomize_keys(tool_args)
+
+            case Jido.Exec.run(tool_module, normalized_args, context, timeout: 60_000) do
+              {:ok, %{team_id: tid, result: text}} ->
+                {res ++ [text], team_ids ++ [tid]}
+
+              {:ok, %{result: text}} ->
+                {res ++ [text], team_ids}
+
+              {:ok, text} when is_binary(text) ->
+                {res ++ [text], team_ids}
+
+              {:error, reason} ->
+                {res ++ ["Error: #{inspect(reason)}"], team_ids}
+            end
 
           {:error, :not_found} ->
-            "Error: Planning tool '#{tool_name}' not found"
+            {res ++ ["Error: Planning tool '#{tool_name}' not found"], team_ids}
         end
       end)
 
     response_text = Enum.join(results, "\n\n")
 
+    # Bootstrap: send the user's request to each spawned team's lead agent
+    for team_id <- spawned_team_ids do
+      bootstrap_team_lead(team_id, user_text)
+
+      # Notify the session about this child team
+      if state.id do
+        case Loom.Session.Manager.find_session(state.id) do
+          {:ok, session_pid} -> send(session_pid, {:child_team_created, team_id})
+          :error -> :ok
+        end
+      end
+    end
+
+    status_text =
+      if spawned_team_ids != [] do
+        "Team working on your request...\n\n#{response_text}"
+      else
+        response_text
+      end
+
     {:ok, _} =
       Persistence.save_message(%{
         session_id: state.id,
         role: :assistant,
-        content: response_text
+        content: status_text
       })
 
-    assistant_msg = %{role: :assistant, content: response_text}
+    assistant_msg = %{role: :assistant, content: status_text}
     state = %{state | messages: state.messages ++ [assistant_msg]}
     broadcast(state.id, {:new_message, state.id, assistant_msg})
 
     # Signal that the team was spawned — run/3 should not fall back to conversational
-    {:ok, %{"plan" => [], "summary" => response_text, "team_spawned" => true}, state}
+    {:ok, %{"plan" => [], "summary" => status_text, "team_spawned" => true}, state}
+  end
+
+  # Find and message the lead agent (or first agent) in a newly spawned team.
+  defp bootstrap_team_lead(team_id, user_text) do
+    alias Loom.Teams.{Agent, Manager}
+
+    agents = Manager.list_agents(team_id)
+
+    lead =
+      Enum.find(agents, fn a -> a.role == :lead end) ||
+        List.first(agents)
+
+    if lead do
+      Logger.info("[Architect] Bootstrapping lead agent #{lead.name} in team #{team_id}")
+
+      Task.Supervisor.start_child(Loom.Teams.TaskSupervisor, fn ->
+        Agent.send_message(lead.pid, user_text)
+      end)
+    else
+      Logger.warning("[Architect] No agents found in team #{team_id} to bootstrap")
+    end
   end
 
   defp conversational_fallback(user_text, state, model) do

--- a/lib/loom/session/session.ex
+++ b/lib/loom/session/session.ex
@@ -16,7 +16,8 @@ defmodule Loom.Session do
     :team_id,
     messages: [],
     tools: [],
-    auto_approve: false
+    auto_approve: false,
+    child_team_ids: []
   ]
 
   # --- Public API ---
@@ -179,6 +180,22 @@ defmodule Loom.Session do
   end
 
   @impl true
+  def handle_info({:child_team_created, child_team_id}, state) do
+    Logger.info("[Session] Child team created: #{child_team_id} for session #{state.id}")
+    Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{child_team_id}:tasks")
+    child_ids = [child_team_id | state.child_team_ids] |> Enum.uniq()
+    broadcast(state.id, {:child_team_available, state.id, child_team_id})
+    {:noreply, %{state | child_team_ids: child_ids}}
+  end
+
+  @impl true
+  def handle_info({:task_completed, _task_id, _agent_name, _result} = event, state) do
+    # Check if this completion means all tasks in a child team are done
+    check_child_team_completion(state, event)
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info(_msg, state) do
     {:noreply, state}
   end
@@ -244,6 +261,46 @@ defmodule Loom.Session do
 
   defp default_model do
     Application.get_env(:loom, :default_model, "anthropic:claude-sonnet-4-6")
+  end
+
+  defp check_child_team_completion(state, _event) do
+    for child_team_id <- state.child_team_ids do
+      tasks = Loom.Teams.Tasks.list_all(child_team_id)
+
+      if tasks != [] && Enum.all?(tasks, fn t -> t.status in [:completed, :failed] end) do
+        results =
+          tasks
+          |> Enum.filter(fn t -> t.status == :completed end)
+          |> Enum.map(fn t -> "- **#{t.title}**: #{t.result || "done"}" end)
+          |> Enum.join("\n")
+
+        failed =
+          tasks
+          |> Enum.filter(fn t -> t.status == :failed end)
+          |> Enum.map(fn t -> "- **#{t.title}**: #{t.result || "failed"}" end)
+          |> Enum.join("\n")
+
+        summary = """
+        ## Team Results
+
+        #{if results != "", do: "### Completed\n#{results}\n", else: ""}#{if failed != "", do: "### Failed\n#{failed}\n", else: ""}
+        """
+
+        msg = %{role: :assistant, content: String.trim(summary)}
+
+        Persistence.save_message(%{
+          session_id: state.id,
+          role: :assistant,
+          content: String.trim(summary)
+        })
+
+        broadcast(state.id, {:new_message, state.id, msg})
+        Logger.info("[Session] Child team #{child_team_id} completed — results sent to chat")
+      end
+    end
+  rescue
+    e ->
+      Logger.error("[Session] Error checking child team completion: #{Exception.message(e)}")
   end
 
   defp broadcast(session_id, event) do

--- a/lib/loom/teams/agent.ex
+++ b/lib/loom/teams/agent.ex
@@ -106,6 +106,7 @@ defmodule Loom.Teams.Agent do
         }
 
         Context.register_agent(team_id, name, %{role: role, status: :idle, model: model})
+        broadcast_team(state, {:agent_status, state.name, :idle})
 
         {:ok, state}
 
@@ -278,7 +279,13 @@ defmodule Loom.Teams.Agent do
           model = ModelRouter.select(state.role, %{id: task.id, description: task.description})
           state = %{state | task: %{id: task.id, description: task.description, title: task.title}, model: model}
           messages = maybe_prefetch_context(state, state.task)
-          {:noreply, %{state | messages: messages}}
+          state = %{state | messages: messages}
+
+          if state.status == :idle do
+            send(self(), {:auto_execute_task, task_id})
+          end
+
+          {:noreply, state}
 
         {:error, _} ->
           Logger.warning("[Agent:#{state.name}] Could not fetch task #{task_id}")
@@ -287,6 +294,48 @@ defmodule Loom.Teams.Agent do
     else
       Logger.debug("[Agent:#{state.name}] Task #{task_id} assigned to #{agent_name}")
       {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:auto_execute_task, task_id}, state) do
+    if state.status != :idle do
+      Logger.debug("[Agent:#{state.name}] Skipping auto-execute for #{task_id} — status is #{state.status}")
+      {:noreply, state}
+    else
+      task = state.task
+      description = task[:description] || task[:title] || "Complete task #{task_id}"
+      Logger.info("[Agent:#{state.name}] Auto-executing task #{task_id}")
+
+      state = set_status(state, :working)
+      broadcast_team(state, {:agent_status, state.name, :working})
+
+      user_message = %{role: :user, content: description}
+      messages = state.messages ++ [user_message]
+      loop_opts = build_loop_opts(state)
+
+      case AgentLoop.run(messages, loop_opts) do
+        {:ok, response_text, messages, metadata} ->
+          state = %{state | messages: messages, failure_count: 0}
+          state = track_usage(state, metadata)
+          Loom.Teams.Tasks.complete_task(task_id, response_text)
+          state = set_status(state, :idle)
+          broadcast_team(state, {:agent_status, state.name, :idle})
+          {:noreply, state}
+
+        {:error, reason, messages} ->
+          Logger.error("[Agent:#{state.name}] Task #{task_id} failed: #{inspect(reason)}")
+          state = %{state | messages: messages}
+          Loom.Teams.Tasks.fail_task(task_id, inspect(reason))
+          state = set_status(state, :idle)
+          broadcast_team(state, {:agent_status, state.name, :idle})
+          {:noreply, state}
+
+        {:pending_permission, _info, messages} ->
+          state = %{state | messages: messages}
+          state = set_status(state, :idle)
+          {:noreply, state}
+      end
     end
   end
 

--- a/lib/loom/tools/team_spawn.ex
+++ b/lib/loom/tools/team_spawn.ex
@@ -27,12 +27,13 @@ defmodule Loom.Tools.TeamSpawn do
     team_name = param!(params, :team_name)
     template = param(params, :template)
     project_path = param(params, :project_path) || param(context, :project_path)
+    parent_team_id = param(context, :parent_team_id)
 
     if template do
       spawn_from_template(team_name, template, project_path)
     else
       roles = param!(params, :roles)
-      spawn_from_roles(team_name, roles, project_path)
+      spawn_from_roles(team_name, roles, project_path, parent_team_id)
     end
   end
 
@@ -63,8 +64,13 @@ defmodule Loom.Tools.TeamSpawn do
     end
   end
 
-  defp spawn_from_roles(team_name, roles, project_path) do
-    {:ok, team_id} = Manager.create_team(name: team_name, project_path: project_path)
+  defp spawn_from_roles(team_name, roles, project_path, parent_team_id \\ nil) do
+    {:ok, team_id} =
+      if parent_team_id do
+        Manager.create_sub_team(parent_team_id, "architect", name: team_name, project_path: project_path)
+      else
+        Manager.create_team(name: team_name, project_path: project_path)
+      end
 
     results =
       Enum.map(roles, fn role_map ->

--- a/lib/loom_web/live/team_cost_component.ex
+++ b/lib/loom_web/live/team_cost_component.ex
@@ -162,6 +162,34 @@ defmodule LoomWeb.TeamCostComponent do
     end
   end
 
+  # --- PubSub handlers (forwarded from parent LiveView via send_update) ---
+
+  def handle_info({:usage, _agent_name, _payload}, socket) do
+    {:noreply, load_cost_data(socket)}
+  end
+
+  def handle_info({:agent_escalation, agent_name, old_model, new_model}, socket) do
+    escalation = %{
+      agent: agent_name,
+      from: old_model,
+      to: new_model,
+      at: DateTime.utc_now()
+    }
+
+    {:noreply,
+     socket
+     |> assign(:escalations, socket.assigns.escalations ++ [escalation])
+     |> load_cost_data()}
+  end
+
+  def handle_info({:task_completed, _task_id, _agent_name, _result}, socket) do
+    {:noreply, load_cost_data(socket)}
+  end
+
+  def handle_info(_msg, socket) do
+    {:noreply, socket}
+  end
+
   @impl true
   def render(assigns) do
     ~H"""

--- a/lib/loom_web/live/team_dashboard_component.ex
+++ b/lib/loom_web/live/team_dashboard_component.ex
@@ -78,9 +78,82 @@ defmodule LoomWeb.TeamDashboardComponent do
   defp to_float(n) when is_number(n), do: n / 1
   defp to_float(_), do: 0.0
 
-  # --- PubSub handlers (forwarded from parent LiveView via handle_info) ---
-  # LiveComponents receive PubSub messages through the parent process.
-  # The parent should forward relevant messages via send_update/3.
+  # --- PubSub handlers (forwarded from parent LiveView via send_update) ---
+
+  def handle_info({:agent_status, agent_name, status}, socket) do
+    agents =
+      Enum.map(socket.assigns.agents, fn agent ->
+        if agent.name == agent_name, do: %{agent | status: status}, else: agent
+      end)
+
+    {:noreply, assign(socket, :agents, agents)}
+  end
+
+  def handle_info({:task_assigned, _task_id, agent_name}, socket) do
+    {:noreply, reload_tasks(socket, agent_name)}
+  end
+
+  def handle_info({:task_completed, _task_id, agent_name, _result}, socket) do
+    {:noreply, reload_tasks(socket, agent_name)}
+  end
+
+  def handle_info({:task_started, _task_id, owner}, socket) do
+    {:noreply, reload_tasks(socket, owner)}
+  end
+
+  def handle_info({:task_failed, _task_id, owner, _reason}, socket) do
+    {:noreply, reload_tasks(socket, owner)}
+  end
+
+  def handle_info({:role_changed, agent_name, _old_role, new_role}, socket) do
+    agents =
+      Enum.map(socket.assigns.agents, fn agent ->
+        if agent.name == agent_name, do: %{agent | role: new_role}, else: agent
+      end)
+
+    {:noreply, assign(socket, :agents, agents)}
+  end
+
+  def handle_info({:agent_escalation, agent_name, _old_model, _new_model}, socket) do
+    # Escalation may affect budget — reload cost data
+    summary = CostTracker.team_cost_summary(socket.assigns.team_id)
+    spent = to_float(summary.total_cost_usd)
+    budget_limit = socket.assigns.budget[:limit] || 5.0
+
+    agents =
+      Enum.map(socket.assigns.agents, fn agent ->
+        if agent.name == agent_name, do: %{agent | status: :working}, else: agent
+      end)
+
+    {:noreply,
+     socket
+     |> assign(:agents, agents)
+     |> assign(:budget, %{spent: spent, limit: budget_limit})}
+  end
+
+  def handle_info(_msg, socket) do
+    {:noreply, socket}
+  end
+
+  defp reload_tasks(socket, agent_name) do
+    team_id = socket.assigns.team_id
+    tasks = Tasks.list_all(team_id)
+    current_task = find_agent_current_task(team_id, agent_name)
+
+    agents =
+      Enum.map(socket.assigns.agents, fn agent ->
+        if agent.name == agent_name, do: %{agent | current_task: current_task}, else: agent
+      end)
+
+    summary = CostTracker.team_cost_summary(team_id)
+    spent = to_float(summary.total_cost_usd)
+    budget_limit = socket.assigns.budget[:limit] || 5.0
+
+    socket
+    |> assign(:tasks, tasks)
+    |> assign(:agents, agents)
+    |> assign(:budget, %{spent: spent, limit: budget_limit})
+  end
 
   @impl true
   def render(assigns) do

--- a/lib/loom_web/live/workspace_live.ex
+++ b/lib/loom_web/live/workspace_live.ex
@@ -3,6 +3,7 @@ defmodule LoomWeb.WorkspaceLive do
 
   alias Loom.Session
   alias Loom.Session.Manager
+  alias Loom.Teams
 
   require Logger
 
@@ -25,6 +26,8 @@ defmodule LoomWeb.WorkspaceLive do
         permission_request: nil,
         page_title: "Loom Workspace",
         team_id: params["team_id"],
+        child_teams: [],
+        active_team_id: params["team_id"],
         team_sub_tab: :activity
       )
 
@@ -70,8 +73,11 @@ defmodule LoomWeb.WorkspaceLive do
       team_id = socket.assigns[:team_id]
 
       if team_id do
-        Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}")
-        Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}:tasks")
+        subscribe_to_team(team_id)
+
+        # Recover child teams from previous pageloads
+        child_ids = Teams.Manager.list_sub_teams(team_id)
+        Enum.each(child_ids, &subscribe_to_team/1)
       end
     end
 
@@ -84,6 +90,11 @@ defmodule LoomWeb.WorkspaceLive do
 
     session_metrics = Loom.Telemetry.Metrics.session_metrics(session_id)
 
+    # Recover child teams if backing team exists
+    team_id = socket.assigns[:team_id]
+    child_teams = if team_id, do: Teams.Manager.list_sub_teams(team_id), else: []
+    active_team_id = socket.assigns[:active_team_id] || team_id
+
     assign(socket,
       session_id: session_id,
       project_path: project_path,
@@ -91,7 +102,9 @@ defmodule LoomWeb.WorkspaceLive do
       messages: messages,
       session_cost: session_metrics.cost_usd,
       session_tokens: session_metrics.prompt_tokens + session_metrics.completion_tokens,
-      page_title: "Loom - #{short_id(session_id)}"
+      page_title: "Loom - #{short_id(session_id)}",
+      child_teams: child_teams,
+      active_team_id: active_team_id
     )
   end
 
@@ -143,6 +156,10 @@ defmodule LoomWeb.WorkspaceLive do
     {:noreply, assign(socket, team_sub_tab: String.to_existing_atom(tab))}
   end
 
+  def handle_event("switch_team", %{"team-id" => team_id}, socket) do
+    {:noreply, assign(socket, active_team_id: team_id)}
+  end
+
   # --- PubSub Info ---
 
   def handle_info({:new_message, _session_id, msg}, socket) do
@@ -191,12 +208,21 @@ defmodule LoomWeb.WorkspaceLive do
 
   def handle_info({:team_available, _session_id, team_id}, socket) do
     # Auto-subscribe to backing team events when the team is created
-    if connected?(socket) do
-      Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}")
-      Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}:tasks")
-    end
+    if connected?(socket), do: subscribe_to_team(team_id)
+    {:noreply, assign(socket, team_id: team_id, active_team_id: team_id)}
+  end
 
-    {:noreply, assign(socket, team_id: team_id)}
+  def handle_info({:child_team_available, _session_id, child_team_id}, socket) do
+    if connected?(socket), do: subscribe_to_team(child_team_id)
+
+    child_teams =
+      if child_team_id in socket.assigns.child_teams do
+        socket.assigns.child_teams
+      else
+        socket.assigns.child_teams ++ [child_team_id]
+      end
+
+    {:noreply, assign(socket, :child_teams, child_teams)}
   end
 
   def handle_info({:architect_phase, _phase}, socket) do
@@ -244,32 +270,73 @@ defmodule LoomWeb.WorkspaceLive do
 
   # Team PubSub events -- forward to team components via send_update
   def handle_info({:agent_status, _agent_name, _status}, socket) do
-    if socket.assigns[:team_id] do
-      send_update(LoomWeb.TeamDashboardComponent, id: "team-dashboard", team_id: socket.assigns.team_id)
-      send_update(LoomWeb.TeamActivityComponent, id: "team-activity", team_id: socket.assigns.team_id)
-    end
-
+    forward_to_team_components(socket)
     {:noreply, socket}
   end
 
-  def handle_info({:task_assigned, _task_id, _agent_name} = _msg, socket) do
-    if socket.assigns[:team_id] do
-      send_update(LoomWeb.TeamDashboardComponent, id: "team-dashboard", team_id: socket.assigns.team_id)
-    end
-
+  def handle_info({:task_assigned, _task_id, _agent_name}, socket) do
+    forward_to_dashboard(socket)
     {:noreply, socket}
   end
 
-  def handle_info({:task_completed, _task_id, _agent_name, _result} = _msg, socket) do
-    if socket.assigns[:team_id] do
-      send_update(LoomWeb.TeamDashboardComponent, id: "team-dashboard", team_id: socket.assigns.team_id)
-    end
-
+  def handle_info({:task_completed, _task_id, _agent_name, _result}, socket) do
+    forward_to_dashboard(socket)
+    forward_to_cost(socket)
     {:noreply, socket}
   end
 
-  def handle_info({:team_dissolved, _team_id}, socket) do
-    {:noreply, assign(socket, team_id: nil, active_tab: :files)}
+  def handle_info({:task_started, _task_id, _owner}, socket) do
+    forward_to_dashboard(socket)
+    {:noreply, socket}
+  end
+
+  def handle_info({:task_failed, _task_id, _owner, _reason}, socket) do
+    forward_to_dashboard(socket)
+    {:noreply, socket}
+  end
+
+  def handle_info({:role_changed, _agent_name, _old, _new}, socket) do
+    forward_to_dashboard(socket)
+    {:noreply, socket}
+  end
+
+  def handle_info({:agent_escalation, _agent_name, _old, _new}, socket) do
+    forward_to_dashboard(socket)
+    forward_to_cost(socket)
+    {:noreply, socket}
+  end
+
+  def handle_info({:usage, _agent_name, _payload}, socket) do
+    forward_to_cost(socket)
+    {:noreply, socket}
+  end
+
+  def handle_info({:child_team_created, child_team_id}, socket) do
+    if connected?(socket), do: subscribe_to_team(child_team_id)
+
+    child_teams =
+      if child_team_id in socket.assigns.child_teams do
+        socket.assigns.child_teams
+      else
+        socket.assigns.child_teams ++ [child_team_id]
+      end
+
+    {:noreply, assign(socket, :child_teams, child_teams)}
+  end
+
+  def handle_info({:team_dissolved, team_id}, socket) do
+    if team_id == socket.assigns.team_id do
+      {:noreply, assign(socket, team_id: nil, child_teams: [], active_team_id: nil, active_tab: :files)}
+    else
+      child_teams = List.delete(socket.assigns.child_teams, team_id)
+
+      active_team_id =
+        if socket.assigns.active_team_id == team_id,
+          do: socket.assigns.team_id,
+          else: socket.assigns.active_team_id
+
+      {:noreply, assign(socket, child_teams: child_teams, active_team_id: active_team_id)}
+    end
   end
 
   # Telemetry metrics update
@@ -523,12 +590,40 @@ defmodule LoomWeb.WorkspaceLive do
   end
 
   defp render_tab(:team, assigns) do
+    display_team_id = assigns[:active_team_id] || assigns[:team_id]
+    assigns = assign(assigns, :display_team_id, display_team_id)
+
     ~H"""
     <div class="flex flex-col h-full gap-3">
+      <%!-- Team switcher (visible when child teams exist) --%>
+      <div :if={@child_teams != []} class="flex items-center gap-1 flex-wrap border-b border-gray-800 pb-2">
+        <button
+          phx-click="switch_team"
+          phx-value-team-id={@team_id}
+          class={"text-xs px-2.5 py-1 rounded-lg font-medium transition " <>
+            if(@active_team_id == @team_id,
+              do: "bg-violet-600 text-white",
+              else: "bg-gray-800 text-gray-400 hover:text-gray-200")}
+        >
+          Lead
+        </button>
+        <button
+          :for={child_id <- @child_teams}
+          phx-click="switch_team"
+          phx-value-team-id={child_id}
+          class={"text-xs px-2.5 py-1 rounded-lg font-medium transition " <>
+            if(@active_team_id == child_id,
+              do: "bg-violet-600 text-white",
+              else: "bg-gray-800 text-gray-400 hover:text-gray-200")}
+        >
+          {short_team_id(child_id)}
+        </button>
+      </div>
+
       <.live_component
         module={LoomWeb.TeamDashboardComponent}
         id="team-dashboard"
-        team_id={@team_id}
+        team_id={@display_team_id}
       />
 
       <div class="flex items-center gap-1 border-b border-gray-800 pb-1">
@@ -561,7 +656,7 @@ defmodule LoomWeb.WorkspaceLive do
     <.live_component
       module={LoomWeb.TeamActivityComponent}
       id="team-activity"
-      team_id={@team_id}
+      team_id={@display_team_id}
     />
     """
   end
@@ -571,7 +666,7 @@ defmodule LoomWeb.WorkspaceLive do
     <.live_component
       module={LoomWeb.TeamCostComponent}
       id="team-cost"
-      team_id={@team_id}
+      team_id={@display_team_id}
     />
     """
   end
@@ -585,6 +680,30 @@ defmodule LoomWeb.WorkspaceLive do
     />
     """
   end
+
+  defp subscribe_to_team(team_id) do
+    Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}")
+    Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}:tasks")
+  end
+
+  defp forward_to_team_components(socket) do
+    forward_to_dashboard(socket)
+    tid = socket.assigns[:active_team_id] || socket.assigns[:team_id]
+    if tid, do: send_update(LoomWeb.TeamActivityComponent, id: "team-activity", team_id: tid)
+  end
+
+  defp forward_to_dashboard(socket) do
+    tid = socket.assigns[:active_team_id] || socket.assigns[:team_id]
+    if tid, do: send_update(LoomWeb.TeamDashboardComponent, id: "team-dashboard", team_id: tid)
+  end
+
+  defp forward_to_cost(socket) do
+    tid = socket.assigns[:active_team_id] || socket.assigns[:team_id]
+    if tid, do: send_update(LoomWeb.TeamCostComponent, id: "team-cost", team_id: tid)
+  end
+
+  defp short_team_id(id) when is_binary(id), do: String.slice(id, 0, 8)
+  defp short_team_id(_), do: "?"
 
   defp ensure_index_started(project_path) do
     case GenServer.whereis(Loom.RepoIntel.Index) do

--- a/test/loom/teams/orchestration_test.exs
+++ b/test/loom/teams/orchestration_test.exs
@@ -1,0 +1,388 @@
+defmodule Loom.Teams.OrchestrationTest do
+  @moduledoc """
+  End-to-end integration test for Epic 5.10: Team Orchestration & Visibility.
+
+  Exercises the full lifecycle:
+    User sends message → Architect spawns team → Agents receive work →
+    Execute tools → Complete tasks → Results bubble back to session.
+
+  LLM calls are bypassed by driving the orchestration plumbing directly.
+  """
+
+  use Loom.DataCase, async: false
+
+  alias Loom.Teams.{Agent, Comms, Tasks}
+  alias Loom.Teams.Manager, as: TeamManager
+  alias Loom.Session.Manager, as: SessionManager
+
+  @project_path "/tmp/loom-orchestration-test"
+
+  setup do
+    File.mkdir_p!(@project_path)
+
+    # Start a session
+    session_id = Ecto.UUID.generate()
+
+    {:ok, session_pid} =
+      SessionManager.start_session(
+        session_id: session_id,
+        model: "test:model",
+        project_path: @project_path
+      )
+
+    # Subscribe to session events
+    Phoenix.PubSub.subscribe(Loom.PubSub, "session:#{session_id}")
+
+    on_exit(fn ->
+      File.rm_rf!(@project_path)
+    end)
+
+    %{session_id: session_id, session_pid: session_pid}
+  end
+
+  describe "full orchestration lifecycle" do
+    test "spawn → assign → execute → complete → report", %{
+      session_id: session_id,
+      session_pid: session_pid
+    } do
+      # --- Phase 1: Create backing team and sub-team ---
+      # Simulate what the Architect does when it calls team_spawn
+
+      {:ok, backing_team_id} =
+        TeamManager.create_team(name: "backing", project_path: @project_path)
+
+      # Wire the session to know about its backing team
+      send(session_pid, {:team_created, backing_team_id})
+      Process.sleep(50)
+      assert_receive {:team_available, ^session_id, ^backing_team_id}
+
+      # Architect spawns a child team (sub-team of the backing team)
+      {:ok, sub_team_id} =
+        TeamManager.create_sub_team(backing_team_id, "architect",
+          name: "code-task",
+          project_path: @project_path
+        )
+
+      assert sub_team_id in TeamManager.list_sub_teams(backing_team_id)
+      assert {:ok, ^backing_team_id} = TeamManager.get_parent_team(sub_team_id)
+
+      # --- Phase 2: Spawn agents in the sub-team ---
+
+      # Subscribe to sub-team PubSub to observe events
+      Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{sub_team_id}")
+      Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{sub_team_id}:tasks")
+
+      {:ok, lead_pid} =
+        TeamManager.spawn_agent(sub_team_id, "lead-1", :lead,
+          project_path: @project_path
+        )
+
+      {:ok, coder_pid} =
+        TeamManager.spawn_agent(sub_team_id, "coder-1", :coder,
+          project_path: @project_path
+        )
+
+      {:ok, researcher_pid} =
+        TeamManager.spawn_agent(sub_team_id, "researcher-1", :researcher,
+          project_path: @project_path
+        )
+
+      # Verify agents broadcast their existence on init (5.10.1)
+      assert_receive {:agent_status, "lead-1", :idle}
+      assert_receive {:agent_status, "coder-1", :idle}
+      assert_receive {:agent_status, "researcher-1", :idle}
+
+      # Verify agents are listed
+      agents = TeamManager.list_agents(sub_team_id)
+      agent_names = Enum.map(agents, & &1.name) |> Enum.sort()
+      assert agent_names == ["coder-1", "lead-1", "researcher-1"]
+
+      # --- Phase 3: Create and assign tasks ---
+      # This simulates what the lead agent (or Architect) would do after
+      # receiving the user's request.
+
+      {:ok, task1} =
+        Tasks.create_task(sub_team_id, %{
+          title: "Research existing patterns",
+          description: "Read lib/ and identify patterns used in the codebase"
+        })
+
+      {:ok, task2} =
+        Tasks.create_task(sub_team_id, %{
+          title: "Implement feature",
+          description: "Add the new feature module based on research findings"
+        })
+
+      # task2 depends on task1
+      {:ok, _dep} = Tasks.add_dependency(task2.id, task1.id, :blocks)
+
+      # Verify task_created events broadcast
+      assert_receive {:task_created, _, "Research existing patterns"}
+      assert_receive {:task_created, _, "Implement feature"}
+
+      # Assign task1 to researcher
+      {:ok, assigned_task1} = Tasks.assign_task(task1.id, "researcher-1")
+      assert assigned_task1.status == :assigned
+      assert assigned_task1.owner == "researcher-1"
+
+      # Verify task_assigned event
+      assert_receive {:task_assigned, task1_id, "researcher-1"}
+      assert task1_id == task1.id
+
+      # --- Phase 4: Agent receives task assignment via PubSub ---
+      # The task_assigned event is sent to the agent's direct topic.
+      # After 5.10.7, agents auto-execute on assignment. For now, we
+      # verify the agent receives and stores the task.
+
+      Process.sleep(100)
+
+      researcher_state = :sys.get_state(researcher_pid)
+      assert researcher_state.task != nil
+      assert researcher_state.task.id == task1.id
+
+      # --- Phase 5: Simulate task execution and completion ---
+      # In the full system (5.10.7), the agent would auto-execute via
+      # AgentLoop. Here we simulate the completion path.
+
+      {:ok, _} = Tasks.start_task(task1.id)
+      assert_receive {:task_started, ^task1_id, "researcher-1"}
+
+      {:ok, completed_task1} =
+        Tasks.complete_task(task1.id, "Found 3 patterns: GenServer, PubSub, ETS")
+
+      assert completed_task1.status == :completed
+      assert completed_task1.result == "Found 3 patterns: GenServer, PubSub, ETS"
+
+      # Verify task_completed event
+      assert_receive {:task_completed, ^task1_id, "researcher-1",
+                       "Found 3 patterns: GenServer, PubSub, ETS"}
+
+      # --- Phase 6: Blocked task becomes available ---
+      # After task1 completes, task2 should be unblocked
+
+      assert_receive {:tasks_unblocked, unblocked_ids}
+      assert task2.id in unblocked_ids
+
+      available = Tasks.list_available(sub_team_id)
+      available_ids = Enum.map(available, & &1.id)
+      assert task2.id in available_ids
+
+      # Assign and complete task2
+      {:ok, _} = Tasks.assign_task(task2.id, "coder-1")
+      assert_receive {:task_assigned, task2_id, "coder-1"}
+      assert task2_id == task2.id
+
+      {:ok, _} = Tasks.start_task(task2.id)
+      {:ok, _} = Tasks.complete_task(task2.id, "Feature implemented in lib/feature.ex")
+
+      assert_receive {:task_completed, ^task2_id, "coder-1",
+                       "Feature implemented in lib/feature.ex"}
+
+      # --- Phase 7: Verify all tasks completed ---
+
+      all_tasks = Tasks.list_all(sub_team_id)
+      assert Enum.all?(all_tasks, &(&1.status == :completed))
+
+      # --- Phase 8: Team dissolution and cleanup ---
+      # When all tasks complete, the sub-team can be dissolved.
+      # The parent team's spawning agent receives a notification.
+
+      Phoenix.PubSub.subscribe(
+        Loom.PubSub,
+        "team:#{backing_team_id}:agent:architect"
+      )
+
+      TeamManager.dissolve_team(sub_team_id)
+
+      # Spawning agent in parent team receives sub_team_completed
+      assert_receive {:sub_team_completed, ^sub_team_id}
+
+      # Sub-team ETS table is cleaned up
+      assert :error = Loom.Teams.TableRegistry.get_table(sub_team_id)
+
+      # Sub-team removed from parent's list
+      assert sub_team_id not in TeamManager.list_sub_teams(backing_team_id)
+
+      # Agents are stopped
+      Process.sleep(50)
+      refute Process.alive?(lead_pid)
+      refute Process.alive?(coder_pid)
+      refute Process.alive?(researcher_pid)
+
+      # Clean up backing team
+      TeamManager.dissolve_team(backing_team_id)
+    end
+  end
+
+  describe "PubSub event ordering" do
+    test "events fire in correct sequence during task lifecycle", %{session_id: _session_id} do
+      {:ok, team_id} =
+        TeamManager.create_team(name: "event-order", project_path: @project_path)
+
+      Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}")
+      Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}:tasks")
+
+      {:ok, _agent_pid} =
+        TeamManager.spawn_agent(team_id, "worker", :coder,
+          project_path: @project_path
+        )
+
+      # Agent init broadcast
+      assert_receive {:agent_status, "worker", :idle}
+
+      # Task lifecycle
+      {:ok, task} = Tasks.create_task(team_id, %{title: "Ordered task"})
+      assert_receive {:task_created, task_id, "Ordered task"}
+      assert task_id == task.id
+
+      {:ok, _} = Tasks.assign_task(task.id, "worker")
+      assert_receive {:task_assigned, ^task_id, "worker"}
+
+      {:ok, _} = Tasks.start_task(task.id)
+      assert_receive {:task_started, ^task_id, "worker"}
+
+      {:ok, _} = Tasks.complete_task(task.id, "done")
+      assert_receive {:task_completed, ^task_id, "worker", "done"}
+
+      TeamManager.dissolve_team(team_id)
+    end
+
+    test "failed task emits correct event", %{session_id: _session_id} do
+      {:ok, team_id} =
+        TeamManager.create_team(name: "fail-test", project_path: @project_path)
+
+      Phoenix.PubSub.subscribe(Loom.PubSub, "team:#{team_id}:tasks")
+
+      {:ok, task} = Tasks.create_task(team_id, %{title: "Doomed task"})
+      {:ok, _} = Tasks.assign_task(task.id, "worker")
+      {:ok, _} = Tasks.fail_task(task.id, "compilation error")
+
+      assert_receive {:task_failed, _, "worker", "compilation error"}
+
+      TeamManager.dissolve_team(team_id)
+    end
+  end
+
+  describe "multi-agent coordination" do
+    test "multiple agents receive team-wide broadcasts", %{session_id: _session_id} do
+      {:ok, team_id} =
+        TeamManager.create_team(name: "multi-agent", project_path: @project_path)
+
+      {:ok, pid1} =
+        TeamManager.spawn_agent(team_id, "agent-a", :coder,
+          project_path: @project_path
+        )
+
+      {:ok, pid2} =
+        TeamManager.spawn_agent(team_id, "agent-b", :researcher,
+          project_path: @project_path
+        )
+
+      # Broadcast context update to entire team
+      Comms.broadcast(team_id, {:context_update, "lead", %{plan: "build feature X"}})
+
+      Process.sleep(100)
+
+      state1 = :sys.get_state(pid1)
+      state2 = :sys.get_state(pid2)
+
+      assert state1.context["lead"] == %{plan: "build feature X"}
+      assert state2.context["lead"] == %{plan: "build feature X"}
+
+      TeamManager.dissolve_team(team_id)
+    end
+
+    test "peer messages delivered to specific agents", %{session_id: _session_id} do
+      {:ok, team_id} =
+        TeamManager.create_team(name: "peer-msg", project_path: @project_path)
+
+      {:ok, pid1} =
+        TeamManager.spawn_agent(team_id, "sender", :lead,
+          project_path: @project_path
+        )
+
+      {:ok, pid2} =
+        TeamManager.spawn_agent(team_id, "receiver", :coder,
+          project_path: @project_path
+        )
+
+      Agent.peer_message(pid2, "sender", "Please implement the fix")
+      Process.sleep(100)
+
+      history = Agent.get_history(pid2)
+      assert length(history) == 1
+      assert hd(history).content =~ "sender"
+      assert hd(history).content =~ "Please implement the fix"
+
+      # Sender should NOT have the message
+      sender_history = Agent.get_history(pid1)
+      assert sender_history == []
+
+      TeamManager.dissolve_team(team_id)
+    end
+  end
+
+  describe "session integration" do
+    test "session tracks backing team", %{session_id: session_id, session_pid: session_pid} do
+      {:ok, team_id} =
+        TeamManager.create_team(name: "session-team", project_path: @project_path)
+
+      send(session_pid, {:team_created, team_id})
+
+      # Wait for the session to process the message and broadcast
+      assert_receive {:team_available, ^session_id, ^team_id}, 1000
+
+      # Verify the session stored the team_id (use get_status to flush mailbox first)
+      {:ok, :idle} = GenServer.call(session_pid, :get_status)
+      stored_team_id = GenServer.call(session_pid, :get_team_id)
+      assert stored_team_id == team_id
+
+      TeamManager.dissolve_team(team_id)
+    end
+
+    test "session tracks child teams and receives completion results", %{
+      session_id: session_id,
+      session_pid: session_pid
+    } do
+      # Wire a backing team
+      {:ok, backing_id} =
+        TeamManager.create_team(name: "backing-results", project_path: @project_path)
+
+      send(session_pid, {:team_created, backing_id})
+      Process.sleep(50)
+
+      # Spawn a child team
+      {:ok, child_id} =
+        TeamManager.create_sub_team(backing_id, "architect",
+          name: "child-results",
+          project_path: @project_path
+        )
+
+      # Notify session about the child team
+      send(session_pid, {:child_team_created, child_id})
+      Process.sleep(50)
+
+      assert_receive {:child_team_available, ^session_id, ^child_id}
+
+      # Create and complete tasks in the child team
+      {:ok, task} =
+        Tasks.create_task(child_id, %{
+          title: "Do the work",
+          description: "Implement the feature"
+        })
+
+      {:ok, _} = Tasks.assign_task(task.id, "worker")
+      {:ok, _} = Tasks.complete_task(task.id, "Feature complete")
+
+      # Session should synthesize results and broadcast to chat
+      Process.sleep(100)
+
+      assert_receive {:new_message, ^session_id, %{role: :assistant, content: summary}}
+      assert summary =~ "Do the work"
+      assert summary =~ "Feature complete"
+
+      TeamManager.dissolve_team(child_id)
+      TeamManager.dissolve_team(backing_id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Agent init broadcasts** — agents announce themselves on spawn so UI sees them immediately
- **Sub-team registration** — `team_spawn` uses `Manager.create_sub_team` when called from Architect, session tracks `child_team_ids`
- **Architect bootstrap** — after spawning a team, sends the user's original request to the lead agent instead of returning silently
- **Agent auto-execute** — agents automatically run tasks on `:task_assigned` when idle, mark completion/failure via `Tasks`
- **Reactive dashboard & cost** — `TeamDashboardComponent` (8 handlers) and `TeamCostComponent` (4 handlers) now handle all PubSub events in real-time
- **Multi-team awareness** — `WorkspaceLive` discovers child teams, shows team switcher pills, forwards events to sub-components
- **Results bubble back** — session synthesizes child team results into an assistant message when all tasks complete
- **Integration test** — 7 tests, 0 failures, covering full spawn → work → complete → report lifecycle

## Changes

8 files changed, 819 insertions, 44 deletions

| File | What |
|------|------|
| `lib/loom/teams/agent.ex` | Init broadcast + auto-execute on task assignment |
| `lib/loom/tools/team_spawn.ex` | `create_sub_team` when `parent_team_id` present |
| `lib/loom/session/session.ex` | Track child teams, check completion, synthesize results |
| `lib/loom/session/architect.ex` | Bootstrap lead agent, notify session of child teams |
| `lib/loom_web/live/team_dashboard_component.ex` | 8 PubSub handlers + reload helper |
| `lib/loom_web/live/team_cost_component.ex` | 4 PubSub handlers |
| `lib/loom_web/live/workspace_live.ex` | Child team discovery, switcher UI, event forwarding |
| `test/loom/teams/orchestration_test.exs` | New — 7 integration tests |

## Test plan

- [x] `mix test test/loom/teams/orchestration_test.exs` — 7 tests, 0 failures
- [ ] Manual: spawn a team via chat, verify agents begin working autonomously
- [ ] Manual: verify team switcher appears when child team spawns
- [ ] Manual: verify dashboard/cost update in real-time as agents work
- [ ] Manual: verify results appear in chat when team completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)