### PR TITLE
Remove iteration cap, fix team activity visibility, add external file permissions

### DIFF
--- a/lib/loomkin/agent_loop.ex
+++ b/lib/loomkin/agent_loop.ex
@@ -13,7 +13,6 @@ defmodule Loomkin.AgentLoop do
 
   require Logger
 
-  @default_max_iterations 25
   @max_rate_limit_retries 3
 
   @type on_event :: (atom(), map() -> :ok)
@@ -26,7 +25,6 @@ defmodule Loomkin.AgentLoop do
     * `:model` - LLM model string (e.g. "anthropic:claude-sonnet-4-6"). Required.
     * `:tools` - list of tool action modules. Default `[]`.
     * `:system_prompt` - the system prompt string. Required.
-    * `:max_iterations` - max tool execution cycles. Default #{@default_max_iterations}.
     * `:project_path` - path to the project being worked on.
     * `:session_id` - session identifier (used for context window enrichment).
     * `:on_event` - `fn event_name, payload -> :ok end` callback for streaming events.
@@ -62,12 +60,24 @@ defmodule Loomkin.AgentLoop do
       {:rate_limited, provider} ->
         if attempt < @max_rate_limit_retries do
           backoff_ms = Integer.pow(2, attempt) * 1_000
-          Logger.warning("Rate limited by #{provider}, retry #{attempt + 1}/#{@max_rate_limit_retries} after #{backoff_ms}ms")
-          config.on_event.(:rate_limited, %{provider: provider, retry: attempt + 1, backoff_ms: backoff_ms})
+
+          Logger.warning(
+            "Rate limited by #{provider}, retry #{attempt + 1}/#{@max_rate_limit_retries} after #{backoff_ms}ms"
+          )
+
+          config.on_event.(:rate_limited, %{
+            provider: provider,
+            retry: attempt + 1,
+            backoff_ms: backoff_ms
+          })
+
           Process.sleep(backoff_ms)
           run_with_rate_limit_retry(messages, config, attempt + 1)
         else
-          Logger.warning("Rate limited by #{provider}, max retries (#{@max_rate_limit_retries}) exhausted")
+          Logger.warning(
+            "Rate limited by #{provider}, max retries (#{@max_rate_limit_retries}) exhausted"
+          )
+
           {:error, :rate_limited, messages}
         end
     end
@@ -80,7 +90,6 @@ defmodule Loomkin.AgentLoop do
       model: Keyword.fetch!(opts, :model),
       tools: Keyword.get(opts, :tools, []),
       system_prompt: Keyword.fetch!(opts, :system_prompt),
-      max_iterations: Keyword.get(opts, :max_iterations, @default_max_iterations),
       project_path: Keyword.get(opts, :project_path),
       session_id: Keyword.get(opts, :session_id),
       agent_name: Keyword.get(opts, :agent_name),
@@ -93,12 +102,6 @@ defmodule Loomkin.AgentLoop do
   end
 
   # -- Loop --------------------------------------------------------------------
-
-  defp do_loop(messages, config, iteration) when iteration >= config.max_iterations do
-    error_msg = "Maximum tool call iterations (#{config.max_iterations}) exceeded."
-    Logger.warning(error_msg)
-    {:error, error_msg, messages}
-  end
 
   defp do_loop(messages, config, iteration) do
     # Auto-offload context if agent is above threshold
@@ -146,10 +149,16 @@ defmodule Loomkin.AgentLoop do
       iteration: iteration
     }
 
-    Logger.debug("AgentLoop calling LLM: #{provider}:#{model_id}, #{length(req_messages)} messages, #{length(opts[:tools] || [])} tools")
+    Logger.debug(
+      "AgentLoop calling LLM: #{provider}:#{model_id}, #{length(req_messages)} messages, #{length(opts[:tools] || [])} tools"
+    )
 
     on_retry = fn attempt, reason, backoff_ms ->
-      emit(config, :llm_retry, %{attempt: attempt, reason: inspect(reason), backoff_ms: backoff_ms})
+      emit(config, :llm_retry, %{
+        attempt: attempt,
+        reason: inspect(reason),
+        backoff_ms: backoff_ms
+      })
     end
 
     case Loomkin.LLMRetry.with_retry([on_retry: on_retry], fn ->
@@ -170,7 +179,13 @@ defmodule Loomkin.AgentLoop do
 
   # -- Response handling -------------------------------------------------------
 
-  defp handle_classified(%{type: :tool_calls} = classified, response, messages, config, iteration) do
+  defp handle_classified(
+         %{type: :tool_calls} = classified,
+         response,
+         messages,
+         config,
+         iteration
+       ) do
     emit(config, :tool_calls_received, %{
       tool_calls: classified.tool_calls,
       text: classified.text
@@ -206,7 +221,13 @@ defmodule Loomkin.AgentLoop do
     end
   end
 
-  defp handle_classified(%{type: :final_answer} = classified, response, messages, config, _iteration) do
+  defp handle_classified(
+         %{type: :final_answer} = classified,
+         response,
+         messages,
+         config,
+         _iteration
+       ) do
     response_text = classified.text
 
     assistant_msg = %{role: :assistant, content: response_text}
@@ -239,7 +260,14 @@ defmodule Loomkin.AgentLoop do
     tool_call_id = tool_call[:id] || "call_#{Ecto.UUID.generate()}"
     tool_path = tool_args["file_path"] || tool_args["path"] || "*"
 
-    context = %{project_path: config.project_path, session_id: config.session_id, agent_name: config.agent_name, team_id: config.team_id, parent_team_id: config.team_id, model: config.model}
+    context = %{
+      project_path: config.project_path,
+      session_id: config.session_id,
+      agent_name: config.agent_name,
+      team_id: config.team_id,
+      parent_team_id: config.team_id,
+      model: config.model
+    }
 
     emit(config, :tool_executing, %{tool_name: tool_name, tool_target: tool_path})
 
@@ -260,6 +288,19 @@ defmodule Loomkin.AgentLoop do
 
         case permission_result do
           :allowed ->
+            # Tag context for permitted external reads so file_read can bypass safe_path!
+            context =
+              if config.project_path &&
+                   Loomkin.Tool.outside_project?(
+                     Loomkin.Tool.resolve_path(tool_path, config.project_path),
+                     config.project_path
+                   ) do
+                Map.put(context, :allowed_external_path,
+                  Loomkin.Tool.resolve_path(tool_path, config.project_path))
+              else
+                context
+              end
+
             result_text = run_tool(tool_module, tool_args, context, config)
             messages = record_tool_result(messages, config, tool_name, tool_call_id, result_text)
             {:ok, messages}
@@ -491,7 +532,12 @@ defmodule Loomkin.AgentLoop do
     end
   end
 
-  defp maybe_auto_offload(messages, %{team_id: team_id, agent_name: agent_name, model: model, on_event: on_event})
+  defp maybe_auto_offload(messages, %{
+         team_id: team_id,
+         agent_name: agent_name,
+         model: model,
+         on_event: on_event
+       })
        when not is_nil(team_id) and not is_nil(agent_name) do
     state = %{team_id: team_id, name: agent_name, messages: messages, model: model}
 

--- a/lib/loomkin/permissions/manager.ex
+++ b/lib/loomkin/permissions/manager.ex
@@ -43,6 +43,30 @@ defmodule Loomkin.Permissions.Manager do
   end
 
   @doc """
+  Boundary-aware permission check. For read tools accessing paths outside
+  the project directory, requires explicit user permission instead of
+  auto-approving.
+
+  Returns `:allowed` or `:ask`.
+  """
+  def check(tool_name, path, session_id, project_path) when is_binary(project_path) do
+    resolved = Loomkin.Tool.resolve_path(path, project_path)
+
+    if tool_category(tool_name) in [:read] and
+         Loomkin.Tool.outside_project?(resolved, project_path) do
+      # Out-of-project read — check for an existing scoped grant
+      if has_grant?(tool_name, resolved, session_id) do
+        :allowed
+      else
+        :ask
+      end
+    else
+      # In-project or non-read tool — delegate to standard check
+      check(tool_name, path, session_id)
+    end
+  end
+
+  @doc """
   Store a permission grant for a tool in the given scope and session.
   """
   def grant(tool_name, scope, session_id) do
@@ -82,13 +106,28 @@ defmodule Loomkin.Permissions.Manager do
   # --- Private ---
 
   defp has_grant?(tool_name, path, session_id) do
-    query =
+    # Check for exact match, wildcard, or directory-prefix grants.
+    # Directory-prefix grants are stored as "/path/to/dir/" (trailing slash)
+    # and match any path under that directory.
+    exact_query =
       from g in PermissionGrant,
         where: g.session_id == ^session_id,
         where: g.tool == ^tool_name,
         where: g.scope == "*" or g.scope == ^path,
         limit: 1
 
-    Repo.exists?(query)
+    if Repo.exists?(exact_query) do
+      true
+    else
+      # Check directory-prefix grants — scope ends with "/" and path starts with it
+      prefix_query =
+        from g in PermissionGrant,
+          where: g.session_id == ^session_id,
+          where: g.tool == ^tool_name,
+          where: fragment("? LIKE '%/' AND ? LIKE ? || '%'", g.scope, ^path, g.scope),
+          limit: 1
+
+      Repo.exists?(prefix_query)
+    end
   end
 end

--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -237,14 +237,15 @@ defmodule Loomkin.Teams.Agent do
   end
 
   @impl true
-  def handle_cast({:permission_response, action, tool_name, _tool_path}, state) do
+  def handle_cast({:permission_response, action, tool_name, tool_path}, state) do
     case state.pending_permission do
       nil ->
         {:noreply, state}
 
       pending_info ->
         if action == "allow_always" do
-          Loomkin.Permissions.Manager.grant(to_string(tool_name), "*", state.team_id)
+          # Store grant with the actual resolved path, not wildcard
+          Loomkin.Permissions.Manager.grant(to_string(tool_name), tool_path, state.team_id)
         end
 
         # Resume in a task to avoid blocking the GenServer
@@ -738,7 +739,6 @@ defmodule Loomkin.Teams.Agent do
         model: model,
         tools: [],
         system_prompt: "You are participating in a structured debate. Respond concisely.",
-        max_iterations: 1,
         project_path: state.project_path
       ]
 
@@ -814,7 +814,6 @@ defmodule Loomkin.Teams.Agent do
       model: state.model,
       tools: state.tools,
       system_prompt: system_prompt,
-      max_iterations: state.role_config.max_iterations,
       project_path: state.project_path,
       agent_name: state.name,
       team_id: state.team_id,
@@ -846,11 +845,33 @@ defmodule Loomkin.Teams.Agent do
 
   defp build_permission_callback(%{permission_mode: :auto}), do: nil
 
-  defp build_permission_callback(%{permission_mode: :session, team_id: team_id, name: name}) do
+  defp build_permission_callback(%{
+         permission_mode: :session,
+         team_id: team_id,
+         name: name,
+         project_path: project_path
+       }) do
     agent_name = name
 
     fn tool_name, tool_path ->
-      case Loomkin.Permissions.Manager.check(to_string(tool_name), tool_path, team_id) do
+      tool_name_str = to_string(tool_name)
+
+      # Resolve path to absolute for display and permission checking
+      resolved_path =
+        if project_path do
+          Loomkin.Tool.resolve_path(tool_path, project_path)
+        else
+          tool_path
+        end
+
+      check_result =
+        if project_path do
+          Loomkin.Permissions.Manager.check(tool_name_str, tool_path, team_id, project_path)
+        else
+          Loomkin.Permissions.Manager.check(tool_name_str, tool_path, team_id)
+        end
+
+      case check_result do
         :allowed ->
           :allowed
 
@@ -858,11 +879,11 @@ defmodule Loomkin.Teams.Agent do
           Phoenix.PubSub.broadcast(
             Loomkin.PubSub,
             "team:#{team_id}",
-            {:permission_request, team_id, to_string(tool_name), tool_path,
+            {:permission_request, team_id, tool_name_str, resolved_path,
              {:agent, team_id, agent_name}}
           )
 
-          {:pending, %{tool_name: to_string(tool_name), tool_path: tool_path}}
+          {:pending, %{tool_name: tool_name_str, tool_path: resolved_path}}
       end
     end
   end

--- a/lib/loomkin/teams/role.ex
+++ b/lib/loomkin/teams/role.ex
@@ -8,13 +8,12 @@ defmodule Loomkin.Teams.Role do
   for all built-in roles — meaning "use whatever the user configured."
   """
 
-  defstruct [:name, :model_tier, :tools, :max_iterations, :system_prompt, :budget_limit]
+  defstruct [:name, :model_tier, :tools, :system_prompt, :budget_limit]
 
   @type t :: %__MODULE__{
           name: atom(),
           model_tier: atom(),
           tools: [module()],
-          max_iterations: pos_integer(),
           system_prompt: String.t(),
           budget_limit: float() | nil
         }
@@ -182,7 +181,6 @@ defmodule Loomkin.Teams.Role do
     lead: %{
       model_tier: :default,
       tools: @all_tools,
-      max_iterations: 25,
       system_prompt: """
       You are the team lead. Your job is to decompose complex tasks into smaller subtasks,
       coordinate work across team agents, and synthesize results into a coherent response.
@@ -199,7 +197,6 @@ defmodule Loomkin.Teams.Role do
     researcher: %{
       model_tier: :default,
       tools: @read_only_tools ++ @decision_tools ++ @peer_tools,
-      max_iterations: 15,
       system_prompt: """
       You are a research agent. Your job is to explore the codebase, analyze patterns,
       and report findings to the team lead.
@@ -217,7 +214,6 @@ defmodule Loomkin.Teams.Role do
     coder: %{
       model_tier: :default,
       tools: @read_only_tools ++ @write_tools ++ @exec_tools ++ [Loomkin.Tools.DecisionLog] ++ @peer_tools,
-      max_iterations: 25,
       system_prompt: """
       You are a coding agent. Your job is to implement changes, write code, and run commands.
 
@@ -234,7 +230,6 @@ defmodule Loomkin.Teams.Role do
     reviewer: %{
       model_tier: :default,
       tools: @read_only_tools ++ [Loomkin.Tools.Shell] ++ @decision_tools ++ @peer_tools,
-      max_iterations: 10,
       system_prompt: """
       You are a code review agent. Your job is to review code quality, find issues,
       and suggest improvements.
@@ -252,7 +247,6 @@ defmodule Loomkin.Teams.Role do
     tester: %{
       model_tier: :default,
       tools: @read_only_tools ++ [Loomkin.Tools.Shell, Loomkin.Tools.DecisionLog] ++ @peer_tools,
-      max_iterations: 15,
       system_prompt: """
       You are a testing agent. Your job is to run tests, validate changes, and report results.
 
@@ -327,7 +321,6 @@ defmodule Loomkin.Teams.Role do
       name: name,
       model_tier: get_config_value(config, :model_tier, base.model_tier),
       tools: resolve_tools(config, base.tools),
-      max_iterations: get_config_value(config, :max_iterations, base.max_iterations),
       system_prompt: get_config_value(config, :system_prompt, base.system_prompt),
       budget_limit: get_config_value(config, :budget_limit, base.budget_limit)
     }

--- a/lib/loomkin/tool.ex
+++ b/lib/loomkin/tool.ex
@@ -56,6 +56,28 @@ defmodule Loomkin.Tool do
     end)
   end
 
+  @doc """
+  Resolves a file path relative to the project path without enforcing boundaries.
+
+  Returns the fully resolved absolute path (with symlinks resolved).
+  """
+  @spec resolve_path(String.t(), String.t()) :: String.t()
+  def resolve_path(file_path, project_path) do
+    expanded = Path.expand(file_path, project_path)
+    resolve_real(expanded)
+  end
+
+  @doc """
+  Returns true if the resolved path is outside the project directory.
+  """
+  @spec outside_project?(String.t(), String.t()) :: boolean()
+  def outside_project?(resolved_path, project_path) do
+    project_root = resolve_real(Path.expand(project_path))
+
+    not (resolved_path == project_root or
+           String.starts_with?(resolved_path, project_root <> "/"))
+  end
+
   @doc "Fetches a param by key, trying atom key first then string key."
   @spec param!(map(), atom()) :: any()
   def param!(params, key) when is_atom(key) do

--- a/lib/loomkin/tools/file_read.ex
+++ b/lib/loomkin/tools/file_read.ex
@@ -5,9 +5,14 @@ defmodule Loomkin.Tools.FileRead do
     name: "file_read",
     description:
       "Reads a file from the project. Returns contents formatted with line numbers. " <>
-        "Use offset and limit to read specific sections of large files.",
+        "Use offset and limit to read specific sections of large files. " <>
+        "For directories, use directory_list.",
     schema: [
-      file_path: [type: :string, required: true, doc: "Path to the file (relative to project root)"],
+      file_path: [
+        type: :string,
+        required: true,
+        doc: "Path to the file (relative to project root)"
+      ],
       offset: [type: :integer, doc: "Line number to start reading from (1-based)"],
       limit: [type: :integer, doc: "Maximum number of lines to return"]
     ]
@@ -21,7 +26,22 @@ defmodule Loomkin.Tools.FileRead do
     offset = param(params, :offset)
     limit = param(params, :limit)
 
-    full_path = safe_path!(file_path, project_path)
+    # Bypass safe_path! for permitted external reads (approved via permission system)
+    full_path =
+      case Map.get(context, :allowed_external_path) do
+        nil ->
+          safe_path!(file_path, project_path)
+
+        allowed_path ->
+          resolved = Loomkin.Tool.resolve_path(file_path, project_path)
+
+          if resolved == allowed_path do
+            resolved
+          else
+            # Resolved path doesn't match what was approved — fall back to safe_path!
+            safe_path!(file_path, project_path)
+          end
+      end
 
     case File.read(full_path) do
       {:ok, content} ->
@@ -52,12 +72,29 @@ defmodule Loomkin.Tools.FileRead do
         {:error, "File not found: #{full_path}"}
 
       {:error, :eisdir} ->
-        {:error, "Path is a directory, not a file: #{full_path}"}
+        rel_path = Path.relative_to(full_path, project_path)
+
+        {:ok,
+         %{
+           result:
+             "Path is a directory, not a file: #{full_path}\n" <>
+               "Use directory_list with path: #{rel_path}"
+         }}
 
       {:error, reason} ->
         {:error, "Failed to read #{full_path}: #{reason}"}
     end
   rescue
-    e in ArgumentError -> {:error, e.message}
+    e in ArgumentError ->
+      if String.contains?(e.message, "outside the project directory") do
+        {:ok,
+         %{
+           result:
+             "#{e.message}\n" <>
+               "Use a path relative to the project root or move the file into this project."
+         }}
+      else
+        {:error, e.message}
+      end
   end
 end

--- a/lib/loomkin_web/live/team_activity_component.ex
+++ b/lib/loomkin_web/live/team_activity_component.ex
@@ -1,7 +1,13 @@
 defmodule LoomkinWeb.TeamActivityComponent do
-  use LoomkinWeb, :live_component
+  @moduledoc """
+  Real-time activity feed for team agents.
 
-  @max_events 200
+  Events are buffered in the parent LiveView (workspace_live) and passed
+  as assigns. This ensures events survive tab switches — the component
+  can unmount and remount without losing history.
+  """
+
+  use LoomkinWeb, :live_component
 
   @agent_colors [
     "#818cf8",
@@ -30,126 +36,23 @@ defmodule LoomkinWeb.TeamActivityComponent do
     {:ok,
      assign(socket,
        events: [],
-       agent_filter: nil,
-       type_filter: MapSet.new(),
        known_agents: [],
-       streaming_agents: %{},
-       subscribed: false
+       agent_filter: nil,
+       type_filter: MapSet.new()
      )}
   end
 
   @impl true
-  def update(%{team_id: team_id} = assigns, socket) do
-    if connected?(socket) && !socket.assigns[:subscribed] do
-      Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}")
-      Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:tasks")
-      Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:decisions")
-      Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:context")
-    end
+  def update(assigns, socket) do
+    # Events and known_agents come from parent LiveView's buffer
+    socket =
+      socket
+      |> assign(:team_id, assigns[:team_id])
+      |> assign(:id, assigns[:id])
+      |> assign(:events, assigns[:events] || socket.assigns.events)
+      |> assign(:known_agents, assigns[:known_agents] || socket.assigns.known_agents)
 
-    {:ok,
-     socket
-     |> assign(assigns)
-     |> assign(:subscribed, true)}
-  end
-
-  # --- PubSub Handlers ---
-
-  def handle_info({:agent_status, agent_name, status}, socket) do
-    type =
-      case status do
-        :error -> :error
-        _ -> :message
-      end
-
-    content =
-      case status do
-        :idle -> "#{agent_name} is now idle"
-        :working -> "#{agent_name} started working"
-        :blocked -> "#{agent_name} is blocked"
-        :error -> "#{agent_name} encountered an error"
-      end
-
-    event = build_event(type, agent_name, content)
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:context_update, from_agent, %{type: :discovery, content: content}}, socket) do
-    event = build_event(:discovery, from_agent, content)
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:context_update, from_agent, payload}, socket) do
-    content = Map.get(payload, :content, inspect(payload))
-    event = build_event(:discovery, from_agent, content)
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:task_assigned, task_id, agent_name}, socket) do
-    event = build_event(:task_assigned, agent_name, "picked up task #{task_id}")
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:task_completed, task_id, agent_name, result}, socket) do
-    content =
-      case result do
-        result when is_binary(result) -> "completed task #{task_id}: #{result}"
-        _ -> "completed task #{task_id}"
-      end
-
-    event = build_event(:task_complete, agent_name, content)
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:decision_logged, node_id, agent_name}, socket) do
-    event = build_event(:decision, agent_name, "logged decision #{node_id}")
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:tool_call, agent_name, tool_name, target}, socket) do
-    content = "used #{tool_name} on #{target}"
-    event = build_event(:tool_call, agent_name, content)
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:agent_message, from_agent, to_agent, content}, socket) do
-    event = build_event(:message, from_agent, "to #{to_agent}: #{content}")
-    {:noreply, append_event(socket, event)}
-  end
-
-  def handle_info({:agent_stream_start, agent_name, _payload}, socket) do
-    streaming = Map.put(socket.assigns.streaming_agents, agent_name, "")
-    {:noreply, assign(socket, streaming_agents: streaming)}
-  end
-
-  def handle_info({:agent_stream_delta, agent_name, %{text: chunk}}, socket) do
-    streaming =
-      Map.update(
-        socket.assigns.streaming_agents,
-        agent_name,
-        chunk,
-        &(&1 <> chunk)
-      )
-
-    {:noreply, assign(socket, streaming_agents: streaming)}
-  end
-
-  def handle_info({:agent_stream_end, agent_name, _payload}, socket) do
-    text = Map.get(socket.assigns.streaming_agents, agent_name, "")
-    streaming = Map.delete(socket.assigns.streaming_agents, agent_name)
-
-    socket = assign(socket, streaming_agents: streaming)
-
-    if String.length(text) > 0 do
-      event = build_event(:thinking, agent_name, text)
-      {:noreply, append_event(socket, event)}
-    else
-      {:noreply, socket}
-    end
-  end
-
-  def handle_info(_msg, socket) do
-    {:noreply, socket}
+    {:ok, socket}
   end
 
   # --- UI Event Handlers ---
@@ -232,25 +135,6 @@ defmodule LoomkinWeb.TeamActivityComponent do
         </button>
       </div>
 
-      <!-- Active Streams -->
-      <div
-        :for={{agent_name, text} <- @streaming_agents}
-        :if={text != ""}
-        class="px-2 py-1.5 bg-indigo-900/20 border-b border-indigo-500/10 animate-fade-in"
-      >
-        <div class="flex items-center gap-2">
-          <span
-            class="w-2 h-2 rounded-full flex-shrink-0 animate-pulse"
-            style={"background-color: #{agent_color(agent_name)}"}
-          ></span>
-          <span class="text-xs font-medium text-indigo-300">{agent_name}</span>
-          <span class="text-xs text-indigo-400/60">thinking...</span>
-        </div>
-        <p class="text-xs text-gray-400 mt-1 truncate max-w-full">
-          {String.slice(text, -120, 120)}
-        </p>
-      </div>
-
       <!-- Event Feed -->
       <div class="flex-1 overflow-auto" id={"activity-feed-#{@id}"} phx-hook="ScrollToBottom">
         <div class="flex flex-col gap-0.5 p-2">
@@ -304,37 +188,6 @@ defmodule LoomkinWeb.TeamActivityComponent do
   end
 
   # --- Helpers ---
-
-  defp build_event(type, agent_name, content) do
-    %{
-      id: Ecto.UUID.generate(),
-      type: type,
-      agent: agent_name,
-      content: content,
-      timestamp: DateTime.utc_now(),
-      expanded: false
-    }
-  end
-
-  defp append_event(socket, event) do
-    events = socket.assigns.events ++ [event]
-
-    events =
-      if length(events) > @max_events do
-        Enum.drop(events, length(events) - @max_events)
-      else
-        events
-      end
-
-    known_agents =
-      if event.agent in socket.assigns.known_agents do
-        socket.assigns.known_agents
-      else
-        socket.assigns.known_agents ++ [event.agent]
-      end
-
-    assign(socket, events: events, known_agents: known_agents)
-  end
 
   defp filtered_events(assigns) do
     events = assigns.events

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -33,7 +33,9 @@ defmodule LoomkinWeb.WorkspaceLive do
         streaming_content: "",
         architect_phase: nil,
         plan_steps: [],
-        current_step: nil
+        current_step: nil,
+        activity_events: [],
+        activity_known_agents: []
       )
 
     case socket.assigns.live_action do
@@ -165,8 +167,11 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, assign(socket, selected_file: nil, file_content: nil)}
   end
 
-
-  def handle_event("permission_response", %{"action" => action, "tool_name" => tool_name, "tool_path" => tool_path}, socket) do
+  def handle_event(
+        "permission_response",
+        %{"action" => action, "tool_name" => tool_name, "tool_path" => tool_path},
+        socket
+      ) do
     route_permission_response(socket, action, tool_name, tool_path)
     {:noreply, assign(socket, permission_request: nil)}
   end
@@ -218,13 +223,24 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, assign(socket, status: status)}
   end
 
-  def handle_info({:tool_executing, _source, %{tool_name: name, tool_target: target}}, socket) do
+  def handle_info({:tool_executing, _source, %{tool_name: name, tool_target: target}} = event, socket) do
     display = if target && target != "*", do: "#{name}: #{target}", else: name
-    {:noreply, assign(socket, current_tool: display, current_tool_name: name)}
+
+    socket =
+      socket
+      |> forward_to_activity(event)
+      |> assign(current_tool: display, current_tool_name: name)
+
+    {:noreply, socket}
   end
 
-  def handle_info({:tool_executing, _source, %{tool_name: name}}, socket) do
-    {:noreply, assign(socket, current_tool: name, current_tool_name: name)}
+  def handle_info({:tool_executing, _source, %{tool_name: name}} = event, socket) do
+    socket =
+      socket
+      |> forward_to_activity(event)
+      |> assign(current_tool: name, current_tool_name: name)
+
+    {:noreply, socket}
   end
 
   def handle_info({:tool_executing, _source, tool_name}, socket) when is_binary(tool_name) do
@@ -232,8 +248,13 @@ defmodule LoomkinWeb.WorkspaceLive do
   end
 
   # Team agent tool_complete (3-element tuple)
-  def handle_info({:tool_complete, _agent_name, %{tool_name: _name}}, socket) do
-    {:noreply, assign(socket, current_tool: nil)}
+  def handle_info({:tool_complete, _agent_name, %{tool_name: _name}} = event, socket) do
+    socket =
+      socket
+      |> forward_to_activity(event)
+      |> assign(current_tool: nil)
+
+    {:noreply, socket}
   end
 
   # Session tool_complete (4-element tuple with result)
@@ -267,12 +288,18 @@ defmodule LoomkinWeb.WorkspaceLive do
 
   # 5-tuple with source tag (from architect :session or {:agent, team_id, name})
   def handle_info({:permission_request, _id, tool_name, tool_path, source}, socket) do
-    {:noreply, assign(socket, permission_request: %{tool_name: tool_name, tool_path: tool_path, source: source})}
+    {:noreply,
+     assign(socket,
+       permission_request: %{tool_name: tool_name, tool_path: tool_path, source: source}
+     )}
   end
 
   # 4-tuple backwards compat (default to :session source)
   def handle_info({:permission_request, _session_id, tool_name, tool_path}, socket) do
-    {:noreply, assign(socket, permission_request: %{tool_name: tool_name, tool_path: tool_path, source: :session})}
+    {:noreply,
+     assign(socket,
+       permission_request: %{tool_name: tool_name, tool_path: tool_path, source: :session}
+     )}
   end
 
   def handle_info({:team_available, _session_id, team_id}, socket) do
@@ -376,20 +403,20 @@ defmodule LoomkinWeb.WorkspaceLive do
   end
 
   # Team PubSub events -- forward to team components via send_update
-  def handle_info({:agent_status, _agent_name, _status}, socket) do
+  def handle_info({:agent_status, _agent_name, _status} = event, socket) do
     forward_to_team_components(socket)
-    {:noreply, socket}
+    {:noreply, forward_to_activity(socket, event)}
   end
 
-  def handle_info({:task_assigned, _task_id, _agent_name}, socket) do
+  def handle_info({:task_assigned, _task_id, _agent_name} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, socket}
+    {:noreply, forward_to_activity(socket, event)}
   end
 
-  def handle_info({:task_completed, _task_id, _agent_name, _result}, socket) do
+  def handle_info({:task_completed, _task_id, _agent_name, _result} = event, socket) do
     forward_to_dashboard(socket)
     forward_to_cost(socket)
-    {:noreply, socket}
+    {:noreply, forward_to_activity(socket, event)}
   end
 
   def handle_info({:task_started, _task_id, _owner}, socket) do
@@ -418,7 +445,7 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, socket}
   end
 
-  # Agent streaming events — handled by TeamActivityComponent via its own PubSub subscription
+  # Agent streaming events — buffered for activity feed
   def handle_info({:agent_stream_start, _agent_name, _payload}, socket) do
     {:noreply, socket}
   end
@@ -427,8 +454,8 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, socket}
   end
 
-  def handle_info({:agent_stream_end, _agent_name, _payload}, socket) do
-    {:noreply, socket}
+  def handle_info({:agent_stream_end, _agent_name, _payload} = event, socket) do
+    {:noreply, forward_to_activity(socket, event)}
   end
 
   def handle_info({:child_team_created, child_team_id}, socket) do
@@ -446,7 +473,8 @@ defmodule LoomkinWeb.WorkspaceLive do
 
   def handle_info({:team_dissolved, team_id}, socket) do
     if team_id == socket.assigns.team_id do
-      {:noreply, assign(socket, team_id: nil, child_teams: [], active_team_id: nil, active_tab: :files)}
+      {:noreply,
+       assign(socket, team_id: nil, child_teams: [], active_team_id: nil, active_tab: :files)}
     else
       child_teams = List.delete(socket.assigns.child_teams, team_id)
 
@@ -488,7 +516,10 @@ defmodule LoomkinWeb.WorkspaceLive do
           |> put_flash(:error, format_llm_error(reason))
 
         other ->
-          Logger.warning("[WorkspaceLive] Async task returned unexpected result: #{inspect(other)}")
+          Logger.warning(
+            "[WorkspaceLive] Async task returned unexpected result: #{inspect(other)}"
+          )
+
           socket
       end
 
@@ -501,6 +532,19 @@ defmodule LoomkinWeb.WorkspaceLive do
     end
 
     {:noreply, assign(socket, async_task: nil)}
+  end
+
+  # Team decision and context events — buffer for activity feed
+  def handle_info({:decision_logged, _node_id, _agent_name} = event, socket) do
+    {:noreply, forward_to_activity(socket, event)}
+  end
+
+  def handle_info({:context_update, _from_agent, _payload} = event, socket) do
+    {:noreply, forward_to_activity(socket, event)}
+  end
+
+  def handle_info({:context_offloaded, _agent_name, _payload} = event, socket) do
+    {:noreply, forward_to_activity(socket, event)}
   end
 
   # Catch-all for unhandled PubSub messages (team events, etc.)
@@ -528,14 +572,14 @@ defmodule LoomkinWeb.WorkspaceLive do
           <%!-- Branding --%>
           <div class="flex items-center gap-2">
             <svg class="w-7 h-7" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <polygon points="10,2 6,10 15,7" fill="#5B21B6"/>
-              <polygon points="22,2 26,10 17,7" fill="#5B21B6"/>
-              <polygon points="6,10 4,20 12,15" fill="#4B0082"/>
-              <polygon points="26,10 28,20 20,15" fill="#4B0082"/>
-              <polygon points="12,15 16,7 20,15" fill="#7C3AED"/>
-              <polygon points="12,15 16,24 20,15" fill="#4B0082"/>
-              <circle cx="12" cy="14" r="3" fill="#F59E0B"/>
-              <circle cx="20" cy="14" r="3" fill="#F59E0B"/>
+              <polygon points="10,2 6,10 15,7" fill="#5B21B6" />
+              <polygon points="22,2 26,10 17,7" fill="#5B21B6" />
+              <polygon points="6,10 4,20 12,15" fill="#4B0082" />
+              <polygon points="26,10 28,20 20,15" fill="#4B0082" />
+              <polygon points="12,15 16,7 20,15" fill="#7C3AED" />
+              <polygon points="12,15 16,24 20,15" fill="#4B0082" />
+              <circle cx="12" cy="14" r="3" fill="#F59E0B" />
+              <circle cx="20" cy="14" r="3" fill="#F59E0B" />
             </svg>
             <span class="text-xl font-bold bg-gradient-to-r from-violet-400 to-purple-400 bg-clip-text text-transparent tracking-tight">
               Loomkin
@@ -543,7 +587,11 @@ defmodule LoomkinWeb.WorkspaceLive do
           </div>
 
           <%!-- Model selector --%>
-          <.live_component module={LoomkinWeb.ModelSelectorComponent} id="model-selector" model={@model} />
+          <.live_component
+            module={LoomkinWeb.ModelSelectorComponent}
+            id="model-selector"
+            model={@model}
+          />
         </div>
 
         <div class="flex items-center gap-3">
@@ -552,13 +600,22 @@ defmodule LoomkinWeb.WorkspaceLive do
             href="/dashboard"
             class="flex items-center gap-1.5 bg-gray-800/60 hover:bg-gray-800 rounded-full px-3 py-1.5 transition-colors group"
           >
-            <.icon name="hero-sparkles-mini" class="w-3.5 h-3.5 text-violet-400 group-hover:text-violet-300" />
+            <.icon
+              name="hero-sparkles-mini"
+              class="w-3.5 h-3.5 text-violet-400 group-hover:text-violet-300"
+            />
             <span class="text-xs font-mono text-gray-300">${format_cost(@session_cost)}</span>
-            <span class="text-[10px] text-gray-500 font-mono">{format_tokens(@session_tokens)} tok</span>
+            <span class="text-[10px] text-gray-500 font-mono">
+              {format_tokens(@session_tokens)} tok
+            </span>
           </a>
 
           <%!-- Session switcher --%>
-          <.live_component module={LoomkinWeb.SessionSwitcherComponent} id="session-switcher" session_id={@session_id} />
+          <.live_component
+            module={LoomkinWeb.SessionSwitcherComponent}
+            id="session-switcher"
+            session_id={@session_id}
+          />
 
           <%!-- Status indicator --%>
           <div class={"flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-300 " <> status_pill_class(@status)}>
@@ -605,8 +662,18 @@ defmodule LoomkinWeb.WorkspaceLive do
                   if(@status == :idle, do: "bg-violet-600 hover:bg-violet-500 text-white send-btn-ready", else: "bg-gray-800 text-gray-600 cursor-not-allowed")}
                 disabled={@status != :idle}
               >
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
+                <svg
+                  class="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+                  />
                 </svg>
               </button>
               <button
@@ -621,7 +688,9 @@ defmodule LoomkinWeb.WorkspaceLive do
               </button>
             </div>
             <p class="text-[10px] text-gray-600 mt-1.5 pl-1">
-              <kbd class="px-1 py-0.5 bg-gray-800/60 rounded text-gray-500 font-mono text-[9px]">Shift+Enter</kbd>
+              <kbd class="px-1 py-0.5 bg-gray-800/60 rounded text-gray-500 font-mono text-[9px]">
+                Shift+Enter
+              </kbd>
               for new line
             </p>
           </form>
@@ -646,7 +715,11 @@ defmodule LoomkinWeb.WorkspaceLive do
           </div>
 
           <%!-- Sidebar content with transition --%>
-          <div class="flex-1 overflow-auto p-4 tab-content-enter" phx-hook="TabTransition" id={"tab-content-#{@active_tab}"}>
+          <div
+            class="flex-1 overflow-auto p-4 tab-content-enter"
+            phx-hook="TabTransition"
+            id={"tab-content-#{@active_tab}"}
+          >
             {render_tab(@active_tab, assigns)}
           </div>
         </div>
@@ -673,11 +746,20 @@ defmodule LoomkinWeb.WorkspaceLive do
   defp status_label(:executing_tool, tool_name), do: tool_name
   defp status_label(status, _tool), do: to_string(status)
 
-  defp tab_icon(:files), do: raw("<span class=\"hero-folder-mini inline-block w-3.5 h-3.5\"></span>")
-  defp tab_icon(:diff), do: raw("<span class=\"hero-code-bracket-mini inline-block w-3.5 h-3.5\"></span>")
-  defp tab_icon(:terminal), do: raw("<span class=\"hero-command-line-mini inline-block w-3.5 h-3.5\"></span>")
-  defp tab_icon(:graph), do: raw("<span class=\"hero-share-mini inline-block w-3.5 h-3.5\"></span>")
-  defp tab_icon(:team), do: raw("<span class=\"hero-user-group-mini inline-block w-3.5 h-3.5\"></span>")
+  defp tab_icon(:files),
+    do: raw("<span class=\"hero-folder-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:diff),
+    do: raw("<span class=\"hero-code-bracket-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:terminal),
+    do: raw("<span class=\"hero-command-line-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:graph),
+    do: raw("<span class=\"hero-share-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:team),
+    do: raw("<span class=\"hero-user-group-mini inline-block w-3.5 h-3.5\"></span>")
 
   defp tab_label(:files), do: "Files"
   defp tab_label(:diff), do: "Diff"
@@ -753,7 +835,10 @@ defmodule LoomkinWeb.WorkspaceLive do
     ~H"""
     <div class="flex flex-col h-full gap-3">
       <%!-- Team switcher (visible when child teams exist) --%>
-      <div :if={@child_teams != []} class="flex items-center gap-1 flex-wrap border-b border-gray-800 pb-2">
+      <div
+        :if={@child_teams != []}
+        class="flex items-center gap-1 flex-wrap border-b border-gray-800 pb-2"
+      >
         <button
           phx-click="switch_team"
           phx-value-team-id={@team_id}
@@ -797,7 +882,19 @@ defmodule LoomkinWeb.WorkspaceLive do
         </button>
       </div>
 
-      <div class="flex-1 overflow-auto">
+      <%!-- Activity feed: always mounted, hidden when not selected --%>
+      <div class={if @team_sub_tab == :activity, do: "flex-1 overflow-auto", else: "hidden"}>
+        <.live_component
+          module={LoomkinWeb.TeamActivityComponent}
+          id="team-activity"
+          team_id={@display_team_id}
+          events={@activity_events}
+          known_agents={@activity_known_agents}
+        />
+      </div>
+
+      <%!-- Other sub-tab content --%>
+      <div :if={@team_sub_tab != :activity} class="flex-1 overflow-auto">
         {render_team_sub_tab(@team_sub_tab, assigns)}
       </div>
     </div>
@@ -807,16 +904,6 @@ defmodule LoomkinWeb.WorkspaceLive do
   defp team_sub_tab_label(:activity), do: "Activity"
   defp team_sub_tab_label(:cost), do: "Cost"
   defp team_sub_tab_label(:graph), do: "Graph"
-
-  defp render_team_sub_tab(:activity, assigns) do
-    ~H"""
-    <.live_component
-      module={LoomkinWeb.TeamActivityComponent}
-      id="team-activity"
-      team_id={@display_team_id}
-    />
-    """
-  end
 
   defp render_team_sub_tab(:cost, assigns) do
     ~H"""
@@ -856,21 +943,111 @@ defmodule LoomkinWeb.WorkspaceLive do
     Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:tasks")
   end
 
+  @max_activity_events 200
+
+  defp forward_to_activity(socket, pubsub_event) do
+    case activity_event_from(pubsub_event) do
+      nil ->
+        socket
+
+      event ->
+        events = socket.assigns.activity_events ++ [event]
+
+        events =
+          if length(events) > @max_activity_events,
+            do: Enum.drop(events, length(events) - @max_activity_events),
+            else: events
+
+        agents = socket.assigns.activity_known_agents
+        agents = if event.agent in agents, do: agents, else: agents ++ [event.agent]
+
+        assign(socket, activity_events: events, activity_known_agents: agents)
+    end
+  end
+
+  defp activity_event_from({:tool_executing, agent, %{tool_name: name, tool_target: target}}) do
+    display = if target && target != "*", do: "#{name} on #{target}", else: name
+    %{id: Ecto.UUID.generate(), type: :tool_call, agent: agent, content: "used #{display}", timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:tool_complete, agent, %{tool_name: name, result: result}}) do
+    truncated = String.slice(to_string(result), 0, 200)
+    %{id: Ecto.UUID.generate(), type: :tool_call, agent: agent, content: "#{name} done: #{truncated}", timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:agent_status, agent, status}) do
+    {type, content} =
+      case status do
+        :idle -> {:message, "is now idle"}
+        :working -> {:message, "started working"}
+        :blocked -> {:message, "is blocked"}
+        :error -> {:error, "encountered an error"}
+        _ -> {:message, "status: #{status}"}
+      end
+
+    %{id: Ecto.UUID.generate(), type: type, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:task_assigned, task_id, agent}) do
+    %{id: Ecto.UUID.generate(), type: :task_assigned, agent: agent, content: "picked up task #{task_id}", timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:task_completed, task_id, agent, result}) do
+    content =
+      case result do
+        r when is_binary(r) -> "completed task #{task_id}: #{String.slice(r, 0, 200)}"
+        _ -> "completed task #{task_id}"
+      end
+
+    %{id: Ecto.UUID.generate(), type: :task_complete, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:decision_logged, node_id, agent}) do
+    %{id: Ecto.UUID.generate(), type: :decision, agent: agent, content: "logged decision #{node_id}", timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:context_update, agent, payload}) do
+    content =
+      case payload do
+        %{type: :discovery, content: c} -> c
+        %{content: c} -> c
+        _ -> inspect(payload)
+      end
+
+    %{id: Ecto.UUID.generate(), type: :discovery, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:context_offloaded, agent, _payload}) do
+    %{id: Ecto.UUID.generate(), type: :discovery, agent: agent, content: "offloaded context to keeper", timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from({:agent_stream_end, agent, _payload}) do
+    %{id: Ecto.UUID.generate(), type: :thinking, agent: agent, content: "finished thinking", timestamp: DateTime.utc_now(), expanded: false}
+  end
+
+  defp activity_event_from(_), do: nil
+
   defp forward_to_team_components(socket) do
     forward_to_dashboard(socket)
-    tid = socket.assigns[:active_team_id] || socket.assigns[:team_id]
-    if tid, do: send_update(LoomkinWeb.TeamActivityComponent, id: "team-activity", team_id: tid)
   end
 
   defp forward_to_dashboard(socket) do
     tid = socket.assigns[:active_team_id] || socket.assigns[:team_id]
-    if tid, do: send_update(LoomkinWeb.TeamDashboardComponent, id: "team-dashboard", team_id: tid)
+
+    if tid && team_tab_visible?(socket) do
+      send_update(LoomkinWeb.TeamDashboardComponent, id: "team-dashboard", team_id: tid)
+    end
   end
 
   defp forward_to_cost(socket) do
     tid = socket.assigns[:active_team_id] || socket.assigns[:team_id]
-    if tid, do: send_update(LoomkinWeb.TeamCostComponent, id: "team-cost", team_id: tid)
+
+    if tid && team_tab_visible?(socket) && socket.assigns[:team_sub_tab] == :cost do
+      send_update(LoomkinWeb.TeamCostComponent, id: "team-cost", team_id: tid)
+    end
   end
+
+  defp team_tab_visible?(socket), do: socket.assigns[:active_tab] == :team
 
   defp short_team_id(id) when is_binary(id), do: String.slice(id, 0, 8)
   defp short_team_id(_), do: "?"

--- a/test/loomkin/agent_loop_test.exs
+++ b/test/loomkin/agent_loop_test.exs
@@ -45,17 +45,6 @@ defmodule Loomkin.AgentLoopTest do
     end
   end
 
-  describe "run/2 with max_iterations" do
-    test "respects max_iterations of 0" do
-      # max_iterations=0 means the loop exits immediately
-      result =
-        AgentLoop.run([], model: "test:model", system_prompt: "test", max_iterations: 0)
-
-      assert {:error, msg, []} = result
-      assert msg =~ "Maximum tool call iterations (0) exceeded"
-    end
-  end
-
   describe "run/2 with LLM error (no API key)" do
     test "returns error when LLM call fails" do
       messages = [%{role: :user, content: "Hello"}]
@@ -183,7 +172,7 @@ defmodule Loomkin.AgentLoopTest do
       result = AgentLoop.default_run_tool(Loomkin.Tools.FileRead, string_keyed_args, context)
 
       assert is_binary(result)
-      assert result =~ "Error:"
+      assert result =~ "outside the project directory"
     end
   end
 

--- a/test/loomkin/teams/role_test.exs
+++ b/test/loomkin/teams/role_test.exs
@@ -169,25 +169,6 @@ defmodule Loomkin.Teams.RoleTest do
     end
   end
 
-  describe "max_iterations" do
-    test "each role has the expected iteration limits" do
-      {:ok, lead} = Role.get(:lead)
-      assert lead.max_iterations == 25
-
-      {:ok, researcher} = Role.get(:researcher)
-      assert researcher.max_iterations == 15
-
-      {:ok, coder} = Role.get(:coder)
-      assert coder.max_iterations == 25
-
-      {:ok, reviewer} = Role.get(:reviewer)
-      assert reviewer.max_iterations == 10
-
-      {:ok, tester} = Role.get(:tester)
-      assert tester.max_iterations == 15
-    end
-  end
-
   describe "uniform model default" do
     test "all built-in roles use :default model_tier" do
       for role_name <- Role.built_in_roles() do
@@ -202,7 +183,6 @@ defmodule Loomkin.Teams.RoleTest do
     test "creates a custom role from a config map" do
       config = %{
         model_tier: :expert,
-        max_iterations: 20,
         system_prompt: "You are a custom agent.",
         budget_limit: 5.0
       }
@@ -211,21 +191,18 @@ defmodule Loomkin.Teams.RoleTest do
 
       assert role.name == :custom_role
       assert role.model_tier == :expert
-      assert role.max_iterations == 20
       assert role.system_prompt == "You are a custom agent."
       assert role.budget_limit == 5.0
     end
 
     test "overrides a built-in role with config values" do
       config = %{
-        max_iterations: 50,
         budget_limit: 10.0
       }
 
       role = Role.from_config(:coder, config)
 
       assert role.name == :coder
-      assert role.max_iterations == 50
       assert role.budget_limit == 10.0
       # Preserves defaults not overridden
       assert role.model_tier == :default
@@ -235,14 +212,12 @@ defmodule Loomkin.Teams.RoleTest do
     test "accepts string keys in config map" do
       config = %{
         "model_tier" => :grunt,
-        "max_iterations" => 5,
         "system_prompt" => "String key prompt."
       }
 
       role = Role.from_config(:custom, config)
 
       assert role.model_tier == :grunt
-      assert role.max_iterations == 5
       assert role.system_prompt == "String key prompt."
     end
 


### PR DESCRIPTION
## Summary

Three related fixes surfaced during a team session where the Researcher agent hit its 15-tool-call cap while the UI showed nothing useful:

- **Remove `max_iterations` cap** — Budget and cost tracking are the natural limiters. Agents no longer die mid-work at arbitrary tool-call counts. Removed from `AgentLoop`, `Role`, and `Agent`. SubAgent keeps its own bounded `@max_iterations 10`.

- **Add out-of-project file read permission boundary** — `safe_path!` hard-blocks external reads with no chance for user consent. Now `Manager.check/4` resolves paths, detects out-of-project reads, and returns `:ask` so the permission UI can prompt. Grants are scoped to exact resolved paths (not wildcard).

- **Fix team activity feed (3 layers of breakage)**:
  1. Event name mismatch — component listened for `:tool_call`, agents broadcast `:tool_executing`
  2. LiveComponent `handle_info` was dead code — LiveComponents share the parent process, so PubSub went to `workspace_live` and the component's handlers never fired
  3. Component only mounted when Team > Activity sub-tab was visible — events lost on any other tab. Now events are buffered in `workspace_live` assigns and the component is always mounted when the team tab is open.

## Files changed

| File | Change |
|------|--------|
| `agent_loop.ex` | Remove `max_iterations`, `force_finalize`, iteration guard messages; tag external paths in context |
| `role.ex` | Remove `max_iterations` from struct, type, all 5 built-in roles, `from_config` |
| `agent.ex` | Remove `max_iterations` from loop opts; fix permission callback to use `check/4` with project_path; scope `allow_always` grants to actual path |
| `tool.ex` | Add `resolve_path/2` and `outside_project?/2` |
| `manager.ex` | Add boundary-aware `check/4`; add directory-prefix grant matching |
| `file_read.ex` | Bypass `safe_path!` for permitted external reads via `allowed_external_path` context |
| `team_activity_component.ex` | Rewrite — pure renderer receiving events from parent assigns, no dead `handle_info` |
| `workspace_live.ex` | Buffer events in `activity_events` assigns; process PubSub tuples into display events; always render activity component in team tab |
| Tests | Remove `max_iterations` test blocks, update `from_config` assertions |

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — 926 tests, 0 failures
- [ ] Manual: start team session, confirm activity feed shows tool calls with agent names in real-time
- [ ] Manual: switch away from Activity sub-tab and back — events should persist
- [ ] Manual: agent reads file outside project → permission prompt appears with absolute path

🤖 Generated with [Claude Code](https://claude.com/claude-code)