### PR TITLE
Epic 5.19: Decision graph as shared nervous system

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -11,3 +11,7 @@ config :loomkin, LoomkinWeb.Endpoint,
   server: false
 
 config :logger, level: :warning
+
+# Disable auto-start of nervous system (AutoLogger/Broadcaster) in tests.
+# Tests that need them start them explicitly with sandbox-aware setup.
+config :loomkin, start_nervous_system: false

--- a/docs/epic-5.19-decision-graph-nervous-system.md
+++ b/docs/epic-5.19-decision-graph-nervous-system.md
@@ -1,0 +1,246 @@
+# Epic 5.19: Decision Graph as Shared Nervous System
+
+> **Priority**: P0 — builds on all existing Phase 5 infrastructure
+> **Depends on**: Epics 5.1-5.18 (all complete)
+> **Principle**: Graph is the index/nervous system. Keepers are the memory. They enhance each other.
+
+---
+
+## Origin
+
+This epic originates from `~/documents/decision-graph-vision.md`, which identified that the
+decision graph today is essentially a journal — agents log what they decided and why. The real
+unlock is making it the **shared nervous system** of the entire agent mesh, while preserving
+Context Keepers as the irreplaceable full-fidelity memory layer.
+
+---
+
+## The Problem
+
+### Two Layers, Zero Integration
+
+Loomkin has two powerful coordination layers that currently don't talk to each other:
+
+| Layer | What it is | Scope | Writes |
+|-------|-----------|-------|--------|
+| **Decision Graph** | Structured DAG — 7 node types, typed edges, confidence scores | Session-scoped (`session_id` FK) | Manual (agent calls `decision_log`) + rare auto (debates, role changes) |
+| **Context Keepers** | Full-fidelity conversation buffers in GenServer processes | Team-scoped (`team_id`) | Automatic (offload when context > 60% of model limit) |
+
+The graph never consults keepers. Keepers never write to the graph. They're parallel.
+
+### What's Missing (from the vision doc)
+
+1. **Causality is invisible** — When an agent spawns a sub-team because it discovered something mid-task, that causal chain lives in scattered PubSub messages. A new agent joining later can't understand WHY things are happening.
+
+2. **Knowledge routing is ad-hoc** — Agents can ask questions (`peer_ask_question`), but can't say "I learned X, and it's relevant to goal Y that agent Z is pursuing." Discovery is pull-only.
+
+3. **Confidence propagation doesn't exist** — If an agent marks a decision at confidence 40 and another agent depends on that decision, nothing alerts the downstream agent. The graph has the edges but nobody walks them.
+
+4. **Planning ignores history** — Before a lead decomposes a task, it doesn't query the graph for prior attempts, abandoned approaches, or discovered constraints.
+
+---
+
+## The Complementary Model
+
+### One-Sentence Architecture
+
+> **The graph knows WHAT happened and WHO cares. Keepers know the FULL STORY. Graph nodes point to keepers via `keeper_id`. Fast questions hit the graph. Deep questions follow the reference to keepers.**
+
+### How They Enhance Each Other
+
+```
+                    DECISION GRAPH                          CONTEXT KEEPERS
+              (Index / Nervous System)                    (Memory / Archive)
+         ┌─────────────────────────────┐          ┌─────────────────────────────┐
+         │                             │          │                             │
+         │  goal ──→ decision ──→ action│  keeper_id │  Full 200-message thread   │
+         │    │         │         │     │────────────→│  about auth debate with    │
+         │    │      option(rejected)   │          │  every argument, code        │
+         │    │         │              │          │  snippet, and tradeoff       │
+         │    └──→ observation         │          │                             │
+         │                             │          │  Smart query: "Why was      │
+         │  Confidence: 85             │          │  OAuth rejected?" → focused │
+         │  Agent: coder-1             │          │  answer from full context   │
+         │  Status: active             │          │                             │
+         └─────────────────────────────┘          └─────────────────────────────┘
+
+         FAST: "What did we decide?"               DEEP: "Why? Show me everything."
+         STRUCTURED: nodes, edges, scores           RAW: full conversation fidelity
+         ROUTING: who cares about this?             PAYLOAD: here's the full context
+```
+
+### Data Flow Principles
+
+1. **Graph references keepers, not the other way around** — `metadata.keeper_id` on graph nodes points to relevant keepers. Keepers don't need to know about the graph.
+
+2. **Keepers are never modified by graph operations** — The graph reads from keepers (via smart retrieval) but never writes to or alters keeper state.
+
+3. **Graph is the routing layer, keepers are the payload** — Discovery broadcasting walks graph edges to find WHO cares, then points them to the relevant keeper for full context.
+
+4. **Two-tier retrieval** — Fast path hits the graph for structured answers. Deep path follows `keeper_id` to get full-fidelity context from keepers.
+
+---
+
+## Research Findings
+
+### Decision Graph — Current State
+
+**Module**: `Loomkin.Decisions.Graph` (`lib/loomkin/decisions/graph.ex`)
+**Schema**: `Loomkin.Schemas.DecisionNode` (`lib/loomkin/schemas/decision_node.ex`)
+
+- **7 node types**: goal, decision, option, action, outcome, observation, revisit
+- **7 edge types**: leads_to (default), chosen, rejected, requires, blocks, enables, supersedes
+- **Confidence**: 0-100 integer, optional, no semantic definition in code
+- **Metadata**: map field, currently unused — this is where `keeper_id` will go
+- **Agent attribution**: `agent_name` field added Feb 28 migration
+- **Context injection**: `ContextBuilder.build/2` injects active goals + recent decisions into system prompt (capped at 1024 tokens / 4096 chars)
+- **Pulse reports**: `Pulse.generate/1` flags coverage gaps, low-confidence nodes, stale nodes
+
+**Key gap**: Only debates and role changes auto-write to graph. Everything else requires agents to explicitly call `decision_log`. Most lifecycle events (spawn, task assign, offload) leave no graph trace.
+
+### Context Keepers — Current State
+
+**Module**: `Loomkin.Teams.ContextKeeper` (`lib/loomkin/teams/context_keeper.ex`)
+**Schema**: `Loomkin.Schemas.ContextKeeper` (`lib/loomkin/schemas/context_keeper.ex`)
+
+- **Storage**: Full message lists (role + content), topics, token counts, metadata
+- **Offload trigger**: 60% of model context limit → split at topic boundary → spawn keeper
+- **Smart retrieval**: Single cheap LLM call over stored context, keyword fallback
+- **Cross-agent access**: Any agent can query any keeper in the team via Registry
+- **Persistence**: Debounced SQLite writes (50ms), reload on init, archived on team dissolve
+- **Knowledge routing integration**: `QueryRouter.ask` auto-enriches questions with keeper context (5s timeout, graceful fallback)
+
+**Key strength**: Keepers are independent processes, discoverable via Registry, and auto-enriched into knowledge routing. This must not be disrupted.
+
+---
+
+## Capability Design
+
+### Capability 1: Causal Tracing
+
+> Graph writes the edges, keepers hold the evidence.
+
+When lifecycle events happen, auto-create graph nodes with edges linking them to the triggering context:
+
+| Event | Graph Node | Edge | Keeper Link |
+|-------|-----------|------|-------------|
+| `team_spawn` | `:action` "Spawned team: {name}" | `:leads_to` from triggering goal | `keeper_id` of lead's context at spawn time |
+| `context_offload` | `:observation` "Context offloaded: {topic}" | `:leads_to` from active goal | `keeper_id` of the new keeper |
+| `peer_message` (significant) | `:observation` "Discovery: {summary}" | `:enables` to relevant goals | `keeper_id` if message references offloaded context |
+| `task_assigned` | `:action` "Task assigned: {title} → {agent}" | `:leads_to` from parent goal | None (lightweight) |
+| `task_completed` | `:outcome` "Completed: {title}" | `:leads_to` from task action | `keeper_id` if agent offloaded during task |
+| `agent_spawned` | `:action` "Agent {name} ({role}) joined" | `:leads_to` from team spawn | None (lightweight) |
+
+**Implementation**: Hook into existing PubSub events in `Loomkin.Teams.Comms`. A new module subscribes to team events and writes graph nodes. No changes to keepers.
+
+### Capability 2: Discovery Broadcasting
+
+> Graph discovers who cares, keepers deliver the payload.
+
+When an agent logs an `:observation` node:
+
+1. **Graph walker** queries edges from the observation → find connected goals (via `:enables`/`:requires` reverse-walk)
+2. For each connected goal, find the owning agent (via `agent_name` field)
+3. Send lightweight PubSub notification: `{:discovery_relevant, observation_id, goal_id, keeper_id}`
+4. Receiving agent can choose to:
+   - Read the graph node summary (fast, structured)
+   - Query the referenced keeper via smart retrieval (deep, full context)
+
+**Implementation**: New `Loomkin.Decisions.Broadcaster` GenServer. Subscribes to graph write events. Does edge-walking. Sends PubSub notifications. Keepers are only involved as optional deep-dive targets.
+
+### Capability 3: Confidence Cascades
+
+> Graph propagates signals, keepers provide evidence for re-evaluation.
+
+When a node's confidence is set or updated below a threshold (default 50):
+
+1. **Cascade walker** follows `:requires`/`:blocks` edges downstream
+2. Flag dependent nodes as `metadata.upstream_uncertainty: true`
+3. Notify owning agents: `{:confidence_warning, node_id, upstream_confidence, keeper_id}`
+4. Agents can then query the referenced keeper for the full discussion that led to the low-confidence decision
+
+**Implementation**: Hook into `Graph.update_node/2`. When confidence changes, trigger cascade. Builds on Pulse (which already finds low-confidence nodes) but makes it real-time and edge-aware.
+
+### Capability 4: Graph-Informed Planning
+
+> Graph provides structure, keepers provide depth.
+
+Before a lead agent decomposes a task:
+
+1. **ContextBuilder** queries graph for `revisit` and `superseded` nodes matching the topic
+2. Inject structured summary: "Prior attempts: X was tried (confidence 30, abandoned). Y was rejected (reason in keeper K)."
+3. If lead needs more, it calls `context_retrieve` on the referenced keeper
+
+**Implementation**: Extend `Loomkin.Decisions.ContextBuilder.build/2` to include prior-attempt context. Add a new section alongside "Active Goals" and "Recent Decisions": "Prior Attempts & Lessons."
+
+### Capability 5: Cross-Session Memory
+
+> Graph is the fast lookup, keepers are the archive.
+
+This is largely already built. The remaining piece:
+
+1. **ContextBuilder** should query across ALL sessions (not just current) for active goals
+2. Archived keepers (status: `:archived`) should be discoverable by new sessions
+3. Graph nodes with `keeper_id` create a durable link: new session reads graph → follows keeper references → gets full prior context
+
+**Implementation**: Remove session-scoping from some `ContextBuilder` queries. Add `list_nodes(team_id: id)` filter alongside existing `session_id` filter.
+
+---
+
+## Files Affected
+
+### New Files
+
+| File | Purpose | Est. LOC |
+|------|---------|----------|
+| `lib/loomkin/decisions/auto_logger.ex` | Subscribes to PubSub, auto-writes lifecycle events to graph | ~200 |
+| `lib/loomkin/decisions/broadcaster.ex` | Walks graph edges on new observations, notifies relevant agents | ~150 |
+| `lib/loomkin/decisions/cascade.ex` | Propagates confidence changes through edges | ~120 |
+
+### Modified Files
+
+| File | Change | Est. Delta |
+|------|--------|-----------|
+| `lib/loomkin/decisions/graph.ex` | Add `add_node_with_keeper/2`, team_id filter support | +30 |
+| `lib/loomkin/decisions/context_builder.ex` | Add "Prior Attempts" section, cross-session queries, keeper-enriched context | +60 |
+| `lib/loomkin/decisions/pulse.ex` | Add cascade-aware low-confidence detection | +30 |
+| `lib/loomkin/schemas/decision_node.ex` | Document `metadata.keeper_id` convention (no schema change needed — metadata is already a map) | +5 (comments) |
+| `lib/loomkin/teams/agent.ex` | Handle `:discovery_relevant` and `:confidence_warning` PubSub messages | +40 |
+| `lib/loomkin/teams/supervisor.ex` | Start AutoLogger and Broadcaster under supervision | +10 |
+| `lib/loomkin/application.ex` | (if AutoLogger is app-level, not team-level) | +5 |
+
+### Untouched (Explicitly)
+
+- `lib/loomkin/teams/context_keeper.ex` — No changes. Keepers remain the memory layer.
+- `lib/loomkin/teams/context_offload.ex` — No changes to offload logic.
+- `lib/loomkin/teams/context_retrieval.ex` — No changes. Agents already have smart retrieval.
+- `lib/loomkin/tools/context_*.ex` — No tool changes. Existing tools sufficient.
+
+---
+
+## Total Estimated Effort
+
+| Component | New LOC | Modified LOC | Total |
+|-----------|---------|-------------|-------|
+| AutoLogger (causal tracing) | ~200 | +15 (supervisor) | ~215 |
+| Broadcaster (discovery) | ~150 | +40 (agent handlers) | ~190 |
+| Cascade (confidence) | ~120 | +30 (pulse) | ~150 |
+| ContextBuilder (planning + cross-session) | — | +60 | ~60 |
+| Graph API additions | — | +30 | ~30 |
+| Tests | ~400 | — | ~400 |
+| **Total** | **~870** | **~175** | **~1,045** |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Lifecycle events (team spawn, agent spawn, task assign/complete, context offload) auto-create graph nodes
+- [ ] Auto-created nodes include `metadata.keeper_id` when a relevant keeper exists
+- [ ] New observations trigger edge-walking to find and notify agents with related active goals
+- [ ] Notified agents can follow `keeper_id` to get full context via existing smart retrieval
+- [ ] Low-confidence nodes propagate warnings downstream through `requires`/`blocks` edges
+- [ ] ContextBuilder injects prior-attempt context (revisit/superseded nodes) into planning prompts
+- [ ] ContextBuilder can query across sessions (not just current session)
+- [ ] All new modules are supervised (crash recovery)
+- [ ] Keeper modules remain completely untouched
+- [ ] Tests cover: auto-logging, broadcasting, cascades, cross-session queries, keeper references

--- a/docs/plan-5.19-implementation.md
+++ b/docs/plan-5.19-implementation.md
@@ -1,0 +1,564 @@
+# Implementation Plan: Epic 5.19 — Decision Graph as Shared Nervous System
+
+> **For**: Claude team executing this epic
+> **Read first**: `docs/epic-5.19-decision-graph-nervous-system.md` (architecture + rationale)
+> **Master plan**: `~/projects/loom-master-plan.md` (full project context)
+> **Repo**: `~/projects/loom`
+> **Module namespace**: `Loomkin` (not `Loom`)
+
+---
+
+## Critical Constraints
+
+1. **DO NOT modify context keeper files.** Keepers are the memory layer and must remain untouched:
+   - `lib/loomkin/teams/context_keeper.ex` — NO CHANGES
+   - `lib/loomkin/teams/context_offload.ex` — NO CHANGES
+   - `lib/loomkin/teams/context_retrieval.ex` — NO CHANGES
+   - `lib/loomkin/schemas/context_keeper.ex` — NO CHANGES
+   - `lib/loomkin/tools/context_offload.ex` — NO CHANGES
+   - `lib/loomkin/tools/context_retrieve.ex` — NO CHANGES
+
+2. **No schema migrations needed.** `DecisionNode.metadata` is already a `:map` field. We store `keeper_id` there as a convention, not a column. `DecisionEdge` already has all 7 edge types we need.
+
+3. **Follow existing patterns.** Study these files for conventions:
+   - `lib/loomkin/decisions/graph.ex` — Graph API pattern (import Ecto.Query, alias Repo)
+   - `lib/loomkin/teams/agent.ex` — PubSub handler pattern (handle_info clauses)
+   - `lib/loomkin/teams/comms.ex` — PubSub topic conventions (`team:#{id}`, etc.)
+   - `lib/loomkin/teams/supervisor.ex` — Supervision tree pattern
+   - `lib/loomkin/decisions/pulse.ex` — Graph query patterns
+
+4. **Test conventions.** Check `test/` directory for patterns. Tests use `Loomkin.Repo` with sandbox mode. Team tests typically mock or start agents via the existing test helpers.
+
+---
+
+## Build Order
+
+Execute tasks sequentially. Each task builds on the previous one.
+
+### Task 1: AutoLogger — Causal Tracing via PubSub
+
+**Create**: `lib/loomkin/decisions/auto_logger.ex`
+**Test**: `test/loomkin/decisions/auto_logger_test.exs`
+
+A GenServer that subscribes to team PubSub events and auto-creates graph nodes.
+
+**Step 1a: Study the PubSub events**
+
+Read these files to understand what events are already broadcast:
+- `lib/loomkin/teams/comms.ex` — PubSub helper functions and topic naming
+- `lib/loomkin/teams/agent.ex` — What events agents broadcast (search for `PubSub.broadcast`)
+- `lib/loomkin/teams/manager.ex` — Team lifecycle events
+- `lib/loomkin/tools/team_spawn.ex` — Team spawn events
+- `lib/loomkin/tools/context_offload.ex` — Offload events (READ ONLY, do not modify)
+- `lib/loomkin/tools/peer_create_task.ex` — Task creation events
+- `lib/loomkin/tools/peer_complete_task.ex` — Task completion events
+
+Map out every PubSub broadcast and its payload. You need to know what data is available.
+
+**Step 1b: Implement AutoLogger**
+
+```elixir
+defmodule Loomkin.Decisions.AutoLogger do
+  @moduledoc """
+  Subscribes to team PubSub events and auto-creates decision graph nodes
+  for lifecycle events, establishing causal tracing.
+
+  Graph nodes created by AutoLogger include `metadata.keeper_id` when
+  a relevant context keeper exists, creating a bridge between the
+  structured graph (index) and keepers (full-fidelity memory).
+  """
+  use GenServer
+
+  # Subscribe to team:#{team_id} PubSub topic on start
+  # Handle each event type → create appropriate graph node
+
+  # Events to handle:
+  # - Agent spawned → :action node, "Agent {name} ({role}) joined team"
+  # - Task assigned → :action node, "Task assigned: {title} → {agent}"
+  # - Task completed → :outcome node, "Completed: {title}"
+  # - Context offloaded → :observation node, "Context offloaded: {topic}"
+  #   Include metadata.keeper_id pointing to the new keeper
+  # - Team spawned → :action node with edge from triggering goal if identifiable
+
+  # For each node:
+  # - Set agent_name from event data
+  # - Set session_id from event data if available
+  # - Create :leads_to edge from parent goal/action if identifiable
+  # - Include metadata.keeper_id when relevant keeper exists
+  # - Include metadata.auto_logged: true to distinguish from manual logs
+end
+```
+
+**Key decisions**:
+- AutoLogger is **per-team** (started when team starts, stopped when team dissolves)
+- OR **application-level** singleton that filters by team_id from events
+- Per-team is cleaner (subscribes only to its team's PubSub topic)
+- Start under `Loomkin.Teams.Supervisor` alongside the existing children
+
+**Edge creation heuristic**: When creating a node for a lifecycle event, look for the most recent active `:goal` node in the same session to create a `:leads_to` edge from. If no goal exists, create the node without an edge (orphan nodes are fine — they'll get connected as agents work).
+
+**Acceptance criteria**:
+- [ ] AutoLogger starts with team, stops with team
+- [ ] At least 5 event types create graph nodes (agent spawn, task assign, task complete, context offload, team spawn)
+- [ ] Context offload events include `metadata.keeper_id`
+- [ ] `metadata.auto_logged: true` on all auto-created nodes
+- [ ] Edges link to parent goals when identifiable
+- [ ] Tests: each event type creates correct node type + edges
+
+---
+
+### Task 2: Graph API Additions
+
+**Modify**: `lib/loomkin/decisions/graph.ex`
+**Test**: Update existing `test/loomkin/decisions/graph_test.exs`
+
+Add support for team-scoped queries and keeper-linked node creation.
+
+**Step 2a: Add team-aware filters**
+
+The graph currently filters by `session_id`. Add `team_id` and cross-session support:
+
+```elixir
+# In apply_node_filters/2, add:
+defp apply_node_filters(query, [{:team_id, team_id} | rest]) do
+  # Join through sessions that belong to this team, OR
+  # Filter nodes where metadata contains team_id
+  # (Depends on whether sessions have team_id — check schema)
+  query |> apply_node_filters(rest)
+end
+
+# Cross-session: all nodes regardless of session
+defp apply_node_filters(query, [{:cross_session, true} | rest]) do
+  query |> apply_node_filters(rest)
+  # Simply don't add session_id filter
+end
+```
+
+**Important**: Check `lib/loomkin/schemas/session.ex` to see if sessions have a `team_id` field. If not, AutoLogger should store `team_id` in `metadata.team_id` on nodes it creates, and the filter should query metadata.
+
+**Step 2b: Add helper for keeper-linked nodes**
+
+```elixir
+def add_node_with_keeper(attrs, keeper_id) when is_binary(keeper_id) do
+  attrs = put_in(attrs, [:metadata, :keeper_id], keeper_id)
+  add_node(attrs)
+end
+```
+
+**Step 2c: Add edge-walking helpers**
+
+```elixir
+# Walk downstream from a node through specific edge types
+def walk_downstream(node_id, edge_types, opts \\ []) do
+  max_depth = Keyword.get(opts, :max_depth, 5)
+  # BFS/DFS through edges, return list of {node, depth, edge_type}
+end
+
+# Walk upstream (reverse edges) to find ancestors
+def walk_upstream(node_id, edge_types, opts \\ []) do
+  # Same but following edges in reverse (to_node_id → from_node_id)
+end
+
+# Find nodes connected to a given node through specific edge types
+def connected_nodes(node_id, edge_types) do
+  # Both directions, single hop
+end
+```
+
+These walkers are used by Broadcaster (Task 3) and Cascade (Task 4).
+
+**Acceptance criteria**:
+- [ ] `list_nodes(team_id: id)` returns nodes scoped to a team
+- [ ] `add_node_with_keeper/2` stores keeper_id in metadata
+- [ ] `walk_downstream/3` traverses edges by type with depth limit
+- [ ] `walk_upstream/3` traverses reverse edges
+- [ ] Tests: team filtering, keeper metadata, graph walking
+
+---
+
+### Task 3: Discovery Broadcaster
+
+**Create**: `lib/loomkin/decisions/broadcaster.ex`
+**Test**: `test/loomkin/decisions/broadcaster_test.exs`
+
+A GenServer that watches for new observation nodes and notifies agents whose goals are relevant.
+
+**Step 3a: Understand the flow**
+
+```
+Agent logs :observation node (via decision_log tool or AutoLogger)
+  ↓
+Broadcaster detects new node (via PubSub or polling)
+  ↓
+Walks :enables/:requires edges from observation → find connected :goal nodes
+  ↓
+For each connected goal with status :active, find owning agent (agent_name field)
+  ↓
+Send PubSub notification to that agent:
+  {:discovery_relevant, %{
+    observation_id: obs_id,
+    observation_title: "...",
+    goal_id: goal_id,
+    goal_title: "...",
+    keeper_id: metadata.keeper_id || nil,  # for deep-dive
+    source_agent: who_logged_it
+  }}
+  ↓
+Receiving agent sees notification in handle_info → can choose to:
+  - Read graph node summary (already has title + description)
+  - Call context_retrieve on keeper_id for full context
+```
+
+**Step 3b: Implement Broadcaster**
+
+```elixir
+defmodule Loomkin.Decisions.Broadcaster do
+  @moduledoc """
+  Watches for new observation/outcome nodes in the decision graph and
+  proactively notifies agents whose active goals are connected via
+  :enables or :requires edges.
+
+  This is the "push" layer — instead of agents polling for relevant
+  discoveries, the graph routes knowledge to where it's needed.
+
+  Discovery notifications include keeper_id when available, so agents
+  can follow the reference to get full context from keepers.
+  """
+  use GenServer
+end
+```
+
+**How to detect new nodes**: Two options:
+1. **PubSub**: Have `Graph.add_node/1` broadcast `{:graph_node_added, node}` on a PubSub topic. Broadcaster subscribes. **Preferred** — real-time, follows existing PubSub patterns.
+2. **Polling**: Periodically query for nodes newer than last check. Simpler but adds latency.
+
+Go with option 1. Add a PubSub broadcast to `Graph.add_node/1`:
+
+```elixir
+# In graph.ex, after successful insert:
+def add_node(attrs) do
+  # ... existing code ...
+  case Repo.insert(changeset) do
+    {:ok, node} ->
+      Phoenix.PubSub.broadcast(Loomkin.PubSub, "decision_graph", {:node_added, node})
+      {:ok, node}
+    error -> error
+  end
+end
+```
+
+**Edge-walking strategy**: Use `Graph.walk_upstream/3` (from Task 2) with edge types `[:enables, :requires]` to find connected goal nodes. Limit depth to 3 to avoid expensive traversals.
+
+**Rate limiting**: Don't spam agents. Debounce notifications — if 5 observations are logged in quick succession about the same goal, batch them into one notification.
+
+**Acceptance criteria**:
+- [ ] Graph.add_node broadcasts to PubSub topic
+- [ ] Broadcaster subscribes and processes new observation/outcome nodes
+- [ ] Edge-walking finds connected active goals
+- [ ] Notifications sent to owning agents via team PubSub
+- [ ] Notifications include keeper_id when available
+- [ ] Debouncing prevents notification spam
+- [ ] Tests: observation → goal found → agent notified, with and without keeper_id
+
+---
+
+### Task 4: Confidence Cascade
+
+**Create**: `lib/loomkin/decisions/cascade.ex`
+**Test**: `test/loomkin/decisions/cascade_test.exs`
+
+Propagates confidence warnings downstream when a node's confidence drops below threshold.
+
+**Step 4a: Implement Cascade**
+
+```elixir
+defmodule Loomkin.Decisions.Cascade do
+  @moduledoc """
+  Propagates confidence warnings through the decision graph.
+
+  When a node's confidence is set or updated below the threshold (default 50),
+  walks :requires/:blocks edges downstream and flags dependent nodes as
+  potentially unstable. Notifies owning agents so they can re-evaluate.
+
+  Agents can query the keeper referenced in the low-confidence node's metadata
+  to get the full conversation context for re-evaluation.
+  """
+
+  @default_threshold 50
+
+  def check_and_propagate(node_id, opts \\ []) do
+    threshold = Keyword.get(opts, :threshold, @default_threshold)
+    # 1. Get the node
+    # 2. If confidence < threshold, walk downstream
+    # 3. For each downstream node, update metadata.upstream_uncertainty
+    # 4. Notify owning agents
+  end
+end
+```
+
+**Trigger**: Hook into `Graph.update_node/2`. After a successful update where `confidence` changed:
+
+```elixir
+# In graph.ex update_node/2, after successful update:
+if Map.has_key?(attrs, :confidence) do
+  Cascade.check_and_propagate(node.id)
+end
+```
+
+**Notification payload**:
+
+```elixir
+{:confidence_warning, %{
+  source_node_id: low_confidence_node_id,
+  source_title: "...",
+  source_confidence: 35,
+  affected_node_id: your_dependent_node_id,
+  affected_title: "...",
+  keeper_id: metadata.keeper_id || nil,  # for re-evaluation
+  edge_path: [:requires, :leads_to]  # how they're connected
+}}
+```
+
+**Acceptance criteria**:
+- [ ] Confidence drop below threshold triggers cascade
+- [ ] Downstream nodes found via `:requires`/`:blocks` edges (depth-limited)
+- [ ] `metadata.upstream_uncertainty` set on affected nodes
+- [ ] Owning agents notified via PubSub
+- [ ] Notifications include keeper_id for re-evaluation
+- [ ] Cascade is idempotent (re-running doesn't duplicate warnings)
+- [ ] Tests: cascade propagation, depth limiting, agent notification
+
+---
+
+### Task 5: Enhanced ContextBuilder — Prior Attempts + Cross-Session
+
+**Modify**: `lib/loomkin/decisions/context_builder.ex`
+**Test**: Update `test/loomkin/decisions/context_builder_test.exs`
+
+**Step 5a: Study current ContextBuilder**
+
+Read `lib/loomkin/decisions/context_builder.ex` carefully. Understand:
+- How `build/2` assembles context sections
+- Token budget allocation
+- What sections exist today (active goals, recent decisions, session context)
+
+**Step 5b: Add "Prior Attempts & Lessons" section**
+
+Query for `:revisit` and `:superseded` nodes that match the current session's topics:
+
+```elixir
+defp prior_attempts_section(session_id) do
+  # Get revisit nodes (flagged for re-examination)
+  revisits = Graph.list_nodes(node_type: :revisit, status: :active)
+
+  # Get superseded/abandoned decisions (things that were tried and didn't work)
+  abandoned = Graph.list_nodes(status: :abandoned)
+  superseded = Graph.list_nodes(status: :superseded)
+
+  # Format as context section:
+  # "## Prior Attempts & Lessons
+  #  - [REVISIT] Auth token format (confidence: 30) — needs re-evaluation
+  #  - [ABANDONED] OAuth approach — rejected due to complexity (keeper: abc-123)
+  #  - [SUPERSEDED] REST API → replaced by GraphQL (keeper: def-456)"
+end
+```
+
+**Step 5c: Add cross-session goal awareness**
+
+Currently `build/2` filters by `session_id`. Add an option to include goals from other sessions:
+
+```elixir
+def build(session_id, opts \\ []) do
+  cross_session = Keyword.get(opts, :cross_session, false)
+
+  goals = if cross_session do
+    Graph.list_nodes(node_type: :goal, status: :active)  # all sessions
+  else
+    Graph.list_nodes(node_type: :goal, status: :active, session_id: session_id)
+  end
+
+  # ... rest of build ...
+end
+```
+
+**Step 5d: Include keeper references in context output**
+
+When a graph node has `metadata.keeper_id`, include it in the formatted output so the agent knows it can dig deeper:
+
+```
+## Active Goals
+- Implement user authentication (confidence: 85)
+  → Deep context available in keeper abc-123
+```
+
+**Acceptance criteria**:
+- [ ] "Prior Attempts & Lessons" section added to context output
+- [ ] Revisit, abandoned, and superseded nodes surfaced
+- [ ] Cross-session goal queries work (opt-in flag)
+- [ ] Keeper references included when nodes have `metadata.keeper_id`
+- [ ] Token budget respected (new sections don't blow the budget)
+- [ ] Tests: prior attempts section, cross-session, keeper references
+
+---
+
+### Task 6: Agent Integration — Handle New PubSub Messages
+
+**Modify**: `lib/loomkin/teams/agent.ex`
+**Test**: Update `test/loomkin/teams/agent_test.exs`
+
+**Step 6a: Study existing handle_info clauses**
+
+Read `lib/loomkin/teams/agent.ex`. Find existing `handle_info` clauses to understand the pattern for handling PubSub messages. Look for how agents currently process incoming messages.
+
+**Step 6b: Add handlers for discovery and confidence warnings**
+
+```elixir
+# Discovery notification — another agent's observation is relevant to our goal
+def handle_info({:discovery_relevant, payload}, state) do
+  # Inject into agent's pending context for next LLM turn:
+  # "Discovery from {source_agent}: {observation_title} may be relevant to your goal: {goal_title}"
+  # If keeper_id present: "Full context available via context_retrieve on keeper {keeper_id}"
+  {:noreply, inject_pending_update(state, :discovery, payload)}
+end
+
+# Confidence warning — upstream decision is uncertain
+def handle_info({:confidence_warning, payload}, state) do
+  # Inject warning: "Warning: upstream decision '{source_title}' has low confidence ({confidence}).
+  # Your work on '{affected_title}' may be affected. Consider re-verifying."
+  {:noreply, inject_pending_update(state, :confidence_warning, payload)}
+end
+```
+
+**How `inject_pending_update` works**: Check if the agent already has a pattern for queuing pending updates between LLM turns. If so, follow that pattern. If not, add a `pending_updates` list to agent state that gets injected as a system message on the next LLM call.
+
+**Acceptance criteria**:
+- [ ] Agents handle `:discovery_relevant` messages
+- [ ] Agents handle `:confidence_warning` messages
+- [ ] Messages are queued and injected on next LLM turn (not interrupting current work)
+- [ ] Tests: agent receives and processes both message types
+
+---
+
+### Task 7: Supervision & Startup
+
+**Modify**: `lib/loomkin/teams/supervisor.ex` (or wherever team children are started)
+
+**Step 7a: Start AutoLogger and Broadcaster with each team**
+
+```elixir
+# When a team starts, also start:
+children = [
+  # ... existing children ...
+  {Loomkin.Decisions.AutoLogger, team_id: team_id},
+  {Loomkin.Decisions.Broadcaster, team_id: team_id}
+]
+```
+
+**Note**: `Cascade` doesn't need its own process — it's triggered synchronously from `Graph.update_node/2`. It's a module with functions, not a GenServer.
+
+**Step 7b: Ensure clean shutdown**
+
+When a team dissolves (`team_dissolve` tool), AutoLogger and Broadcaster should terminate gracefully. Check how existing team children are shut down and follow the same pattern.
+
+**Acceptance criteria**:
+- [ ] AutoLogger starts with team
+- [ ] Broadcaster starts with team
+- [ ] Both shut down cleanly on team dissolve
+- [ ] Supervision restarts them on crash (transient restart strategy)
+
+---
+
+### Task 8: Tests — Integration Suite
+
+**Create**: `test/loomkin/decisions/nervous_system_integration_test.exs`
+
+End-to-end test that validates the full flow:
+
+```elixir
+test "observation triggers discovery notification to relevant agent" do
+  # 1. Create a team with two agents
+  # 2. Agent A logs a :goal node
+  # 3. Agent B logs an :observation node with :enables edge to Agent A's goal
+  # 4. Assert Agent A receives {:discovery_relevant, ...} via PubSub
+end
+
+test "context offload creates graph node with keeper_id" do
+  # 1. Agent offloads context → keeper created
+  # 2. Assert AutoLogger created :observation node
+  # 3. Assert node has metadata.keeper_id matching the keeper
+end
+
+test "low confidence cascades to dependent nodes" do
+  # 1. Create goal → decision → action chain with :requires edges
+  # 2. Update decision confidence to 30
+  # 3. Assert action node gets metadata.upstream_uncertainty
+  # 4. Assert owning agent notified
+end
+
+test "ContextBuilder includes prior attempts from other sessions" do
+  # 1. In session A, log a decision then mark it :abandoned
+  # 2. In session B, build context with cross_session: true
+  # 3. Assert abandoned decision appears in "Prior Attempts" section
+end
+
+test "keeper_id in graph nodes enables two-tier retrieval" do
+  # 1. Create keeper with messages about auth
+  # 2. Create graph :decision node with metadata.keeper_id
+  # 3. Agent queries graph → gets structured summary
+  # 4. Agent follows keeper_id → gets full context via smart retrieval
+end
+```
+
+**Acceptance criteria**:
+- [ ] Full flow tests pass: event → auto-log → broadcast → agent notification
+- [ ] Keeper integration tests pass: graph node → keeper_id → smart retrieval
+- [ ] Cascade tests pass: confidence drop → downstream notification
+- [ ] Cross-session tests pass: prior attempts surface in new sessions
+- [ ] No existing tests broken
+
+---
+
+## File Reference
+
+### Existing files you MUST read before starting
+
+| File | Why |
+|------|-----|
+| `lib/loomkin/decisions/graph.ex` | Graph API — you'll extend this |
+| `lib/loomkin/decisions/pulse.ex` | Query patterns for graph analysis |
+| `lib/loomkin/decisions/context_builder.ex` | Context injection — you'll extend this |
+| `lib/loomkin/schemas/decision_node.ex` | Node schema (metadata is a :map field) |
+| `lib/loomkin/schemas/decision_edge.ex` | Edge schema + types |
+| `lib/loomkin/teams/agent.ex` | Agent GenServer — you'll add handle_info clauses |
+| `lib/loomkin/teams/comms.ex` | PubSub conventions — follow these patterns |
+| `lib/loomkin/teams/supervisor.ex` | Team supervision — you'll add children here |
+| `lib/loomkin/teams/manager.ex` | Team lifecycle — understand spawn/dissolve flow |
+| `lib/loomkin/tools/decision_log.ex` | How agents currently write to graph |
+| `lib/loomkin/agent_loop.ex` | The ReAct loop — understand where context is injected |
+
+### Existing files you must NOT modify
+
+| File | Why |
+|------|-----|
+| `lib/loomkin/teams/context_keeper.ex` | Keeper is the memory layer — untouchable |
+| `lib/loomkin/teams/context_offload.ex` | Offload logic is correct as-is |
+| `lib/loomkin/teams/context_retrieval.ex` | Retrieval API is correct as-is |
+| `lib/loomkin/schemas/context_keeper.ex` | Keeper schema is correct as-is |
+| `lib/loomkin/tools/context_offload.ex` | Tool interface is correct as-is |
+| `lib/loomkin/tools/context_retrieve.ex` | Tool interface is correct as-is |
+
+---
+
+## Success Criteria
+
+When this epic is complete:
+
+1. A new agent joining a team can read the decision graph and understand WHY 3 agents are working on auth — because lifecycle events auto-created a causal trail.
+
+2. When researcher-1 discovers "the API uses OAuth not JWT", agents working on related auth goals get notified automatically — they don't have to ask.
+
+3. When someone sets confidence to 30 on "database choice: SQLite", agents building queries downstream get a warning — they can pause and re-evaluate using the full conversation context from keepers.
+
+4. When a lead plans a new task, the graph tells them "this was tried before in session X, it was abandoned because Y" — and they can dig into the keeper for the full discussion.
+
+5. All of this happens WITHOUT modifying a single line of context keeper code. Keepers remain the full-fidelity memory. The graph becomes the index that routes agents to the right keeper at the right time.

--- a/lib/loomkin/decisions/auto_logger.ex
+++ b/lib/loomkin/decisions/auto_logger.ex
@@ -1,0 +1,195 @@
+defmodule Loomkin.Decisions.AutoLogger do
+  @moduledoc "Per-team GenServer that subscribes to team PubSub events and writes decision graph nodes."
+
+  use GenServer
+
+  require Logger
+
+  alias Loomkin.Decisions.Graph
+  alias Loomkin.Teams.Tasks
+
+  @pubsub Loomkin.PubSub
+
+  # --- Public API ---
+
+  def start_link(opts) do
+    team_id = Keyword.fetch!(opts, :team_id)
+    GenServer.start_link(__MODULE__, opts, name: via(team_id))
+  end
+
+  defp via(team_id) do
+    {:via, Registry, {Loomkin.Teams.AgentRegistry, {:auto_logger, team_id}}}
+  end
+
+  # --- Callbacks ---
+
+  @impl true
+  def init(opts) do
+    team_id = Keyword.fetch!(opts, :team_id)
+
+    Phoenix.PubSub.subscribe(@pubsub, "team:#{team_id}")
+    Phoenix.PubSub.subscribe(@pubsub, "team:#{team_id}:tasks")
+
+    state = %{
+      team_id: team_id,
+      seen_agents: MapSet.new(),
+      # Map of task_id => node_id for linking task action → outcome edges
+      task_nodes: %{}
+    }
+
+    Logger.info("[AutoLogger] Started for team #{team_id}")
+    {:ok, state}
+  end
+
+  # Agent joins (first time only)
+  @impl true
+  def handle_info({:agent_status, name, :working}, state) do
+    if MapSet.member?(state.seen_agents, name) do
+      {:noreply, state}
+    else
+      state = %{state | seen_agents: MapSet.put(state.seen_agents, name)}
+
+      log_node(state, %{
+        node_type: :action,
+        title: "Agent #{name} joined team",
+        agent_name: to_string(name)
+      })
+
+      {:noreply, state}
+    end
+  end
+
+  # Ignore subsequent agent_status events
+  def handle_info({:agent_status, _name, _status}, state) do
+    {:noreply, state}
+  end
+
+  # Task assigned
+  def handle_info({:task_assigned, task_id, agent_name}, state) do
+    title = task_title(task_id)
+
+    case log_node(state, %{
+           node_type: :action,
+           title: "Task assigned: #{title} → #{agent_name}",
+           agent_name: to_string(agent_name),
+           metadata: base_metadata(state, %{"task_id" => task_id})
+         }) do
+      {:ok, node} ->
+        state = put_in(state.task_nodes[task_id], node.id)
+        {:noreply, state}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  # Task completed
+  def handle_info({:task_completed, task_id, owner, _result}, state) do
+    title = task_title(task_id)
+
+    {:ok, node} =
+      log_node(state, %{
+        node_type: :outcome,
+        title: "Completed: #{title}",
+        agent_name: to_string(owner),
+        metadata: base_metadata(state, %{"task_id" => task_id})
+      })
+
+    # Edge from task action node → outcome
+    if parent_id = state.task_nodes[task_id] do
+      Graph.add_edge(parent_id, node.id, :leads_to)
+    end
+
+    {:noreply, state}
+  end
+
+  # Task failed
+  def handle_info({:task_failed, task_id, owner, reason}, state) do
+    title = task_title(task_id)
+
+    {:ok, node} =
+      log_node(state, %{
+        node_type: :outcome,
+        title: "Failed: #{title} — #{truncate(inspect(reason), 120)}",
+        agent_name: to_string(owner),
+        metadata: base_metadata(state, %{"task_id" => task_id})
+      })
+
+    if parent_id = state.task_nodes[task_id] do
+      Graph.add_edge(parent_id, node.id, :leads_to)
+    end
+
+    {:noreply, state}
+  end
+
+  # Keeper created (context offloaded)
+  def handle_info({:keeper_created, %{id: keeper_id, topic: topic} = info}, state) do
+    log_node(state, %{
+      node_type: :observation,
+      title: "Context offloaded: #{topic}",
+      agent_name: to_string(Map.get(info, :source, "unknown")),
+      metadata: base_metadata(state, %{"keeper_id" => keeper_id})
+    })
+
+    {:noreply, state}
+  end
+
+  # Skip context_offloaded (redundant with keeper_created)
+  def handle_info({:context_offloaded, _name, _payload}, state) do
+    {:noreply, state}
+  end
+
+  # Catch-all for other PubSub messages
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  # --- Private helpers ---
+
+  defp log_node(state, attrs) do
+    attrs =
+      attrs
+      |> Map.put_new(:metadata, base_metadata(state))
+      |> Map.update!(:metadata, &Map.merge(base_metadata(state), &1))
+
+    case Graph.add_node(attrs) do
+      {:ok, node} = result ->
+        # Try to edge from the active goal (scoped to this team)
+        link_to_active_goal(node, state.team_id)
+        result
+
+      {:error, reason} = error ->
+        Logger.warning("[AutoLogger] Failed to log node: #{inspect(reason)}")
+        error
+    end
+  end
+
+  defp link_to_active_goal(node, team_id) do
+    # Only link action and observation nodes to the active goal
+    # Outcome nodes get linked to their parent task action instead
+    if node.node_type in [:action, :observation] do
+      case Graph.list_nodes(node_type: :goal, status: :active, team_id: team_id) do
+        [] ->
+          :ok
+
+        goals ->
+          goal = List.last(goals)
+          Graph.add_edge(goal.id, node.id, :leads_to)
+      end
+    end
+  end
+
+  defp base_metadata(state, extra \\ %{}) do
+    Map.merge(%{"auto_logged" => true, "team_id" => state.team_id}, extra)
+  end
+
+  defp task_title(task_id) do
+    case Tasks.get_task(task_id) do
+      {:ok, task} -> task.title
+      _ -> task_id
+    end
+  end
+
+  defp truncate(str, max) when byte_size(str) <= max, do: str
+  defp truncate(str, max), do: String.slice(str, 0, max) <> "..."
+end

--- a/lib/loomkin/decisions/broadcaster.ex
+++ b/lib/loomkin/decisions/broadcaster.ex
@@ -1,0 +1,120 @@
+defmodule Loomkin.Decisions.Broadcaster do
+  @moduledoc "Per-team GenServer that watches for new observations/outcomes and notifies agents with relevant active goals."
+
+  use GenServer
+
+  require Logger
+
+  alias Loomkin.Decisions.Graph
+  alias Loomkin.Teams.Comms
+
+  @pubsub Loomkin.PubSub
+  @debounce_ms 5_000
+
+  # --- Public API ---
+
+  def start_link(opts) do
+    team_id = Keyword.fetch!(opts, :team_id)
+    GenServer.start_link(__MODULE__, opts, name: via(team_id))
+  end
+
+  defp via(team_id) do
+    {:via, Registry, {Loomkin.Teams.AgentRegistry, {:broadcaster, team_id}}}
+  end
+
+  # --- Callbacks ---
+
+  @impl true
+  def init(opts) do
+    team_id = Keyword.fetch!(opts, :team_id)
+
+    Phoenix.PubSub.subscribe(@pubsub, "decision_graph")
+
+    state = %{
+      team_id: team_id,
+      # %{{goal_id, agent_name} => timestamp} for debouncing
+      recent_notifications: %{}
+    }
+
+    Logger.info("[Broadcaster] Started for team #{team_id}")
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info({:node_added, node}, state) do
+    if relevant_node?(node, state.team_id) do
+      state = process_node(node, state)
+      {:noreply, state}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  # --- Private ---
+
+  defp relevant_node?(node, team_id) do
+    node.node_type in [:observation, :outcome] and
+      get_in(node.metadata, ["team_id"]) == team_id
+  end
+
+  defp process_node(node, state) do
+    ancestors = Graph.walk_upstream(node.id, [:enables, :requires, :leads_to], max_depth: 3)
+
+    active_goals =
+      Enum.filter(ancestors, fn {ancestor, _depth, _edge_type} ->
+        ancestor.node_type == :goal and ancestor.status == :active
+      end)
+
+    now = System.monotonic_time(:millisecond)
+    state = expire_stale_notifications(state, now)
+
+    Enum.reduce(active_goals, state, fn {goal, _depth, _edge_type}, acc ->
+      agent_name = goal.agent_name
+
+      if agent_name && not debounced?(acc, goal.id, agent_name, now) do
+        payload = %{
+          observation_id: node.id,
+          observation_title: node.title,
+          goal_id: goal.id,
+          goal_title: goal.title,
+          keeper_id: get_in(node.metadata, ["keeper_id"]),
+          source_agent: node.agent_name
+        }
+
+        Comms.send_to(acc.team_id, agent_name, {:discovery_relevant, payload})
+
+        Logger.debug(
+          "[Broadcaster] Notified #{agent_name} about #{node.node_type} #{node.id} → goal #{goal.id}"
+        )
+
+        mark_notified(acc, goal.id, agent_name, now)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp debounced?(state, goal_id, agent_name, now) do
+    case Map.get(state.recent_notifications, {goal_id, agent_name}) do
+      nil -> false
+      last_time -> now - last_time < @debounce_ms
+    end
+  end
+
+  defp mark_notified(state, goal_id, agent_name, now) do
+    %{state | recent_notifications: Map.put(state.recent_notifications, {goal_id, agent_name}, now)}
+  end
+
+  defp expire_stale_notifications(state, now) do
+    cleaned =
+      Map.reject(state.recent_notifications, fn {_key, timestamp} ->
+        now - timestamp > @debounce_ms * 2
+      end)
+
+    %{state | recent_notifications: cleaned}
+  end
+end

--- a/lib/loomkin/decisions/cascade.ex
+++ b/lib/loomkin/decisions/cascade.ex
@@ -1,0 +1,83 @@
+defmodule Loomkin.Decisions.Cascade do
+  @moduledoc "Propagates uncertainty warnings downstream when a node's confidence drops below threshold."
+
+  alias Loomkin.Decisions.Graph
+  alias Loomkin.Teams.Comms
+
+  require Logger
+
+  @default_threshold 50
+
+  @doc """
+  Check a node's confidence and propagate warnings downstream if below threshold.
+
+  Walks downstream via `:requires` and `:blocks` edges (up to `max_depth: 5`).
+  For each affected downstream node, sets `metadata.upstream_uncertainty = true`
+  and notifies the owning agent via PubSub.
+
+  Options:
+    * `:threshold` — confidence level below which cascade triggers (default: #{@default_threshold})
+
+  Returns `{:ok, affected_count}` or `{:ok, :above_threshold}`.
+  """
+  def check_and_propagate(node_id, opts \\ []) do
+    threshold = Keyword.get(opts, :threshold, @default_threshold)
+
+    case Graph.get_node(node_id) do
+      nil ->
+        {:error, :not_found}
+
+      node ->
+        if is_integer(node.confidence) and node.confidence < threshold do
+          downstream = Graph.walk_downstream(node_id, [:requires, :blocks], max_depth: 5)
+          affected = propagate(node, downstream)
+          {:ok, affected}
+        else
+          {:ok, :above_threshold}
+        end
+    end
+  end
+
+  defp propagate(_source_node, []), do: 0
+
+  defp propagate(source_node, downstream_nodes) do
+    Enum.reduce(downstream_nodes, 0, fn {downstream_node, _depth, edge_type}, count ->
+      # Idempotent: skip if already marked
+      if downstream_node.metadata["upstream_uncertainty"] == true do
+        count
+      else
+        metadata =
+          Map.merge(downstream_node.metadata || %{}, %{"upstream_uncertainty" => true})
+
+        case Graph.update_node(downstream_node, %{metadata: metadata}) do
+          {:ok, _updated} ->
+            notify_agent(source_node, downstream_node, edge_type)
+            count + 1
+
+          {:error, reason} ->
+            Logger.warning("[Cascade] Failed to update node #{downstream_node.id}: #{inspect(reason)}")
+            count
+        end
+      end
+    end)
+  end
+
+  defp notify_agent(source_node, downstream_node, edge_type) do
+    team_id = source_node.metadata["team_id"]
+    agent_name = downstream_node.agent_name
+
+    if team_id && agent_name do
+      warning = {:confidence_warning, %{
+        source_node_id: source_node.id,
+        source_title: source_node.title,
+        source_confidence: source_node.confidence,
+        affected_node_id: downstream_node.id,
+        affected_title: downstream_node.title,
+        keeper_id: source_node.metadata["keeper_id"],
+        edge_path: [edge_type]
+      }}
+
+      Comms.send_to(team_id, agent_name, warning)
+    end
+  end
+end

--- a/lib/loomkin/decisions/context_builder.ex
+++ b/lib/loomkin/decisions/context_builder.ex
@@ -7,28 +7,34 @@ defmodule Loomkin.Decisions.ContextBuilder do
 
   def build(session_id, opts \\ []) do
     max_tokens = Keyword.get(opts, :max_tokens, @default_max_tokens)
+    cross_session = Keyword.get(opts, :cross_session, false)
     max_chars = max_tokens * 4
 
     sections = [
-      build_goals_section(),
+      build_goals_section(session_id, cross_session),
       build_decisions_section(),
+      build_prior_attempts_section(),
       build_session_section(session_id)
     ]
 
-    result = Enum.join(sections, "\n\n")
+    result = sections |> Enum.reject(&(&1 == "")) |> Enum.join("\n\n")
     {:ok, truncate(result, max_chars)}
   end
 
-  defp build_goals_section do
-    goals = Graph.active_goals()
+  defp build_goals_section(session_id, cross_session) do
+    goals =
+      if cross_session do
+        Graph.list_nodes(node_type: :goal, status: :active)
+      else
+        Graph.list_nodes(node_type: :goal, status: :active, session_id: session_id)
+      end
 
     if goals == [] do
       "## Active Goals\nNone."
     else
       items =
         Enum.map_join(goals, "\n", fn g ->
-          conf = if g.confidence, do: " (confidence: #{g.confidence}%)", else: ""
-          "- #{g.title}#{conf}"
+          format_node_line(g)
         end)
 
       "## Active Goals\n#{items}"
@@ -43,10 +49,47 @@ defmodule Loomkin.Decisions.ContextBuilder do
     else
       items =
         Enum.map_join(decisions, "\n", fn d ->
-          "- [#{d.node_type}] #{d.title}"
+          "- [#{d.node_type}] #{d.title}#{format_keeper_ref(d)}"
         end)
 
       "## Recent Decisions\n#{items}"
+    end
+  end
+
+  defp build_prior_attempts_section do
+    revisits = Graph.list_nodes(node_type: :revisit, status: :active)
+    abandoned = Graph.list_nodes(status: :abandoned)
+    superseded = Graph.list_nodes(status: :superseded)
+
+    items =
+      Enum.map(revisits, fn n ->
+        confidence = if n.confidence, do: " (confidence: #{n.confidence})", else: ""
+        keeper = format_keeper_ref(n)
+        "- [REVISIT] #{n.title}#{confidence} — needs re-evaluation#{keeper}"
+      end) ++
+        Enum.map(abandoned, fn n ->
+          desc = if n.description, do: " — #{n.description}", else: ""
+          keeper = format_keeper_ref(n)
+          "- [ABANDONED] #{n.title}#{desc}#{keeper}"
+        end) ++
+        Enum.map(superseded, fn n ->
+          keeper = format_keeper_ref(n)
+          "- [SUPERSEDED] #{n.title} → replaced#{keeper}"
+        end)
+
+    if items == [], do: "", else: "## Prior Attempts & Lessons\n" <> Enum.join(items, "\n")
+  end
+
+  defp format_node_line(node) do
+    base = "- #{node.title}"
+    base = if node.confidence, do: "#{base} (confidence: #{node.confidence}%)", else: base
+    base <> format_keeper_ref(node)
+  end
+
+  defp format_keeper_ref(node) do
+    case node.metadata do
+      %{"keeper_id" => id} when is_binary(id) -> " → Deep context available in keeper #{id}"
+      _ -> ""
     end
   end
 

--- a/lib/loomkin/decisions/graph.ex
+++ b/lib/loomkin/decisions/graph.ex
@@ -3,6 +3,7 @@ defmodule Loomkin.Decisions.Graph do
 
   import Ecto.Query
   alias Loomkin.Repo
+  alias Loomkin.Decisions.Cascade
   alias Loomkin.Schemas.{DecisionNode, DecisionEdge}
 
   # --- Nodes ---
@@ -10,9 +11,16 @@ defmodule Loomkin.Decisions.Graph do
   def add_node(attrs) do
     attrs = Map.put_new(attrs, :change_id, Ecto.UUID.generate())
 
-    %DecisionNode{}
-    |> DecisionNode.changeset(attrs)
-    |> Repo.insert()
+    case %DecisionNode{}
+         |> DecisionNode.changeset(attrs)
+         |> Repo.insert() do
+      {:ok, node} ->
+        Phoenix.PubSub.broadcast(Loomkin.PubSub, "decision_graph", {:node_added, node})
+        {:ok, node}
+
+      error ->
+        error
+    end
   end
 
   def get_node(id), do: Repo.get(DecisionNode, id)
@@ -20,9 +28,14 @@ defmodule Loomkin.Decisions.Graph do
   def get_node!(id), do: Repo.get!(DecisionNode, id)
 
   def update_node(%DecisionNode{} = node, attrs) do
-    node
-    |> DecisionNode.changeset(attrs)
-    |> Repo.update()
+    case node |> DecisionNode.changeset(attrs) |> Repo.update() do
+      {:ok, updated_node} ->
+        if Map.has_key?(attrs, :confidence), do: Cascade.check_and_propagate(updated_node.id)
+        {:ok, updated_node}
+
+      error ->
+        error
+    end
   end
 
   def update_node(id, attrs) when is_binary(id) do
@@ -59,7 +72,23 @@ defmodule Loomkin.Decisions.Graph do
     query |> where([n], n.session_id == ^sid) |> apply_node_filters(rest)
   end
 
+  defp apply_node_filters(query, [{:team_id, team_id} | rest]) do
+    query
+    |> where([n], fragment("json_extract(?, '$.team_id') = ?", n.metadata, ^team_id))
+    |> apply_node_filters(rest)
+  end
+
+  defp apply_node_filters(query, [{:cross_session, true} | rest]) do
+    apply_node_filters(query, rest)
+  end
+
   defp apply_node_filters(query, [_ | rest]), do: apply_node_filters(query, rest)
+
+  @doc "Creates a node with keeper_id in metadata for two-tier retrieval."
+  def add_node_with_keeper(attrs, keeper_id) when is_binary(keeper_id) do
+    metadata = Map.get(attrs, :metadata, %{}) |> Map.put("keeper_id", keeper_id)
+    attrs |> Map.put(:metadata, metadata) |> add_node()
+  end
 
   # --- Edges ---
 
@@ -85,6 +114,10 @@ defmodule Loomkin.Decisions.Graph do
   end
 
   defp apply_edge_filters(query, []), do: query
+
+  defp apply_edge_filters(query, [{:edge_type, types} | rest]) when is_list(types) do
+    query |> where([e], e.edge_type in ^types) |> apply_edge_filters(rest)
+  end
 
   defp apply_edge_filters(query, [{:edge_type, type} | rest]) do
     query |> where([e], e.edge_type == ^type) |> apply_edge_filters(rest)
@@ -127,5 +160,79 @@ defmodule Loomkin.Decisions.Graph do
           Repo.rollback(reason)
       end
     end)
+  end
+
+  # --- Edge Walking ---
+
+  @doc "Walk downstream from a node through specific edge types. Returns [{node, depth, edge_type}]."
+  def walk_downstream(node_id, edge_types, opts \\ []) do
+    max_depth = Keyword.get(opts, :max_depth, 5)
+    edge_types = List.wrap(edge_types)
+    {results, _visited} = do_walk(node_id, edge_types, max_depth, 1, :downstream, MapSet.new(), [])
+    results
+  end
+
+  @doc "Walk upstream (reverse edges) to find ancestors. Returns [{node, depth, edge_type}]."
+  def walk_upstream(node_id, edge_types, opts \\ []) do
+    max_depth = Keyword.get(opts, :max_depth, 5)
+    edge_types = List.wrap(edge_types)
+    {results, _visited} = do_walk(node_id, edge_types, max_depth, 1, :upstream, MapSet.new(), [])
+    results
+  end
+
+  @doc "Find nodes connected in either direction, single hop."
+  def connected_nodes(node_id, edge_types) do
+    edge_types = List.wrap(edge_types)
+    downstream = walk_downstream(node_id, edge_types, max_depth: 1)
+    upstream = walk_upstream(node_id, edge_types, max_depth: 1)
+    Enum.uniq_by(downstream ++ upstream, fn {node, _depth, _type} -> node.id end)
+  end
+
+  defp do_walk(_node_id, _edge_types, max_depth, current_depth, _direction, visited, acc)
+       when current_depth > max_depth,
+       do: {acc, visited}
+
+  defp do_walk(node_id, edge_types, max_depth, current_depth, direction, visited, acc) do
+    if MapSet.member?(visited, node_id) do
+      {acc, visited}
+    else
+      visited = MapSet.put(visited, node_id)
+
+      edges =
+        case direction do
+          :downstream -> list_edges(from_node_id: node_id, edge_type: edge_types)
+          :upstream -> list_edges(to_node_id: node_id, edge_type: edge_types)
+        end
+
+      {nodes, next_ids} =
+        Enum.reduce(edges, {[], []}, fn edge, {nodes_acc, ids_acc} ->
+          next_id =
+            case direction do
+              :downstream -> edge.to_node_id
+              :upstream -> edge.from_node_id
+            end
+
+          if MapSet.member?(visited, next_id) do
+            {nodes_acc, ids_acc}
+          else
+            case get_node(next_id) do
+              nil ->
+                {nodes_acc, ids_acc}
+
+              node ->
+                {[{node, current_depth, edge.edge_type} | nodes_acc], [next_id | ids_acc]}
+            end
+          end
+        end)
+
+      # Thread visited set across sibling branches to prevent duplicates on diamond paths
+      {deeper, visited} =
+        Enum.reduce(next_ids, {[], visited}, fn id, {deep_acc, vis} ->
+          {results, vis} = do_walk(id, edge_types, max_depth, current_depth + 1, direction, vis, [])
+          {deep_acc ++ results, vis}
+        end)
+
+      {acc ++ Enum.reverse(nodes) ++ deeper, visited}
+    end
   end
 end

--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -646,6 +646,30 @@ defmodule Loomkin.Teams.Agent do
     {:noreply, state}
   end
 
+  # --- Nervous system handlers ---
+
+  @impl true
+  def handle_info({:discovery_relevant, payload}, state) do
+    %{observation_title: obs_title, goal_title: goal_title, source_agent: source, keeper_id: keeper_id} = payload
+
+    msg = "[Discovery from #{source}] #{obs_title} — relevant to your goal: #{goal_title}"
+    msg = if keeper_id, do: msg <> "\n  → Full context: context_retrieve on keeper #{keeper_id}", else: msg
+
+    messages = state.messages ++ [%{role: :user, content: msg}]
+    {:noreply, %{state | messages: messages}}
+  end
+
+  @impl true
+  def handle_info({:confidence_warning, payload}, state) do
+    %{source_title: title, source_confidence: conf, affected_title: affected, keeper_id: keeper_id} = payload
+
+    msg = "[Confidence Warning] Upstream decision '#{title}' has low confidence (#{conf}). Your work on '#{affected}' may be affected."
+    msg = if keeper_id, do: msg <> "\n  → Re-evaluate using keeper #{keeper_id}", else: msg
+
+    messages = state.messages ++ [%{role: :user, content: msg}]
+    {:noreply, %{state | messages: messages}}
+  end
+
   @impl true
   def handle_info(_msg, state) do
     {:noreply, state}

--- a/lib/loomkin/teams/manager.ex
+++ b/lib/loomkin/teams/manager.ex
@@ -1,6 +1,7 @@
 defmodule Loomkin.Teams.Manager do
   @moduledoc "Public API for team lifecycle management."
 
+  alias Loomkin.Decisions.{AutoLogger, Broadcaster}
   alias Loomkin.Teams.{Comms, Distributed, TableRegistry}
 
   require Logger
@@ -32,6 +33,9 @@ defmodule Loomkin.Teams.Manager do
       depth: 0,
       created_at: DateTime.utc_now()
     }})
+
+    # Start decision graph nervous system processes
+    start_nervous_system(team_id)
 
     Logger.info("[Teams] Created team #{name} (#{team_id})")
     {:ok, team_id}
@@ -76,6 +80,9 @@ defmodule Loomkin.Teams.Manager do
           parent_table = TableRegistry.get_table!(parent_team_id)
           existing = get_sub_team_ids(parent_team_id)
           :ets.insert(parent_table, {:sub_teams, [sub_team_id | existing]})
+
+          # Start decision graph nervous system processes
+          start_nervous_system(sub_team_id)
 
           Logger.info("[Teams] Created sub-team #{name} (#{sub_team_id}) under #{parent_team_id}")
           {:ok, sub_team_id}
@@ -201,6 +208,9 @@ defmodule Loomkin.Teams.Manager do
       if Process.alive?(keeper.pid), do: Distributed.terminate_child(keeper.pid)
     end)
 
+    # Stop decision graph nervous system processes
+    stop_nervous_system(team_id)
+
     # Reset rate limiter budget
     Loomkin.Teams.RateLimiter.reset_team(team_id)
 
@@ -275,6 +285,26 @@ defmodule Loomkin.Teams.Manager do
 
       _ ->
         :ok
+    end
+  end
+
+  defp start_nervous_system(team_id) do
+    if Application.get_env(:loomkin, :start_nervous_system, true) do
+      try do
+        Distributed.start_child({AutoLogger, team_id: team_id})
+        Distributed.start_child({Broadcaster, team_id: team_id})
+      catch
+        :exit, _ -> :ok
+      end
+    end
+  end
+
+  defp stop_nervous_system(team_id) do
+    for key <- [{:auto_logger, team_id}, {:broadcaster, team_id}] do
+      case Registry.lookup(Loomkin.Teams.AgentRegistry, key) do
+        [{pid, _}] -> Distributed.terminate_child(pid)
+        [] -> :ok
+      end
     end
   end
 

--- a/lib/loomkin/tools/decision_log.ex
+++ b/lib/loomkin/tools/decision_log.ex
@@ -35,12 +35,18 @@ defmodule Loomkin.Tools.DecisionLog do
     node_type = String.to_existing_atom(raw_type)
     title = param!(params, :title)
 
+    metadata =
+      %{}
+      |> then(fn m -> if team_id = param(context, :team_id), do: Map.put(m, "team_id", team_id), else: m end)
+
     attrs = %{
       node_type: node_type,
       title: title,
       description: param(params, :description),
       confidence: param(params, :confidence),
-      session_id: param(context, :session_id)
+      session_id: param(context, :session_id),
+      agent_name: param(context, :agent_name),
+      metadata: metadata
     }
 
     case Graph.add_node(attrs) do

--- a/test/loomkin/decisions/auto_logger_test.exs
+++ b/test/loomkin/decisions/auto_logger_test.exs
@@ -1,0 +1,174 @@
+defmodule Loomkin.Decisions.AutoLoggerTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.{AutoLogger, Graph}
+  alias Loomkin.Teams.Comms
+
+  setup do
+    team_id = Ecto.UUID.generate()
+
+    # Create ETS table for team (AutoLogger uses Registry, not ETS directly, but
+    # task lookups may need it)
+    {:ok, _ref} = Loomkin.Teams.TableRegistry.create_table(team_id)
+
+    {:ok, _pid} = start_supervised({AutoLogger, team_id: team_id})
+
+    on_exit(fn ->
+      Loomkin.Teams.TableRegistry.delete_table(team_id)
+    end)
+
+    %{team_id: team_id}
+  end
+
+  describe "agent_status events" do
+    test "logs action node on first :working status", %{team_id: team_id} do
+      Comms.broadcast(team_id, {:agent_status, "alice", :working})
+      Process.sleep(50)
+
+      nodes = Graph.list_nodes(node_type: :action)
+      assert length(nodes) == 1
+      assert hd(nodes).title == "Agent alice joined team"
+      assert hd(nodes).metadata["auto_logged"] == true
+      assert hd(nodes).metadata["team_id"] == team_id
+    end
+
+    test "only logs once per agent (deduplicates)", %{team_id: team_id} do
+      Comms.broadcast(team_id, {:agent_status, "bob", :working})
+      Process.sleep(50)
+      Comms.broadcast(team_id, {:agent_status, "bob", :working})
+      Process.sleep(50)
+
+      nodes = Graph.list_nodes(node_type: :action)
+      assert length(nodes) == 1
+    end
+
+    test "logs separate nodes for different agents", %{team_id: team_id} do
+      Comms.broadcast(team_id, {:agent_status, "alice", :working})
+      Comms.broadcast(team_id, {:agent_status, "bob", :working})
+      Process.sleep(50)
+
+      nodes = Graph.list_nodes(node_type: :action)
+      assert length(nodes) == 2
+      titles = Enum.map(nodes, & &1.title)
+      assert "Agent alice joined team" in titles
+      assert "Agent bob joined team" in titles
+    end
+
+    test "ignores non-working statuses", %{team_id: team_id} do
+      Comms.broadcast(team_id, {:agent_status, "carol", :idle})
+      Process.sleep(50)
+
+      assert Graph.list_nodes(node_type: :action) == []
+    end
+  end
+
+  describe "task events" do
+    test "task_assigned creates action node", %{team_id: team_id} do
+      # Create a task in the DB so the title can be looked up
+      {:ok, task} = create_task(team_id, "Implement feature X")
+
+      Comms.broadcast_task_event(team_id, {:task_assigned, task.id, "alice"})
+      Process.sleep(50)
+
+      nodes = Graph.list_nodes(node_type: :action)
+      assert length(nodes) == 1
+      node = hd(nodes)
+      assert node.title =~ "Task assigned: Implement feature X"
+      assert node.title =~ "alice"
+      assert node.metadata["auto_logged"] == true
+    end
+
+    test "task_completed creates outcome node with edge from task action", %{team_id: team_id} do
+      {:ok, task} = create_task(team_id, "Fix bug Y")
+
+      # First assign (creates action node)
+      Comms.broadcast_task_event(team_id, {:task_assigned, task.id, "bob"})
+      Process.sleep(50)
+
+      # Then complete (creates outcome node + edge)
+      Comms.broadcast_task_event(team_id, {:task_completed, task.id, "bob", "done"})
+      Process.sleep(50)
+
+      outcomes = Graph.list_nodes(node_type: :outcome)
+      assert length(outcomes) == 1
+      outcome = hd(outcomes)
+      assert outcome.title == "Completed: Fix bug Y"
+
+      # Verify edge from action → outcome
+      edges = Graph.list_edges(edge_type: :leads_to, to_node_id: outcome.id)
+      assert length(edges) >= 1
+
+      action = hd(Graph.list_nodes(node_type: :action))
+      assert Enum.any?(edges, &(&1.from_node_id == action.id))
+    end
+
+    test "task_failed creates outcome node", %{team_id: team_id} do
+      {:ok, task} = create_task(team_id, "Deploy service")
+
+      Comms.broadcast_task_event(team_id, {:task_assigned, task.id, "carol"})
+      Process.sleep(50)
+
+      Comms.broadcast_task_event(team_id, {:task_failed, task.id, "carol", "timeout"})
+      Process.sleep(50)
+
+      outcomes = Graph.list_nodes(node_type: :outcome)
+      assert length(outcomes) == 1
+      outcome = hd(outcomes)
+      assert outcome.title =~ "Failed: Deploy service"
+      assert outcome.title =~ "timeout"
+    end
+  end
+
+  describe "keeper_created events" do
+    test "creates observation node with keeper_id in metadata", %{team_id: team_id} do
+      keeper_id = Ecto.UUID.generate()
+
+      Comms.broadcast(team_id, {:keeper_created, %{
+        id: keeper_id,
+        topic: "auth-research",
+        source: "alice",
+        tokens: 500
+      }})
+
+      Process.sleep(50)
+
+      nodes = Graph.list_nodes(node_type: :observation)
+      assert length(nodes) == 1
+      node = hd(nodes)
+      assert node.title == "Context offloaded: auth-research"
+      assert node.metadata["keeper_id"] == keeper_id
+      assert node.metadata["auto_logged"] == true
+    end
+  end
+
+  describe "context_offloaded events" do
+    test "are skipped (redundant with keeper_created)", %{team_id: team_id} do
+      Comms.broadcast(team_id, {:context_offloaded, "alice", %{some: "data"}})
+      Process.sleep(50)
+
+      assert Graph.list_nodes() == []
+    end
+  end
+
+  describe "active goal linking" do
+    test "edges action nodes to active goal when one exists", %{team_id: team_id} do
+      # Create an active goal node with team_id so AutoLogger's scoped query finds it
+      {:ok, goal} = Graph.add_node(%{node_type: :goal, title: "Ship v1", status: :active, metadata: %{"team_id" => team_id}})
+
+      Comms.broadcast(team_id, {:agent_status, "alice", :working})
+      Process.sleep(50)
+
+      action = hd(Graph.list_nodes(node_type: :action))
+      edges = Graph.list_edges(from_node_id: goal.id, edge_type: :leads_to)
+      assert Enum.any?(edges, &(&1.to_node_id == action.id))
+    end
+  end
+
+  # --- Helpers ---
+
+  defp create_task(team_id, title) do
+    %Loomkin.Schemas.TeamTask{}
+    |> Loomkin.Schemas.TeamTask.changeset(%{team_id: team_id, title: title, status: :pending})
+    |> Repo.insert()
+  end
+end

--- a/test/loomkin/decisions/broadcaster_test.exs
+++ b/test/loomkin/decisions/broadcaster_test.exs
@@ -1,0 +1,280 @@
+defmodule Loomkin.Decisions.BroadcasterTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.{Broadcaster, Graph}
+
+  @pubsub Loomkin.PubSub
+  @team_id "test-team-broadcaster"
+
+  defp node_attrs(overrides) do
+    Map.merge(
+      %{node_type: :goal, title: "Test goal", metadata: %{"team_id" => @team_id}},
+      overrides
+    )
+  end
+
+  defp start_broadcaster(_context) do
+    start_supervised!({Broadcaster, team_id: @team_id})
+    :ok
+  end
+
+  describe "add_node broadcasts {:node_added, node}" do
+    test "Graph.add_node broadcasts to decision_graph topic" do
+      Phoenix.PubSub.subscribe(@pubsub, "decision_graph")
+
+      {:ok, node} = Graph.add_node(node_attrs(%{title: "Broadcast test"}))
+
+      assert_receive {:node_added, ^node}, 500
+    end
+  end
+
+  describe "Broadcaster processes observation/outcome nodes" do
+    setup [:start_broadcaster]
+
+    test "notifies agent when observation links to active goal" do
+      # Create graph: goal -enables-> action
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Build API",
+            status: :active,
+            agent_name: "coder-1"
+          })
+        )
+
+      {:ok, action} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Implement endpoint"}))
+
+      {:ok, _} = Graph.add_edge(goal.id, action.id, :enables)
+
+      # Subscribe to the agent's topic to capture notifications
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{@team_id}:agent:coder-1")
+
+      # Create observation and link it: action -enables-> obs
+      {:ok, obs} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :observation,
+            title: "New discovery",
+            agent_name: "researcher-1"
+          })
+        )
+
+      {:ok, _} = Graph.add_edge(action.id, obs.id, :enables)
+
+      # Re-broadcast now that edge exists (original broadcast from add_node fires before edge)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs})
+
+      assert_receive {:discovery_relevant, payload}, 1000
+      assert payload.observation_id == obs.id
+      assert payload.observation_title == "New discovery"
+      assert payload.goal_id == goal.id
+      assert payload.goal_title == "Build API"
+      assert payload.source_agent == "researcher-1"
+    end
+
+    test "notifies on outcome nodes too" do
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Deploy service",
+            status: :active,
+            agent_name: "coder-1"
+          })
+        )
+
+      {:ok, action} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Run deploy"}))
+
+      {:ok, _} = Graph.add_edge(goal.id, action.id, :leads_to)
+
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{@team_id}:agent:coder-1")
+
+      {:ok, outcome} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :outcome,
+            title: "Deploy succeeded",
+            agent_name: "deployer-1"
+          })
+        )
+
+      {:ok, _} = Graph.add_edge(action.id, outcome.id, :leads_to)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, outcome})
+
+      assert_receive {:discovery_relevant, payload}, 1000
+      assert payload.observation_id == outcome.id
+    end
+
+    test "ignores non-observation/outcome node types" do
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Some goal",
+            status: :active,
+            agent_name: "coder-1"
+          })
+        )
+
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{@team_id}:agent:coder-1")
+
+      {:ok, action} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Some action"}))
+
+      {:ok, _} = Graph.add_edge(goal.id, action.id, :enables)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, action})
+
+      refute_receive {:discovery_relevant, _}, 200
+    end
+
+    test "ignores nodes from other teams" do
+      other_team = "other-team-123"
+
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Goal",
+            status: :active,
+            agent_name: "coder-1"
+          })
+        )
+
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{@team_id}:agent:coder-1")
+
+      {:ok, obs} =
+        Graph.add_node(%{
+          node_type: :observation,
+          title: "Other team obs",
+          metadata: %{"team_id" => other_team}
+        })
+
+      {:ok, _} = Graph.add_edge(goal.id, obs.id, :enables)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs})
+
+      refute_receive {:discovery_relevant, _}, 200
+    end
+
+    test "includes keeper_id in payload when available" do
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Goal",
+            status: :active,
+            agent_name: "coder-1"
+          })
+        )
+
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{@team_id}:agent:coder-1")
+
+      keeper_id = Ecto.UUID.generate()
+
+      {:ok, obs} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :observation,
+            title: "Keeper obs",
+            agent_name: "researcher-1",
+            metadata: %{"team_id" => @team_id, "keeper_id" => keeper_id}
+          })
+        )
+
+      {:ok, _} = Graph.add_edge(goal.id, obs.id, :enables)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs})
+
+      assert_receive {:discovery_relevant, payload}, 1000
+      assert payload.keeper_id == keeper_id
+    end
+
+    test "skips goals without agent_name" do
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Unowned goal",
+            status: :active,
+            agent_name: nil
+          })
+        )
+
+      {:ok, obs} =
+        Graph.add_node(
+          node_attrs(%{node_type: :observation, title: "Discovery"})
+        )
+
+      {:ok, _} = Graph.add_edge(goal.id, obs.id, :enables)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs})
+
+      # Should not crash; give it time to process
+      Process.sleep(100)
+    end
+
+    test "skips superseded goals" do
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Old goal",
+            status: :superseded,
+            agent_name: "coder-1"
+          })
+        )
+
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{@team_id}:agent:coder-1")
+
+      {:ok, obs} =
+        Graph.add_node(
+          node_attrs(%{node_type: :observation, title: "Finding"})
+        )
+
+      {:ok, _} = Graph.add_edge(goal.id, obs.id, :enables)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs})
+
+      refute_receive {:discovery_relevant, _}, 200
+    end
+  end
+
+  describe "debouncing" do
+    setup [:start_broadcaster]
+
+    test "debounces repeated notifications for same goal+agent" do
+      {:ok, goal} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :goal,
+            title: "Debounce goal",
+            status: :active,
+            agent_name: "coder-1"
+          })
+        )
+
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{@team_id}:agent:coder-1")
+
+      # First observation
+      {:ok, obs1} =
+        Graph.add_node(
+          node_attrs(%{node_type: :observation, title: "First finding"})
+        )
+
+      {:ok, _} = Graph.add_edge(goal.id, obs1.id, :enables)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs1})
+
+      assert_receive {:discovery_relevant, _}, 1000
+
+      # Second observation immediately after (should be debounced)
+      {:ok, obs2} =
+        Graph.add_node(
+          node_attrs(%{node_type: :observation, title: "Second finding"})
+        )
+
+      {:ok, _} = Graph.add_edge(goal.id, obs2.id, :enables)
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs2})
+
+      refute_receive {:discovery_relevant, _}, 200
+    end
+  end
+end

--- a/test/loomkin/decisions/cascade_test.exs
+++ b/test/loomkin/decisions/cascade_test.exs
@@ -1,0 +1,236 @@
+defmodule Loomkin.Decisions.CascadeTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.{Cascade, Graph}
+  alias Loomkin.Teams.Comms
+
+  @team_id "cascade-test-team"
+
+  setup do
+    {:ok, _ref} = Loomkin.Teams.TableRegistry.create_table(@team_id)
+
+    on_exit(fn ->
+      Loomkin.Teams.TableRegistry.delete_table(@team_id)
+    end)
+
+    :ok
+  end
+
+  describe "check_and_propagate/2" do
+    test "propagates when confidence drops below threshold" do
+      {source, downstream} = create_chain()
+
+      # Drop source confidence below threshold
+      {:ok, _} = Graph.update_node(source, %{confidence: 30})
+
+      # Verify downstream node got marked
+      updated = Graph.get_node(downstream.id)
+      assert updated.metadata["upstream_uncertainty"] == true
+    end
+
+    test "does not propagate when confidence is above threshold" do
+      {source, downstream} = create_chain()
+
+      {:ok, result} = Cascade.check_and_propagate(source.id, threshold: 20)
+      assert result == :above_threshold
+
+      updated = Graph.get_node(downstream.id)
+      refute updated.metadata["upstream_uncertainty"]
+    end
+
+    test "does not propagate when confidence is nil" do
+      {source, _downstream} = create_chain()
+
+      {:ok, result} = Cascade.check_and_propagate(source.id)
+      assert result == :above_threshold
+    end
+
+    test "respects custom threshold" do
+      {source, downstream} = create_chain()
+
+      # Set confidence to 60 — below 70 threshold but above default 50
+      Graph.update_node(source, %{confidence: 60})
+
+      # With default threshold (50), should not propagate
+      updated = Graph.get_node(downstream.id)
+      refute updated.metadata["upstream_uncertainty"]
+
+      # Now with threshold=70, should propagate
+      {:ok, count} = Cascade.check_and_propagate(source.id, threshold: 70)
+      assert count == 1
+
+      updated = Graph.get_node(downstream.id)
+      assert updated.metadata["upstream_uncertainty"] == true
+    end
+
+    test "walks through multi-level chains" do
+      # A --requires--> B --blocks--> C
+      {:ok, a} = Graph.add_node(%{
+        node_type: :decision, title: "Root decision", confidence: 25,
+        metadata: %{"team_id" => @team_id}, agent_name: "lead"
+      })
+      {:ok, b} = Graph.add_node(%{
+        node_type: :action, title: "Middle action",
+        metadata: %{}, agent_name: "worker1"
+      })
+      {:ok, c} = Graph.add_node(%{
+        node_type: :action, title: "Leaf action",
+        metadata: %{}, agent_name: "worker2"
+      })
+
+      {:ok, _} = Graph.add_edge(a.id, b.id, :requires)
+      {:ok, _} = Graph.add_edge(b.id, c.id, :blocks)
+
+      {:ok, count} = Cascade.check_and_propagate(a.id)
+      assert count == 2
+
+      assert Graph.get_node(b.id).metadata["upstream_uncertainty"] == true
+      assert Graph.get_node(c.id).metadata["upstream_uncertainty"] == true
+    end
+
+    test "does not follow non-requires/blocks edges" do
+      {:ok, source} = Graph.add_node(%{
+        node_type: :decision, title: "Source", confidence: 20,
+        metadata: %{"team_id" => @team_id}
+      })
+      {:ok, downstream} = Graph.add_node(%{
+        node_type: :action, title: "Connected via leads_to",
+        metadata: %{}
+      })
+
+      # Use :leads_to — should NOT be followed by cascade
+      {:ok, _} = Graph.add_edge(source.id, downstream.id, :leads_to)
+
+      {:ok, count} = Cascade.check_and_propagate(source.id)
+      assert count == 0
+
+      refute Graph.get_node(downstream.id).metadata["upstream_uncertainty"]
+    end
+
+    test "is idempotent — re-running does not duplicate updates" do
+      {source, downstream} = create_chain()
+
+      # First run
+      Graph.update_node(source, %{confidence: 30})
+      updated1 = Graph.get_node(downstream.id)
+      assert updated1.metadata["upstream_uncertainty"] == true
+
+      # Second run — should skip since already marked
+      {:ok, count} = Cascade.check_and_propagate(source.id)
+      assert count == 0
+    end
+
+    test "returns error for non-existent node" do
+      assert {:error, :not_found} = Cascade.check_and_propagate(Ecto.UUID.generate())
+    end
+  end
+
+  describe "agent notification" do
+    test "notifies owning agent via PubSub" do
+      # Subscribe to receive the notification
+      Comms.subscribe(@team_id, "worker")
+
+      {:ok, source} = Graph.add_node(%{
+        node_type: :decision, title: "Risky call", confidence: 25,
+        metadata: %{"team_id" => @team_id, "keeper_id" => "k-123"},
+        agent_name: "lead"
+      })
+      {:ok, downstream} = Graph.add_node(%{
+        node_type: :action, title: "Downstream task",
+        metadata: %{}, agent_name: "worker"
+      })
+
+      {:ok, _} = Graph.add_edge(source.id, downstream.id, :requires)
+
+      {:ok, 1} = Cascade.check_and_propagate(source.id)
+
+      assert_receive {:confidence_warning, warning}
+      assert warning.source_node_id == source.id
+      assert warning.source_title == "Risky call"
+      assert warning.source_confidence == 25
+      assert warning.affected_node_id == downstream.id
+      assert warning.affected_title == "Downstream task"
+      assert warning.keeper_id == "k-123"
+      assert warning.edge_path == [:requires]
+    end
+
+    test "includes keeper_id from source node metadata" do
+      Comms.subscribe(@team_id, "alice")
+
+      {:ok, source} = Graph.add_node(%{
+        node_type: :observation, title: "Uncertain data", confidence: 10,
+        metadata: %{"team_id" => @team_id, "keeper_id" => "keeper-abc"}
+      })
+      {:ok, downstream} = Graph.add_node(%{
+        node_type: :action, title: "Uses uncertain data",
+        metadata: %{}, agent_name: "alice"
+      })
+
+      {:ok, _} = Graph.add_edge(source.id, downstream.id, :requires)
+      {:ok, _} = Cascade.check_and_propagate(source.id)
+
+      assert_receive {:confidence_warning, warning}
+      assert warning.keeper_id == "keeper-abc"
+    end
+  end
+
+  describe "Graph.update_node cascade hook" do
+    test "automatically triggers cascade when confidence is updated" do
+      Comms.subscribe(@team_id, "bob")
+
+      {:ok, source} = Graph.add_node(%{
+        node_type: :decision, title: "Auto-cascade test",
+        metadata: %{"team_id" => @team_id}, confidence: 80
+      })
+      {:ok, downstream} = Graph.add_node(%{
+        node_type: :action, title: "Depends on decision",
+        metadata: %{}, agent_name: "bob"
+      })
+
+      {:ok, _} = Graph.add_edge(source.id, downstream.id, :requires)
+
+      # Update confidence below threshold — should auto-cascade
+      {:ok, _} = Graph.update_node(source, %{confidence: 30})
+
+      Process.sleep(20)
+      updated = Graph.get_node(downstream.id)
+      assert updated.metadata["upstream_uncertainty"] == true
+      assert_receive {:confidence_warning, _}
+    end
+
+    test "does not trigger cascade when updating non-confidence fields" do
+      {:ok, source} = Graph.add_node(%{
+        node_type: :decision, title: "No cascade", confidence: 30,
+        metadata: %{"team_id" => @team_id}
+      })
+      {:ok, downstream} = Graph.add_node(%{
+        node_type: :action, title: "Should not be affected",
+        metadata: %{}
+      })
+
+      {:ok, _} = Graph.add_edge(source.id, downstream.id, :requires)
+
+      # Update title only — should NOT trigger cascade
+      {:ok, _} = Graph.update_node(source, %{title: "Renamed"})
+
+      refute Graph.get_node(downstream.id).metadata["upstream_uncertainty"]
+    end
+  end
+
+  # --- Helpers ---
+
+  defp create_chain do
+    {:ok, source} = Graph.add_node(%{
+      node_type: :decision, title: "Source decision", confidence: 80,
+      metadata: %{"team_id" => @team_id}, agent_name: "lead"
+    })
+    {:ok, downstream} = Graph.add_node(%{
+      node_type: :action, title: "Downstream action",
+      metadata: %{}, agent_name: "worker"
+    })
+
+    {:ok, _} = Graph.add_edge(source.id, downstream.id, :requires)
+
+    {source, downstream}
+  end
+end

--- a/test/loomkin/decisions/context_builder_test.exs
+++ b/test/loomkin/decisions/context_builder_test.exs
@@ -4,7 +4,7 @@ defmodule Loomkin.Decisions.ContextBuilderTest do
   alias Loomkin.Decisions.{Graph, ContextBuilder}
   alias Loomkin.Schemas.Session
 
-  defp node_attrs(overrides \\ %{}) do
+  defp node_attrs(overrides) do
     Map.merge(%{node_type: :goal, title: "Test goal"}, overrides)
   end
 
@@ -25,9 +25,9 @@ defmodule Loomkin.Decisions.ContextBuilderTest do
       assert result =~ "Session Context"
     end
 
-    test "includes active goals" do
+    test "includes active goals for the session" do
       session = create_session()
-      {:ok, _} = Graph.add_node(node_attrs(%{title: "Ship feature X"}))
+      {:ok, _} = Graph.add_node(node_attrs(%{title: "Ship feature X", session_id: session.id}))
 
       assert {:ok, result} = ContextBuilder.build(session.id)
       assert result =~ "Ship feature X"
@@ -39,7 +39,8 @@ defmodule Loomkin.Decisions.ContextBuilderTest do
       for i <- 1..50 do
         Graph.add_node(node_attrs(%{
           title: "Goal #{i} with a very long title to use up space",
-          description: String.duplicate("x", 200)
+          description: String.duplicate("x", 200),
+          session_id: session.id
         }))
       end
 
@@ -53,6 +54,204 @@ defmodule Loomkin.Decisions.ContextBuilderTest do
       session = create_session()
       assert {:ok, result} = ContextBuilder.build(session.id, max_tokens: 4096)
       refute result =~ "[truncated...]"
+    end
+
+    test "truncation still works with prior attempts section included" do
+      session = create_session()
+
+      for i <- 1..20 do
+        Graph.add_node(node_attrs(%{
+          node_type: :revisit,
+          title: "Revisit item #{i} with long title padding",
+          status: :active
+        }))
+      end
+
+      for i <- 1..20 do
+        Graph.add_node(node_attrs(%{
+          node_type: :decision,
+          title: "Abandoned decision #{i} with long title padding",
+          status: :abandoned
+        }))
+      end
+
+      assert {:ok, result} = ContextBuilder.build(session.id, max_tokens: 64)
+      max_chars = 64 * 4
+      assert byte_size(result) <= max_chars
+      assert result =~ "[truncated...]"
+    end
+  end
+
+  describe "prior attempts section" do
+    test "includes revisit nodes" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          node_type: :revisit,
+          title: "Retry caching strategy",
+          confidence: 40,
+          status: :active
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "## Prior Attempts & Lessons"
+      assert result =~ "[REVISIT] Retry caching strategy (confidence: 40) — needs re-evaluation"
+    end
+
+    test "includes abandoned nodes" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          node_type: :decision,
+          title: "Use Redis",
+          description: "Too complex for current scale",
+          status: :abandoned
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "[ABANDONED] Use Redis — Too complex for current scale"
+    end
+
+    test "includes superseded nodes" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          node_type: :decision,
+          title: "Old API design",
+          status: :superseded
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "[SUPERSEDED] Old API design → replaced"
+    end
+
+    test "omits section header when no prior attempts exist" do
+      session = create_session()
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      refute result =~ "Prior Attempts & Lessons"
+    end
+  end
+
+  describe "cross-session goals" do
+    test "cross_session: false only shows goals for the current session" do
+      session = create_session()
+      other_session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          title: "Session-bound goal",
+          session_id: session.id
+        }))
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          title: "Other session goal",
+          session_id: other_session.id
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "Session-bound goal"
+      refute result =~ "Other session goal"
+    end
+
+    test "cross_session: true includes goals from all sessions" do
+      session = create_session()
+      other_session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          title: "Goal A",
+          session_id: session.id
+        }))
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          title: "Goal B",
+          session_id: other_session.id
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id, cross_session: true)
+      assert result =~ "Goal A"
+      assert result =~ "Goal B"
+    end
+  end
+
+  describe "keeper references" do
+    test "includes keeper_id in goal output" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          title: "Goal with keeper",
+          session_id: session.id,
+          metadata: %{"keeper_id" => "keeper-abc-123"}
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "Goal with keeper"
+      assert result =~ "Deep context available in keeper keeper-abc-123"
+    end
+
+    test "includes keeper_id in decision output" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          node_type: :decision,
+          title: "Decision with keeper",
+          metadata: %{"keeper_id" => "keeper-def-456"}
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "Deep context available in keeper keeper-def-456"
+    end
+
+    test "includes keeper_id in prior attempts output" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          node_type: :decision,
+          title: "Abandoned with keeper",
+          status: :abandoned,
+          metadata: %{"keeper_id" => "keeper-ghi-789"}
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "[ABANDONED] Abandoned with keeper"
+      assert result =~ "Deep context available in keeper keeper-ghi-789"
+    end
+
+    test "omits keeper reference when metadata has no keeper_id" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          title: "Goal without keeper",
+          session_id: session.id,
+          metadata: %{"some_other" => "value"}
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "Goal without keeper"
+      refute result =~ "Deep context available in keeper"
+    end
+
+    test "omits keeper reference when metadata is empty" do
+      session = create_session()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{
+          title: "Goal empty metadata",
+          session_id: session.id
+        }))
+
+      assert {:ok, result} = ContextBuilder.build(session.id)
+      assert result =~ "Goal empty metadata"
+      refute result =~ "Deep context available in keeper"
     end
   end
 end

--- a/test/loomkin/decisions/graph_test.exs
+++ b/test/loomkin/decisions/graph_test.exs
@@ -174,6 +174,231 @@ defmodule Loomkin.Decisions.GraphTest do
     end
   end
 
+  describe "list_nodes/1 team_id filter" do
+    test "filters nodes by team_id in metadata" do
+      team_id = Ecto.UUID.generate()
+      other_team_id = Ecto.UUID.generate()
+
+      {:ok, _n1} =
+        Graph.add_node(node_attrs(%{title: "Team node", metadata: %{"team_id" => team_id}}))
+
+      {:ok, _n2} =
+        Graph.add_node(
+          node_attrs(%{title: "Other team", metadata: %{"team_id" => other_team_id}})
+        )
+
+      {:ok, _n3} = Graph.add_node(node_attrs(%{title: "No team"}))
+
+      results = Graph.list_nodes(team_id: team_id)
+      assert length(results) == 1
+      assert hd(results).title == "Team node"
+    end
+
+    test "returns empty list when no nodes match team_id" do
+      {:ok, _} = Graph.add_node(node_attrs(%{metadata: %{"team_id" => "other"}}))
+      assert Graph.list_nodes(team_id: "nonexistent") == []
+    end
+  end
+
+  describe "list_nodes/1 cross_session filter" do
+    test "cross_session: true does not restrict results" do
+      {:ok, _n1} = Graph.add_node(node_attrs(%{title: "Node A"}))
+      {:ok, _n2} = Graph.add_node(node_attrs(%{title: "Node B"}))
+
+      # cross_session: true is a no-op filter — all nodes still returned
+      results = Graph.list_nodes(cross_session: true, node_type: :goal)
+      assert length(results) == 2
+    end
+
+    test "cross_session: true can combine with other filters" do
+      {:ok, _} = Graph.add_node(node_attrs(%{title: "Goal", node_type: :goal}))
+      {:ok, _} = Graph.add_node(node_attrs(%{title: "Action", node_type: :action}))
+
+      results = Graph.list_nodes(cross_session: true, node_type: :goal)
+      assert length(results) == 1
+      assert hd(results).title == "Goal"
+    end
+  end
+
+  describe "add_node_with_keeper/2" do
+    test "stores keeper_id in metadata" do
+      keeper_id = Ecto.UUID.generate()
+      {:ok, node} = Graph.add_node_with_keeper(node_attrs(%{title: "Kept node"}), keeper_id)
+      assert node.metadata["keeper_id"] == keeper_id
+    end
+
+    test "preserves existing metadata" do
+      keeper_id = Ecto.UUID.generate()
+
+      {:ok, node} =
+        Graph.add_node_with_keeper(
+          node_attrs(%{title: "Kept", metadata: %{"extra" => "data"}}),
+          keeper_id
+        )
+
+      assert node.metadata["keeper_id"] == keeper_id
+      assert node.metadata["extra"] == "data"
+    end
+  end
+
+  describe "walk_downstream/3" do
+    test "walks a chain of nodes downstream" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "Root"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "Child"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "Grandchild"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n2.id, n3.id, :leads_to)
+
+      results = Graph.walk_downstream(n1.id, [:leads_to])
+      assert length(results) == 2
+
+      ids = Enum.map(results, fn {node, _depth, _type} -> node.id end)
+      assert n2.id in ids
+      assert n3.id in ids
+    end
+
+    test "respects max_depth" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "A"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "B"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "C"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n2.id, n3.id, :leads_to)
+
+      results = Graph.walk_downstream(n1.id, [:leads_to], max_depth: 1)
+      assert length(results) == 1
+      assert elem(hd(results), 0).id == n2.id
+    end
+
+    test "returns depth and edge_type in tuples" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "Start"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "Next"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :enables)
+
+      [{node, depth, edge_type}] = Graph.walk_downstream(n1.id, [:enables])
+      assert node.id == n2.id
+      assert depth == 1
+      assert edge_type == :enables
+    end
+
+    test "filters by edge type" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "Root"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "Chosen"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "Blocked"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :chosen)
+      {:ok, _} = Graph.add_edge(n1.id, n3.id, :blocks)
+
+      results = Graph.walk_downstream(n1.id, [:chosen])
+      assert length(results) == 1
+      assert elem(hd(results), 0).id == n2.id
+    end
+  end
+
+  describe "walk_upstream/3" do
+    test "walks a chain of nodes upstream" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "Root"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "Child"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "Grandchild"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n2.id, n3.id, :leads_to)
+
+      results = Graph.walk_upstream(n3.id, [:leads_to])
+      assert length(results) == 2
+
+      ids = Enum.map(results, fn {node, _depth, _type} -> node.id end)
+      assert n2.id in ids
+      assert n1.id in ids
+    end
+
+    test "respects max_depth upstream" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "A"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "B"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "C"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n2.id, n3.id, :leads_to)
+
+      results = Graph.walk_upstream(n3.id, [:leads_to], max_depth: 1)
+      assert length(results) == 1
+      assert elem(hd(results), 0).id == n2.id
+    end
+  end
+
+  describe "connected_nodes/2" do
+    test "finds nodes in both directions" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "Parent"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "Center"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "Child"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n2.id, n3.id, :leads_to)
+
+      results = Graph.connected_nodes(n2.id, [:leads_to])
+      ids = Enum.map(results, fn {node, _depth, _type} -> node.id end)
+
+      assert n1.id in ids
+      assert n3.id in ids
+      assert length(results) == 2
+    end
+
+    test "deduplicates nodes connected in both directions" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "A"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "B"}))
+
+      # Edges in both directions between same pair
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n2.id, n1.id, :leads_to)
+
+      results = Graph.connected_nodes(n1.id, [:leads_to])
+      assert length(results) == 1
+      assert elem(hd(results), 0).id == n2.id
+    end
+  end
+
+  describe "edge walking — circular references" do
+    test "visited set prevents infinite loops" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "A"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "B"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "C"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n2.id, n3.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n3.id, n1.id, :leads_to)
+
+      results = Graph.walk_downstream(n1.id, [:leads_to], max_depth: 10)
+      # Should find n2, n3 but not loop infinitely back to n1
+      ids = Enum.map(results, fn {node, _depth, _type} -> node.id end)
+      assert n2.id in ids
+      assert n3.id in ids
+      assert length(results) == 2
+    end
+  end
+
+  describe "list_edges/1 with edge_type list" do
+    test "filters edges by a list of edge types" do
+      {:ok, n1} = Graph.add_node(node_attrs(%{title: "A"}))
+      {:ok, n2} = Graph.add_node(node_attrs(%{title: "B"}))
+      {:ok, n3} = Graph.add_node(node_attrs(%{title: "C"}))
+      {:ok, n4} = Graph.add_node(node_attrs(%{title: "D"}))
+
+      {:ok, _} = Graph.add_edge(n1.id, n2.id, :leads_to)
+      {:ok, _} = Graph.add_edge(n1.id, n3.id, :chosen)
+      {:ok, _} = Graph.add_edge(n1.id, n4.id, :blocks)
+
+      results = Graph.list_edges(edge_type: [:leads_to, :chosen])
+      assert length(results) == 2
+
+      types = Enum.map(results, & &1.edge_type)
+      assert :leads_to in types
+      assert :chosen in types
+      refute :blocks in types
+    end
+  end
+
   defp errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
       Regex.replace(~r"%{(\w+)}", msg, fn _, key ->

--- a/test/loomkin/decisions/nervous_system_integration_test.exs
+++ b/test/loomkin/decisions/nervous_system_integration_test.exs
@@ -1,0 +1,266 @@
+defmodule Loomkin.Decisions.NervousSystemIntegrationTest do
+  @moduledoc "End-to-end tests validating the full nervous system flow across AutoLogger, Broadcaster, Cascade, and ContextBuilder."
+
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.{AutoLogger, Broadcaster, Graph, ContextBuilder}
+  alias Loomkin.Teams.Comms
+  alias Loomkin.Schemas.Session
+
+  @pubsub Loomkin.PubSub
+
+  defp create_session do
+    %Session{}
+    |> Session.changeset(%{model: "test-model", project_path: "/tmp/test"})
+    |> Repo.insert!()
+  end
+
+  defp setup_team(_context) do
+    team_id = Ecto.UUID.generate()
+    {:ok, _ref} = Loomkin.Teams.TableRegistry.create_table(team_id)
+    {:ok, _} = start_supervised({AutoLogger, team_id: team_id}, id: :auto_logger)
+    {:ok, _} = start_supervised({Broadcaster, team_id: team_id}, id: :broadcaster)
+
+    on_exit(fn ->
+      Loomkin.Teams.TableRegistry.delete_table(team_id)
+    end)
+
+    %{team_id: team_id}
+  end
+
+  describe "observation triggers discovery notification to relevant agent" do
+    setup [:setup_team]
+
+    test "Agent A's goal gets notified when Agent B logs an observation", %{team_id: team_id} do
+      # Agent A owns an active goal
+      {:ok, goal} =
+        Graph.add_node(%{
+          node_type: :goal,
+          title: "Implement auth system",
+          status: :active,
+          agent_name: "agent-a",
+          metadata: %{"team_id" => team_id}
+        })
+
+      # Agent B logs an action under that goal
+      {:ok, action} =
+        Graph.add_node(%{
+          node_type: :action,
+          title: "Research OAuth providers",
+          agent_name: "agent-b",
+          metadata: %{"team_id" => team_id}
+        })
+
+      {:ok, _} = Graph.add_edge(goal.id, action.id, :enables)
+
+      # Subscribe as Agent A to receive notifications
+      Phoenix.PubSub.subscribe(@pubsub, "team:#{team_id}:agent:agent-a")
+
+      # Agent B logs an observation linked to the action
+      {:ok, obs} =
+        Graph.add_node(%{
+          node_type: :observation,
+          title: "Found security vulnerability in provider X",
+          agent_name: "agent-b",
+          metadata: %{"team_id" => team_id}
+        })
+
+      {:ok, _} = Graph.add_edge(action.id, obs.id, :enables)
+
+      # Re-broadcast so Broadcaster picks it up with edges in place
+      Phoenix.PubSub.broadcast(@pubsub, "decision_graph", {:node_added, obs})
+
+      # Agent A should receive discovery notification
+      assert_receive {:discovery_relevant, payload}, 1000
+      assert payload.observation_id == obs.id
+      assert payload.observation_title == "Found security vulnerability in provider X"
+      assert payload.goal_id == goal.id
+      assert payload.goal_title == "Implement auth system"
+      assert payload.source_agent == "agent-b"
+    end
+  end
+
+  describe "context offload creates graph node with keeper_id" do
+    setup [:setup_team]
+
+    test "AutoLogger creates observation node when keeper_created event fires", %{
+      team_id: team_id
+    } do
+      keeper_id = Ecto.UUID.generate()
+
+      # Simulate a keeper_created event (normally from ContextOffload)
+      Comms.broadcast(team_id, {:keeper_created, %{
+        id: keeper_id,
+        topic: "authentication-research",
+        source: "agent-b",
+        tokens: 1200
+      }})
+
+      Process.sleep(100)
+
+      # AutoLogger should have created an observation node
+      nodes = Graph.list_nodes(node_type: :observation)
+      assert length(nodes) >= 1
+
+      keeper_node = Enum.find(nodes, fn n -> n.metadata["keeper_id"] == keeper_id end)
+      assert keeper_node != nil
+      assert keeper_node.title == "Context offloaded: authentication-research"
+      assert keeper_node.agent_name == "agent-b"
+      assert keeper_node.metadata["auto_logged"] == true
+      assert keeper_node.metadata["team_id"] == team_id
+    end
+  end
+
+  describe "low confidence cascades to dependent nodes" do
+    setup [:setup_team]
+
+    test "updating decision confidence propagates upstream_uncertainty and notifies agent", %{
+      team_id: team_id
+    } do
+      # Build chain: goal -requires-> decision -requires-> action
+      {:ok, goal} =
+        Graph.add_node(%{
+          node_type: :goal,
+          title: "Ship feature",
+          status: :active,
+          confidence: 90,
+          metadata: %{"team_id" => team_id},
+          agent_name: "lead"
+        })
+
+      {:ok, decision} =
+        Graph.add_node(%{
+          node_type: :decision,
+          title: "Use GraphQL",
+          confidence: 80,
+          metadata: %{"team_id" => team_id},
+          agent_name: "architect"
+        })
+
+      {:ok, action} =
+        Graph.add_node(%{
+          node_type: :action,
+          title: "Build GraphQL resolvers",
+          metadata: %{"team_id" => team_id},
+          agent_name: "coder"
+        })
+
+      {:ok, _} = Graph.add_edge(goal.id, decision.id, :requires)
+      {:ok, _} = Graph.add_edge(decision.id, action.id, :requires)
+
+      # Subscribe as the downstream agent to receive confidence warnings
+      Comms.subscribe(team_id, "coder")
+
+      # Drop decision confidence below threshold (default 50)
+      {:ok, _} = Graph.update_node(decision, %{confidence: 30})
+
+      Process.sleep(50)
+
+      # Action should be marked with upstream_uncertainty
+      updated_action = Graph.get_node(action.id)
+      assert updated_action.metadata["upstream_uncertainty"] == true
+
+      # Agent "coder" should receive confidence_warning
+      assert_receive {:confidence_warning, warning}
+      assert warning.source_node_id == decision.id
+      assert warning.source_title == "Use GraphQL"
+      assert warning.source_confidence == 30
+      assert warning.affected_node_id == action.id
+      assert warning.affected_title == "Build GraphQL resolvers"
+    end
+  end
+
+  describe "ContextBuilder includes prior attempts from other sessions" do
+    test "cross_session: true surfaces abandoned decisions from session A in session B" do
+      session_a = create_session()
+      session_b = create_session()
+
+      # Log a decision in session A, then abandon it
+      {:ok, _} =
+        Graph.add_node(%{
+          node_type: :decision,
+          title: "Try microservices approach",
+          description: "Too much operational overhead",
+          status: :abandoned,
+          session_id: session_a.id
+        })
+
+      # Also add an active goal in session B
+      {:ok, _} =
+        Graph.add_node(%{
+          node_type: :goal,
+          title: "Redesign architecture",
+          status: :active,
+          session_id: session_b.id
+        })
+
+      # Build context for session B with cross_session: true
+      {:ok, result} = ContextBuilder.build(session_b.id, cross_session: true)
+
+      # Should include the abandoned decision from session A
+      assert result =~ "Prior Attempts & Lessons"
+      assert result =~ "[ABANDONED] Try microservices approach"
+      assert result =~ "Too much operational overhead"
+
+      # Should also include the active goal from session B (and A since cross_session)
+      assert result =~ "Redesign architecture"
+    end
+  end
+
+  describe "keeper_id in graph nodes enables two-tier retrieval" do
+    test "graph node with keeper_id surfaces keeper reference in context" do
+      session = create_session()
+      keeper_id = Ecto.UUID.generate()
+
+      # Create a goal with keeper_id (simulating deep context offloaded to keeper)
+      {:ok, goal} =
+        Graph.add_node(%{
+          node_type: :goal,
+          title: "Optimize database queries",
+          status: :active,
+          confidence: 75,
+          session_id: session.id,
+          metadata: %{"keeper_id" => keeper_id}
+        })
+
+      # Create related decision with keeper_id too
+      {:ok, _decision} =
+        Graph.add_node(%{
+          node_type: :decision,
+          title: "Use materialized views",
+          session_id: session.id,
+          metadata: %{"keeper_id" => keeper_id}
+        })
+
+      # Build context — should include keeper references
+      {:ok, result} = ContextBuilder.build(session.id)
+
+      # The graph gives structured summary mentioning the keeper
+      assert result =~ "Optimize database queries"
+      assert result =~ "Deep context available in keeper #{keeper_id}"
+
+      # Verify the keeper_id can be extracted from the graph node for retrieval
+      retrieved = Graph.get_node(goal.id)
+      assert retrieved.metadata["keeper_id"] == keeper_id
+
+      # Verify add_node_with_keeper also works for keeper association
+      {:ok, linked} =
+        Graph.add_node_with_keeper(
+          %{node_type: :observation, title: "Query plan analysis", session_id: session.id},
+          keeper_id
+        )
+
+      assert linked.metadata["keeper_id"] == keeper_id
+
+      # Walk downstream from goal should find linked nodes with keeper context
+      {:ok, _} = Graph.add_edge(goal.id, linked.id, :leads_to)
+      downstream = Graph.walk_downstream(goal.id, [:leads_to], max_depth: 1)
+      assert length(downstream) >= 1
+
+      {found_node, _depth, _type} =
+        Enum.find(downstream, fn {n, _d, _t} -> n.id == linked.id end)
+
+      assert found_node.metadata["keeper_id"] == keeper_id
+    end
+  end
+end

--- a/test/loomkin/decisions/supervision_test.exs
+++ b/test/loomkin/decisions/supervision_test.exs
@@ -1,0 +1,116 @@
+defmodule Loomkin.Decisions.SupervisionTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Teams.Manager
+
+  setup do
+    # Enable nervous system auto-start for these tests
+    prev = Application.get_env(:loomkin, :start_nervous_system)
+    Application.put_env(:loomkin, :start_nervous_system, true)
+
+    {:ok, team_id} = Manager.create_team(name: "supervision-test")
+
+    on_exit(fn ->
+      Manager.dissolve_team(team_id)
+      if is_nil(prev),
+        do: Application.delete_env(:loomkin, :start_nervous_system),
+        else: Application.put_env(:loomkin, :start_nervous_system, prev)
+    end)
+
+    %{team_id: team_id}
+  end
+
+  describe "team creation starts nervous system" do
+    test "AutoLogger is running after create_team", %{team_id: team_id} do
+      [{pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:auto_logger, team_id})
+      assert Process.alive?(pid)
+    end
+
+    test "Broadcaster is running after create_team", %{team_id: team_id} do
+      [{pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:broadcaster, team_id})
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "sub-team creation starts nervous system" do
+    test "AutoLogger and Broadcaster start for sub-teams", %{team_id: parent_id} do
+      {:ok, sub_id} = Manager.create_sub_team(parent_id, "lead", name: "sub-team")
+
+      [{auto_pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:auto_logger, sub_id})
+      [{broad_pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:broadcaster, sub_id})
+
+      assert Process.alive?(auto_pid)
+      assert Process.alive?(broad_pid)
+
+      Manager.dissolve_team(sub_id)
+    end
+  end
+
+  describe "team dissolution stops nervous system" do
+    test "AutoLogger and Broadcaster stop on dissolve_team" do
+      {:ok, team_id} = Manager.create_team(name: "dissolve-ns-test")
+
+      [{auto_pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:auto_logger, team_id})
+      [{broad_pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:broadcaster, team_id})
+
+      assert Process.alive?(auto_pid)
+      assert Process.alive?(broad_pid)
+
+      Manager.dissolve_team(team_id)
+
+      refute Process.alive?(auto_pid)
+      refute Process.alive?(broad_pid)
+
+      assert Registry.lookup(Loomkin.Teams.AgentRegistry, {:auto_logger, team_id}) == []
+      assert Registry.lookup(Loomkin.Teams.AgentRegistry, {:broadcaster, team_id}) == []
+    end
+
+    test "dissolve is safe when nervous system already stopped" do
+      {:ok, team_id} = Manager.create_team(name: "double-dissolve-test")
+
+      # Manually stop the processes first
+      [{auto_pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:auto_logger, team_id})
+      GenServer.stop(auto_pid)
+      Process.sleep(20)
+
+      # dissolve_team should still succeed
+      assert :ok = Manager.dissolve_team(team_id)
+    end
+  end
+
+  describe "nervous system processes are supervised" do
+    test "AutoLogger restarts after crash", %{team_id: team_id} do
+      [{old_pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:auto_logger, team_id})
+      Process.exit(old_pid, :kill)
+      Process.sleep(100)
+
+      # DynamicSupervisor should restart it with a new pid
+      result = Registry.lookup(Loomkin.Teams.AgentRegistry, {:auto_logger, team_id})
+      assert [{new_pid, _}] = result
+      assert Process.alive?(new_pid)
+      assert new_pid != old_pid
+    end
+
+    test "Broadcaster restarts after crash", %{team_id: team_id} do
+      [{old_pid, _}] = Registry.lookup(Loomkin.Teams.AgentRegistry, {:broadcaster, team_id})
+      Process.exit(old_pid, :kill)
+      Process.sleep(100)
+
+      result = Registry.lookup(Loomkin.Teams.AgentRegistry, {:broadcaster, team_id})
+      assert [{new_pid, _}] = result
+      assert Process.alive?(new_pid)
+      assert new_pid != old_pid
+    end
+  end
+
+  describe "AutoLogger receives events after team creation" do
+    test "logs agent_status events automatically", %{team_id: team_id} do
+      # Broadcast an event — AutoLogger should create a graph node
+      Loomkin.Teams.Comms.broadcast(team_id, {:agent_status, "test-agent", :working})
+      Process.sleep(50)
+
+      nodes = Loomkin.Decisions.Graph.list_nodes(node_type: :action)
+      assert Enum.any?(nodes, &(&1.title == "Agent test-agent joined team"))
+    end
+  end
+end

--- a/test/loomkin/teams/agent_test.exs
+++ b/test/loomkin/teams/agent_test.exs
@@ -258,4 +258,134 @@ defmodule Loomkin.Teams.AgentTest do
       assert state.status == :idle
     end
   end
+
+  describe "discovery_relevant handler" do
+    test "injects system message with observation and goal" do
+      %{pid: pid, team_id: team_id} = start_agent()
+
+      Phoenix.PubSub.broadcast(
+        Loomkin.PubSub,
+        "team:#{team_id}",
+        {:discovery_relevant, %{
+          observation_title: "Cache hit rate dropped",
+          goal_title: "Improve API latency",
+          source_agent: "researcher-1",
+          keeper_id: nil
+        }}
+      )
+
+      Process.sleep(50)
+
+      state = :sys.get_state(pid)
+      assert length(state.messages) == 1
+      [msg] = state.messages
+      assert msg.role == :user
+      assert msg.content =~ "[Discovery from researcher-1]"
+      assert msg.content =~ "Cache hit rate dropped"
+      assert msg.content =~ "relevant to your goal: Improve API latency"
+      refute msg.content =~ "keeper"
+    end
+
+    test "includes keeper reference when keeper_id is present" do
+      %{pid: pid, team_id: team_id} = start_agent()
+
+      Phoenix.PubSub.broadcast(
+        Loomkin.PubSub,
+        "team:#{team_id}",
+        {:discovery_relevant, %{
+          observation_title: "Memory leak found",
+          goal_title: "Stabilize production",
+          source_agent: "coder-2",
+          keeper_id: "keeper-xyz-789"
+        }}
+      )
+
+      Process.sleep(50)
+
+      state = :sys.get_state(pid)
+      [msg] = state.messages
+      assert msg.content =~ "context_retrieve on keeper keeper-xyz-789"
+    end
+  end
+
+  describe "confidence_warning handler" do
+    test "injects system message with confidence warning" do
+      %{pid: pid, team_id: team_id} = start_agent()
+
+      Phoenix.PubSub.broadcast(
+        Loomkin.PubSub,
+        "team:#{team_id}",
+        {:confidence_warning, %{
+          source_title: "Use PostgreSQL",
+          source_confidence: 35,
+          affected_title: "Design schema migration",
+          keeper_id: nil
+        }}
+      )
+
+      Process.sleep(50)
+
+      state = :sys.get_state(pid)
+      assert length(state.messages) == 1
+      [msg] = state.messages
+      assert msg.role == :user
+      assert msg.content =~ "[Confidence Warning]"
+      assert msg.content =~ "Upstream decision 'Use PostgreSQL' has low confidence (35)"
+      assert msg.content =~ "Your work on 'Design schema migration' may be affected"
+      refute msg.content =~ "keeper"
+    end
+
+    test "includes keeper reference when keeper_id is present" do
+      %{pid: pid, team_id: team_id} = start_agent()
+
+      Phoenix.PubSub.broadcast(
+        Loomkin.PubSub,
+        "team:#{team_id}",
+        {:confidence_warning, %{
+          source_title: "Use Redis",
+          source_confidence: 20,
+          affected_title: "Cache layer impl",
+          keeper_id: "keeper-abc-123"
+        }}
+      )
+
+      Process.sleep(50)
+
+      state = :sys.get_state(pid)
+      [msg] = state.messages
+      assert msg.content =~ "Re-evaluate using keeper keeper-abc-123"
+    end
+
+    test "multiple nervous system messages accumulate" do
+      %{pid: pid, team_id: team_id} = start_agent()
+
+      Phoenix.PubSub.broadcast(
+        Loomkin.PubSub,
+        "team:#{team_id}",
+        {:discovery_relevant, %{
+          observation_title: "Obs 1",
+          goal_title: "Goal 1",
+          source_agent: "agent-a",
+          keeper_id: nil
+        }}
+      )
+
+      Phoenix.PubSub.broadcast(
+        Loomkin.PubSub,
+        "team:#{team_id}",
+        {:confidence_warning, %{
+          source_title: "Decision X",
+          source_confidence: 25,
+          affected_title: "Task Y",
+          keeper_id: nil
+        }}
+      )
+
+      Process.sleep(50)
+
+      state = :sys.get_state(pid)
+      assert length(state.messages) == 2
+      assert Enum.all?(state.messages, &(&1.role == :user))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **AutoLogger** — Per-team GenServer that subscribes to PubSub events and auto-creates decision graph nodes for lifecycle events (agent spawn, task assign/complete, context offload), establishing causal tracing with `keeper_id` links
- **Discovery Broadcaster** — Watches for new observation/outcome nodes, walks graph edges upstream to find connected active goals, and proactively notifies owning agents (debounced, team-filtered)
- **Confidence Cascade** — When a node's confidence drops below threshold, propagates warnings downstream through `:requires`/`:blocks` edges, flags affected nodes with `upstream_uncertainty`, and alerts agents
- **Enhanced ContextBuilder** — Adds "Prior Attempts & Lessons" section (revisit/abandoned/superseded nodes), cross-session goal queries, and keeper references in planning context
- **Graph API extensions** — Team-scoped filters, `add_node_with_keeper/2`, BFS edge walkers (`walk_downstream`/`walk_upstream`/`connected_nodes`) with diamond-path deduplication
- **Agent integration** — New `handle_info` clauses for `:discovery_relevant` and `:confidence_warning` messages
- **Supervision wiring** — AutoLogger and Broadcaster start/stop with team lifecycle via Manager
- **DecisionLog** — Now injects `team_id` and `agent_name` from tool context so manual logs participate in broadcasting

### Architecture

```
Graph (Index / Nervous System)          Context Keepers (Memory / Archive)
┌─────────────────────────────┐          ┌─────────────────────────────┐
│ goal ──→ decision ──→ action│ keeper_id │ Full conversation thread    │
│   │         │         │     │──────────→│ with every argument, code   │
│   │      option(rejected)   │          │ snippet, and tradeoff       │
│   └──→ observation          │          └─────────────────────────────┘
│                             │
│ FAST: "What did we decide?" │          DEEP: "Why? Show me everything."
└─────────────────────────────┘
```

Graph knows WHAT happened and WHO cares. Keepers know the FULL STORY. Graph nodes point to keepers via `keeper_id`. Fast questions hit the graph. Deep questions follow the reference to keepers.

### Files changed

**New (3 modules, 4 test files, 2 docs):**
- `lib/loomkin/decisions/auto_logger.ex` — ~130 LOC
- `lib/loomkin/decisions/broadcaster.ex` — ~113 LOC
- `lib/loomkin/decisions/cascade.ex` — ~70 LOC
- 4 new test files + integration suite

**Modified (6 source, 3 test, 1 config):**
- `graph.ex` — filters, walkers, PubSub broadcast, cascade hook
- `context_builder.ex` — prior attempts, cross-session, keeper refs
- `agent.ex` — 2 new handle_info clauses
- `manager.ex` — nervous system lifecycle
- `decision_log.ex` — team_id/agent_name metadata injection
- `config/test.exs` — disable auto-start in test env

**Untouched (as designed):** All context keeper modules — `context_keeper.ex`, `context_offload.ex`, `context_retrieval.ex`, keeper schema, keeper tools.

## Test plan

- [x] 111 decisions tests pass (0 failures)
- [x] 395 teams tests pass (0 failures)
- [x] 5 end-to-end integration tests covering full nervous system flows
- [x] 8 supervision lifecycle tests (start/stop/restart)
- [x] No regressions in existing test suite
- [ ] Verify in live multi-team session: AutoLogger creates causal trail
- [ ] Verify Broadcaster delivers discovery notifications across agents
- [ ] Verify Cascade warnings propagate through deep dependency chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)