### PR TITLE
feat: Mission Control UI — team-first interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Loomkin
 
+[![Discord](https://img.shields.io/discord/1234567890?color=5865F2&logo=discord&logoColor=white&label=Discord)](https://discord.gg/WUVneqArVD)
+
 **The AI coding assistant with a nervous system.**
 
 Every session is a team. One agent or twenty — the architecture is the same. Context is never lost. Agents communicate in microseconds. Cheap models in swarms outperform expensive models solo.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -304,3 +304,86 @@ body {
 .chat-markdown tr:hover td {
   background: rgba(139, 92, 246, 0.03);
 }
+
+/* ══════════════════════════════════════════
+   Mission Control Animations
+   ══════════════════════════════════════════ */
+
+/* ── Mode Transition (panel slide-in/out) ── */
+.mc-panel-enter {
+  animation: slideInLeft 0.3s ease-out;
+}
+.mc-panel-exit {
+  animation: slideOutLeft 0.3s ease-in;
+}
+@keyframes slideInLeft {
+  from { transform: translateX(-100%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+@keyframes slideOutLeft {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(-100%); opacity: 0; }
+}
+
+/* ── Activity Feed Event Entrance ── */
+.activity-event-enter {
+  animation: fadeInUp 0.2s ease-out;
+}
+
+/* ── Streaming Card (pulsing border + typing cursor) ── */
+.streaming-card {
+  border-color: rgba(139, 92, 246, 0.5);
+  animation: pulse-border 2s ease-in-out infinite;
+}
+@keyframes pulse-border {
+  0%, 100% { border-color: rgba(139, 92, 246, 0.3); }
+  50% { border-color: rgba(139, 92, 246, 0.7); }
+}
+
+.streaming-cursor::after {
+  content: "\2588";
+  animation: blink-cursor 0.8s step-end infinite;
+  color: #a78bfa;
+}
+@keyframes blink-cursor {
+  50% { opacity: 0; }
+}
+
+/* ── Agent Status Dots ── */
+.agent-dot-working {
+  animation: pulse-dot 1.5s ease-in-out infinite;
+}
+@keyframes pulse-dot {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.7); }
+  50% { box-shadow: 0 0 0 4px rgba(74, 222, 128, 0); }
+}
+
+.agent-dot-error {
+  animation: flash-dot 0.5s ease-in-out 3;
+}
+@keyframes flash-dot {
+  50% { opacity: 0.3; }
+}
+
+.agent-dot-thinking {
+  animation: pulse-soft 2s ease-in-out infinite;
+}
+
+/* ── Inspector Collapse Transition ── */
+.inspector-panel {
+  transition: width 0.3s ease, opacity 0.2s ease;
+}
+.inspector-collapsed {
+  width: 2.5rem;
+  overflow: hidden;
+}
+
+/* ── Event Card Type Borders ── */
+.event-card-tool { border-left: 2px solid #818cf8; }
+.event-card-message { border-left: 2px solid #9ca3af; }
+.event-card-task { border-left: 2px solid #22d3ee; }
+.event-card-discovery { border-left: 2px solid #fbbf24; }
+.event-card-error { border-left: 2px solid #f87171; }
+.event-card-spawn { border-left: 2px solid #4ade80; }
+.event-card-context { border-left: 2px solid #a78bfa; }
+.event-card-streaming { border-left: 2px solid #818cf8; animation: pulse-border 2s infinite; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -143,6 +143,51 @@ Hooks.CopyToClipboard = {
   }
 }
 
+// KeyboardShortcuts: mission control keyboard shortcuts (Cmd+M, Cmd+., arrows, etc.)
+Hooks.KeyboardShortcuts = {
+  mounted() {
+    this.handleKeydown = (e) => {
+      // Don't fire in input/textarea unless Esc
+      const isInput = e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA'
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        this.pushEvent('keyboard_shortcut', { key: 'escape' })
+        return
+      }
+
+      if (isInput) return
+
+      const mod = e.metaKey || e.ctrlKey
+
+      if (mod && e.key === 'm') {
+        e.preventDefault()
+        this.pushEvent('keyboard_shortcut', { key: 'toggle_mode' })
+      } else if (mod && e.key === '.') {
+        e.preventDefault()
+        this.pushEvent('keyboard_shortcut', { key: 'cancel' })
+      } else if (mod && e.key >= '1' && e.key <= '3') {
+        e.preventDefault()
+        this.pushEvent('keyboard_shortcut', { key: `focus_panel_${e.key}` })
+      } else if (e.key === '/' && !mod) {
+        e.preventDefault()
+        this.pushEvent('keyboard_shortcut', { key: 'focus_input' })
+      } else if (e.key === 'ArrowLeft' && !mod) {
+        e.preventDefault()
+        this.pushEvent('keyboard_shortcut', { key: 'prev_agent' })
+      } else if (e.key === 'ArrowRight' && !mod) {
+        e.preventDefault()
+        this.pushEvent('keyboard_shortcut', { key: 'next_agent' })
+      }
+    }
+
+    document.addEventListener('keydown', this.handleKeydown)
+  },
+  destroyed() {
+    document.removeEventListener('keydown', this.handleKeydown)
+  }
+}
+
 // AutoResizeTextarea: auto-grows textarea as user types
 Hooks.AutoResizeTextarea = {
   mounted() {

--- a/lib/loomkin/llm_retry.ex
+++ b/lib/loomkin/llm_retry.ex
@@ -64,6 +64,17 @@ defmodule Loomkin.LLMRetry do
       is_binary(reason) ->
         transient_string?(reason)
 
+      is_struct(reason) ->
+        status = Map.get(reason, :status)
+        message = Map.get(reason, :reason) || Map.get(reason, :message) || ""
+
+        cond do
+          status in [429, 500, 502, 503, 504, 529] -> true
+          status in [400, 401, 403, 404] -> false
+          is_binary(message) -> transient_string?(message)
+          true -> false
+        end
+
       is_map(reason) ->
         status = reason[:status] || reason["status"]
         message = reason[:reason] || reason[:message] || reason["message"] || ""

--- a/lib/loomkin_web/live/agent_roster_component.ex
+++ b/lib/loomkin_web/live/agent_roster_component.ex
@@ -1,0 +1,253 @@
+defmodule LoomkinWeb.AgentRosterComponent do
+  @moduledoc """
+  Left-panel sidebar for mission control mode.
+
+  Displays agent roster with status indicators, task summary, and budget bar.
+  Communicates focus/unpin actions to the parent LiveView via `send(self(), msg)`.
+  """
+
+  use LoomkinWeb, :live_component
+
+  @agent_colors [
+    "#818cf8",
+    "#34d399",
+    "#f472b6",
+    "#fb923c",
+    "#22d3ee",
+    "#a78bfa",
+    "#fbbf24",
+    "#4ade80"
+  ]
+
+  @impl true
+  def mount(socket) do
+    {:ok, assign(socket, tasks_collapsed: false)}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
+  @impl true
+  def handle_event("focus_agent", %{"agent" => agent_name}, socket) do
+    if socket.assigns[:focused_agent] == agent_name do
+      send(self(), {:unpin_agent})
+    else
+      send(self(), {:focus_agent, agent_name})
+    end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("toggle_tasks", _params, socket) do
+    {:noreply, assign(socket, tasks_collapsed: !socket.assigns.tasks_collapsed)}
+  end
+
+  # --- Render ---
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col h-full w-56 bg-gray-950 border-r border-gray-800">
+      <%!-- Team Header --%>
+      <div class="px-3 py-3 border-b border-gray-800 flex items-center justify-between">
+        <span class="text-sm font-semibold text-violet-400 truncate">{@team_id}</span>
+        <span class="text-xs bg-gray-800 text-gray-400 px-1.5 py-0.5 rounded-full font-mono">
+          {length(@agents)}
+        </span>
+      </div>
+
+      <%!-- Agents Section --%>
+      <div class="flex-1 overflow-y-auto">
+        <div class="px-3 py-2">
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Agents</h3>
+        </div>
+
+        <div :if={@agents == []} class="px-3 py-4 text-center text-xs text-gray-600">
+          No agents spawned
+        </div>
+
+        <div class="space-y-0.5 px-1.5">
+          <button
+            :for={agent <- @agents}
+            phx-click="focus_agent"
+            phx-value-agent={agent.name}
+            phx-target={@myself}
+            class={"w-full text-left px-2 py-2 rounded-md transition cursor-pointer hover:bg-gray-900 #{if @focused_agent == agent.name, do: "bg-gray-900 border border-violet-500/50", else: "border border-transparent"}"}
+          >
+            <%!-- Row 1: status dot + name + role badge --%>
+            <div class="flex items-center gap-2">
+              <span class={"w-2 h-2 rounded-full flex-shrink-0 #{status_dot_class(agent.status)}"}></span>
+              <span
+                class="text-sm font-medium truncate flex-1"
+                style={"color: #{agent_color(agent.name)}"}
+              >
+                {agent.name}
+              </span>
+              <span class="text-xs bg-gray-800 text-gray-500 px-1.5 py-0.5 rounded font-medium">
+                {format_role(agent.role)}
+              </span>
+            </div>
+            <%!-- Row 2: current task --%>
+            <div class="mt-0.5 pl-4">
+              <span class={"text-xs #{status_text_color(agent.status)}"}>
+                {agent.current_task || status_label(agent.status)}
+              </span>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <%!-- Divider --%>
+      <div class="border-t border-gray-800"></div>
+
+      <%!-- Tasks Section (collapsible) --%>
+      <div class="flex-shrink-0">
+        <button
+          phx-click="toggle_tasks"
+          phx-target={@myself}
+          class="w-full flex items-center justify-between px-3 py-2 hover:bg-gray-900/50 transition cursor-pointer"
+        >
+          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Tasks</h3>
+          <span class={"text-xs text-gray-600 transition-transform #{if @tasks_collapsed, do: "-rotate-90", else: ""}"}>
+            {Phoenix.HTML.raw("&#9662;")}
+          </span>
+        </button>
+
+        <div :if={!@tasks_collapsed} class="max-h-48 overflow-y-auto">
+          <div :if={@tasks == []} class="px-3 py-3 text-center text-xs text-gray-600">
+            No tasks
+          </div>
+
+          <div class="space-y-0.5 px-1.5 pb-2">
+            <div
+              :for={task <- @tasks}
+              class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-900/50"
+            >
+              <span class="flex-shrink-0 w-4 text-center">{task_status_icon(task.status)}</span>
+              <span class="text-xs text-gray-300 truncate flex-1">{task.title}</span>
+              <span class="text-xs text-gray-600 truncate max-w-[4rem] text-right">
+                {task.owner || ""}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <%!-- Divider --%>
+      <div class="border-t border-gray-800"></div>
+
+      <%!-- Budget Bar --%>
+      <div class="flex-shrink-0 px-3 py-3">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="text-xs text-gray-500">Budget</span>
+          <span class="text-xs text-gray-400 font-mono">
+            ${format_decimal(@budget.spent)}&nbsp;/&nbsp;${format_decimal(@budget.limit)}
+            <span class={"ml-1 #{budget_pct_color(@budget)}"}>{budget_percentage(@budget)}%</span>
+          </span>
+        </div>
+        <div class="w-full bg-gray-800 rounded-full h-1.5">
+          <div
+            class={"h-1.5 rounded-full transition-all duration-300 #{budget_bar_color(@budget)}"}
+            style={"width: #{min(budget_percentage(@budget), 100)}%"}
+          >
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # --- Agent color hash ---
+
+  defp agent_color(name) do
+    index = :erlang.phash2(name, length(@agent_colors))
+    Enum.at(@agent_colors, index)
+  end
+
+  # --- Status helpers ---
+
+  defp status_dot_class(:working), do: "bg-green-400 animate-pulse"
+  defp status_dot_class(:idle), do: "bg-gray-500"
+  defp status_dot_class(:blocked), do: "bg-yellow-400"
+  defp status_dot_class(:error), do: "bg-red-400 animate-pulse"
+  defp status_dot_class(:waiting_permission), do: "bg-amber-400"
+  defp status_dot_class(_), do: "bg-gray-500"
+
+  defp status_text_color(:working), do: "text-green-400"
+  defp status_text_color(:idle), do: "text-gray-500"
+  defp status_text_color(:blocked), do: "text-yellow-400"
+  defp status_text_color(:error), do: "text-red-400"
+  defp status_text_color(:waiting_permission), do: "text-amber-400"
+  defp status_text_color(_), do: "text-gray-500"
+
+  defp status_label(:working), do: "working"
+  defp status_label(:idle), do: "idle"
+  defp status_label(:blocked), do: "blocked"
+  defp status_label(:error), do: "error"
+  defp status_label(:waiting_permission), do: "awaiting"
+  defp status_label(_), do: "idle"
+
+  # --- Task status icons ---
+
+  defp task_status_icon(:completed),
+    do: Phoenix.HTML.raw(~s(<span class="text-green-400">&#10003;</span>))
+
+  defp task_status_icon(:in_progress),
+    do:
+      Phoenix.HTML.raw(
+        ~s(<span class="text-violet-400 animate-spin inline-block">&#9684;</span>)
+      )
+
+  defp task_status_icon(:assigned),
+    do: Phoenix.HTML.raw(~s(<span class="text-blue-400">&#8594;</span>))
+
+  defp task_status_icon(:pending),
+    do: Phoenix.HTML.raw(~s(<span class="text-gray-500">&#9675;</span>))
+
+  defp task_status_icon(:failed),
+    do: Phoenix.HTML.raw(~s(<span class="text-red-400">&#10007;</span>))
+
+  defp task_status_icon(_),
+    do: Phoenix.HTML.raw(~s(<span class="text-gray-600">&#8226;</span>))
+
+  # --- Budget helpers ---
+
+  defp budget_percentage(%{spent: spent, limit: limit}) when limit > 0 do
+    Float.round(spent / limit * 100, 1)
+  end
+
+  defp budget_percentage(_), do: 0.0
+
+  defp budget_bar_color(budget) do
+    pct = budget_percentage(budget)
+
+    cond do
+      pct >= 80 -> "bg-red-500"
+      pct >= 50 -> "bg-yellow-500"
+      true -> "bg-green-500"
+    end
+  end
+
+  defp budget_pct_color(budget) do
+    pct = budget_percentage(budget)
+
+    cond do
+      pct >= 80 -> "text-red-400"
+      pct >= 50 -> "text-yellow-400"
+      true -> "text-green-400"
+    end
+  end
+
+  # --- Formatting helpers ---
+
+  defp format_decimal(n) when is_number(n),
+    do: :erlang.float_to_binary(n / 1, decimals: 2)
+
+  defp format_decimal(_), do: "0.00"
+
+  defp format_role(role) when is_atom(role), do: role |> Atom.to_string() |> format_role()
+  defp format_role(role) when is_binary(role), do: String.slice(role, 0, 8)
+  defp format_role(_), do: "-"
+end

--- a/lib/loomkin_web/live/context_inspector_component.ex
+++ b/lib/loomkin_web/live/context_inspector_component.ex
@@ -1,0 +1,271 @@
+defmodule LoomkinWeb.ContextInspectorComponent do
+  @moduledoc """
+  Right-panel context inspector for Mission Control mode.
+
+  Hosts existing components (FileTree, Diff, Terminal, Graph, Chat) in a tabbed
+  layout with auto-follow and pin modes. Delegates all rendering to the child
+  components — does not rebuild any of them.
+  """
+
+  use LoomkinWeb, :live_component
+
+  @tabs [:files, :diff, :terminal, :graph, :chat]
+
+  @impl true
+  def mount(socket) do
+    {:ok, assign(socket, collapsed: false)}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
+  @impl true
+  def handle_event("switch_inspector_tab", %{"tab" => tab}, socket) do
+    send(self(), {:inspector_tab, String.to_existing_atom(tab)})
+    {:noreply, socket}
+  end
+
+  def handle_event("resume_follow", _params, socket) do
+    send(self(), {:resume_follow})
+    {:noreply, socket}
+  end
+
+  def handle_event("toggle_collapse", _params, socket) do
+    {:noreply, assign(socket, collapsed: !socket.assigns.collapsed)}
+  end
+
+  @impl true
+  def render(assigns) do
+    assigns = assign(assigns, :tabs, @tabs)
+
+    ~H"""
+    <div class={panel_class(@collapsed)}>
+      <%= if @collapsed do %>
+        <.collapsed_strip
+          tabs={@tabs}
+          active_inspector_tab={@active_inspector_tab}
+          myself={@myself}
+        />
+      <% else %>
+        <%!-- Header / Tab bar --%>
+        <div class="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/80 flex-shrink-0">
+          <button
+            :for={tab <- @tabs}
+            phx-click="switch_inspector_tab"
+            phx-value-tab={tab}
+            phx-target={@myself}
+            class={tab_button_class(@active_inspector_tab, tab)}
+          >
+            <span class="text-sm">{tab_icon(tab)}</span>
+            {tab_label(tab)}
+          </button>
+
+          <div class="ml-auto flex items-center gap-2">
+            <.follow_indicator
+              inspector_mode={@inspector_mode}
+              focused_agent={@focused_agent}
+              myself={@myself}
+            />
+            <button
+              phx-click="toggle_collapse"
+              phx-target={@myself}
+              class="text-gray-500 hover:text-gray-300 p-1 rounded hover:bg-gray-800/50 transition-colors"
+              title="Collapse panel"
+            >
+              <.icon name="hero-chevron-right-mini" class="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+
+        <%!-- Content area --%>
+        <div class="flex-1 overflow-auto">
+          {render_inspector_tab(@active_inspector_tab, assigns)}
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  # --- Collapsed strip (icon-only sidebar) ---
+
+  defp collapsed_strip(assigns) do
+    ~H"""
+    <div class="flex flex-col items-center py-2 gap-1 h-full">
+      <button
+        :for={tab <- @tabs}
+        phx-click="switch_inspector_tab"
+        phx-value-tab={tab}
+        phx-target={@myself}
+        class={collapsed_tab_class(@active_inspector_tab, tab)}
+        title={tab_label(tab)}
+      >
+        <span class="text-sm">{tab_icon(tab)}</span>
+      </button>
+
+      <div class="mt-auto">
+        <button
+          phx-click="toggle_collapse"
+          phx-target={@myself}
+          class="text-gray-500 hover:text-gray-300 p-1.5 rounded hover:bg-gray-800/50 transition-colors"
+          title="Expand panel"
+        >
+          <.icon name="hero-chevron-left-mini" class="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  # --- Follow mode indicator ---
+
+  defp follow_indicator(%{focused_agent: nil} = assigns), do: ~H""
+  defp follow_indicator(%{inspector_mode: :auto_follow} = assigns) do
+    ~H"""
+    <div class="flex items-center gap-1.5">
+      <span class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse"></span>
+      <span class="text-xs text-green-400 truncate max-w-[120px]">Following {@focused_agent}</span>
+    </div>
+    """
+  end
+  defp follow_indicator(%{inspector_mode: :pinned} = assigns) do
+    ~H"""
+    <div class="flex items-center gap-1.5">
+      <.icon name="hero-map-pin-mini" class="w-3 h-3 text-violet-400" />
+      <span class="text-xs text-violet-400 truncate max-w-[120px]">Pinned to {@focused_agent}</span>
+      <button
+        phx-click="resume_follow"
+        phx-target={@myself}
+        class="text-[10px] px-1.5 py-0.5 rounded bg-violet-600/20 text-violet-400 hover:bg-violet-600/30 transition-colors"
+      >
+        Resume
+      </button>
+    </div>
+    """
+  end
+  defp follow_indicator(assigns), do: ~H""
+
+  # --- Tab content delegation ---
+
+  defp render_inspector_tab(:files, assigns) do
+    ~H"""
+    <div class="flex flex-col h-full">
+      <div class={if @selected_file, do: "h-1/2 overflow-auto", else: "flex-1"}>
+        <.live_component
+          module={LoomkinWeb.FileTreeComponent}
+          id="inspector-files"
+          project_path={@project_path}
+          version={@file_tree_version}
+          selected={@selected_file}
+        />
+      </div>
+      <div :if={@selected_file} class="h-1/2 border-t border-gray-800 flex flex-col animate-fade-in">
+        <div class="flex items-center justify-between px-3 py-2 bg-gray-900/80 border-b border-gray-800">
+          <div class="flex items-center gap-2 truncate">
+            <.icon name="hero-document-text-mini" class="w-3.5 h-3.5 text-violet-400 flex-shrink-0" />
+            <span class="text-xs text-violet-400 font-mono truncate">{@selected_file}</span>
+          </div>
+        </div>
+        <pre class="flex-1 overflow-auto p-3 text-xs font-mono text-gray-300 whitespace-pre">{@file_content}</pre>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_inspector_tab(:diff, assigns) do
+    ~H"""
+    <.live_component
+      module={LoomkinWeb.DiffComponent}
+      id="inspector-diff"
+      diffs={@diffs}
+    />
+    """
+  end
+
+  defp render_inspector_tab(:terminal, assigns) do
+    ~H"""
+    <.live_component
+      module={LoomkinWeb.TerminalComponent}
+      id="inspector-terminal"
+      commands={@shell_commands}
+    />
+    """
+  end
+
+  defp render_inspector_tab(:graph, assigns) do
+    ~H"""
+    <.live_component
+      module={LoomkinWeb.DecisionGraphComponent}
+      id="inspector-graph"
+      session_id={@team_id}
+    />
+    """
+  end
+
+  defp render_inspector_tab(:chat, assigns) do
+    ~H"""
+    <.live_component
+      module={LoomkinWeb.ChatComponent}
+      id="inspector-chat"
+      messages={@messages}
+      status={@status}
+      current_tool={@current_tool}
+      streaming={@streaming}
+      streaming_content={@streaming_content}
+      architect_phase={@architect_phase}
+      plan_steps={@plan_steps}
+      current_step={@current_step}
+    />
+    """
+  end
+
+  # --- Styling helpers ---
+
+  defp panel_class(true = _collapsed),
+    do: "w-10 flex flex-col h-full bg-gray-900/50 border-l border-gray-800 transition-all duration-200"
+
+  defp panel_class(false = _collapsed),
+    do: "w-80 flex flex-col h-full bg-gray-900/50 border-l border-gray-800 transition-all duration-200"
+
+  defp tab_button_class(active, tab) do
+    base = "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 "
+
+    if active == tab do
+      base <> "bg-gray-800 text-violet-400"
+    else
+      base <> "text-gray-500 hover:text-gray-300 hover:bg-gray-800/40"
+    end
+  end
+
+  defp collapsed_tab_class(active, tab) do
+    base = "p-1.5 rounded-lg transition-all duration-200 "
+
+    if active == tab do
+      base <> "bg-gray-800 text-violet-400"
+    else
+      base <> "text-gray-500 hover:text-gray-300 hover:bg-gray-800/40"
+    end
+  end
+
+  defp tab_icon(:files),
+    do: raw("<span class=\"hero-folder-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:diff),
+    do: raw("<span class=\"hero-code-bracket-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:terminal),
+    do: raw("<span class=\"hero-command-line-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:graph),
+    do: raw("<span class=\"hero-share-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_icon(:chat),
+    do: raw("<span class=\"hero-chat-bubble-left-right-mini inline-block w-3.5 h-3.5\"></span>")
+
+  defp tab_label(:files), do: "Files"
+  defp tab_label(:diff), do: "Diff"
+  defp tab_label(:terminal), do: "Terminal"
+  defp tab_label(:graph), do: "Graph"
+  defp tab_label(:chat), do: "Chat"
+end

--- a/lib/loomkin_web/live/team_activity_component.ex
+++ b/lib/loomkin_web/live/team_activity_component.ex
@@ -1,6 +1,10 @@
 defmodule LoomkinWeb.TeamActivityComponent do
   @moduledoc """
-  Real-time activity feed for team agents.
+  Primary activity feed for Mission Control.
+
+  Renders a rich, full-width center panel of team events with distinct card
+  types for tool calls, inter-agent messages, task lifecycle, discoveries,
+  agent spawns, errors, streaming, context offloads, and Q&A.
 
   Events are buffered in the parent LiveView (workspace_live) and passed
   as assigns. This ensures events survive tab switches — the component
@@ -21,14 +25,22 @@ defmodule LoomkinWeb.TeamActivityComponent do
   ]
 
   @type_config %{
-    tool_call: %{label: "tool", bg: "bg-violet-400/20", text: "text-violet-400"},
-    message: %{label: "message", bg: "bg-gray-400/20", text: "text-gray-400"},
-    decision: %{label: "decision", bg: "bg-purple-400/20", text: "text-purple-400"},
-    task_complete: %{label: "done", bg: "bg-green-400/20", text: "text-green-400"},
-    task_assigned: %{label: "assigned", bg: "bg-cyan-400/20", text: "text-cyan-400"},
-    discovery: %{label: "discovery", bg: "bg-yellow-400/20", text: "text-yellow-400"},
-    error: %{label: "error", bg: "bg-red-400/20", text: "text-red-400"},
-    thinking: %{label: "thinking", bg: "bg-indigo-400/20", text: "text-indigo-400"}
+    tool_call: %{label: "tool", bg: "bg-violet-400/20", text: "text-violet-400", border: "border-violet-500/40"},
+    message: %{label: "message", bg: "bg-emerald-400/20", text: "text-emerald-400", border: "border-emerald-500/40"},
+    decision: %{label: "decision", bg: "bg-purple-400/20", text: "text-purple-400", border: "border-purple-500/40"},
+    task_created: %{label: "created", bg: "bg-cyan-400/20", text: "text-cyan-400", border: "border-cyan-500/40"},
+    task_assigned: %{label: "assigned", bg: "bg-blue-400/20", text: "text-blue-400", border: "border-blue-500/40"},
+    task_started: %{label: "started", bg: "bg-violet-400/20", text: "text-violet-400", border: "border-violet-500/40"},
+    task_complete: %{label: "done", bg: "bg-green-400/20", text: "text-green-400", border: "border-green-500/40"},
+    task_failed: %{label: "failed", bg: "bg-red-400/20", text: "text-red-400", border: "border-red-500/40"},
+    discovery: %{label: "discovery", bg: "bg-yellow-400/20", text: "text-yellow-400", border: "border-yellow-500/40"},
+    error: %{label: "error", bg: "bg-red-400/20", text: "text-red-400", border: "border-red-500/40"},
+    thinking: %{label: "thinking", bg: "bg-indigo-400/20", text: "text-indigo-400", border: "border-indigo-500/40"},
+    streaming: %{label: "thinking", bg: "bg-indigo-400/20", text: "text-indigo-400", border: "border-indigo-500/40"},
+    agent_spawn: %{label: "joined", bg: "bg-teal-400/20", text: "text-teal-400", border: "border-teal-500/40"},
+    context_offload: %{label: "offload", bg: "bg-amber-400/20", text: "text-amber-400", border: "border-amber-500/40"},
+    question: %{label: "question", bg: "bg-sky-400/20", text: "text-sky-400", border: "border-sky-500/40"},
+    answer: %{label: "answer", bg: "bg-sky-400/20", text: "text-sky-400", border: "border-sky-500/40"}
   }
 
   @impl true
@@ -37,6 +49,7 @@ defmodule LoomkinWeb.TeamActivityComponent do
      assign(socket,
        events: [],
        known_agents: [],
+       focused_agent: nil,
        agent_filter: nil,
        type_filter: MapSet.new()
      )}
@@ -44,13 +57,19 @@ defmodule LoomkinWeb.TeamActivityComponent do
 
   @impl true
   def update(assigns, socket) do
-    # Events and known_agents come from parent LiveView's buffer
     socket =
       socket
       |> assign(:team_id, assigns[:team_id])
       |> assign(:id, assigns[:id])
       |> assign(:events, assigns[:events] || socket.assigns.events)
       |> assign(:known_agents, assigns[:known_agents] || socket.assigns.known_agents)
+
+    # Accept focused_agent from parent (e.g. roster click) — auto-apply as agent filter
+    socket =
+      case assigns[:focused_agent] do
+        nil -> socket
+        agent -> assign(socket, focused_agent: agent, agent_filter: agent)
+      end
 
     {:ok, socket}
   end
@@ -59,14 +78,13 @@ defmodule LoomkinWeb.TeamActivityComponent do
 
   @impl true
   def handle_event("filter_agent", %{"agent" => ""}, socket) do
-    {:noreply, assign(socket, agent_filter: nil)}
+    {:noreply, assign(socket, agent_filter: nil, focused_agent: nil)}
   end
 
   def handle_event("filter_agent", %{"agent" => agent}, socket) do
     current = socket.assigns.agent_filter
-
-    {:noreply,
-     assign(socket, agent_filter: if(current == agent, do: nil, else: agent))}
+    new_filter = if(current == agent, do: nil, else: agent)
+    {:noreply, assign(socket, agent_filter: new_filter, focused_agent: nil)}
   end
 
   def handle_event("toggle_type", %{"type" => type_str}, socket) do
@@ -74,11 +92,9 @@ defmodule LoomkinWeb.TeamActivityComponent do
     filter = socket.assigns.type_filter
 
     new_filter =
-      if MapSet.member?(filter, type) do
-        MapSet.delete(filter, type)
-      else
-        MapSet.put(filter, type)
-      end
+      if MapSet.member?(filter, type),
+        do: MapSet.delete(filter, type),
+        else: MapSet.put(filter, type)
 
     {:noreply, assign(socket, type_filter: new_filter)}
   end
@@ -92,6 +108,16 @@ defmodule LoomkinWeb.TeamActivityComponent do
     {:noreply, assign(socket, events: events)}
   end
 
+  def handle_event("focus_agent", %{"agent" => agent}, socket) do
+    send(self(), {:focus_agent, agent})
+    {:noreply, socket}
+  end
+
+  def handle_event("inspect_file", %{"path" => path}, socket) do
+    send(self(), {:inspector_file, path})
+    {:noreply, socket}
+  end
+
   # --- Render ---
 
   @impl true
@@ -100,88 +126,570 @@ defmodule LoomkinWeb.TeamActivityComponent do
 
     ~H"""
     <div class="flex flex-col h-full bg-gray-950">
-      <!-- Agent Filters -->
-      <div class="flex flex-wrap items-center gap-1.5 px-3 py-2 border-b border-gray-800">
-        <button
-          phx-click="filter_agent"
-          phx-value-agent=""
-          phx-target={@myself}
-          class={"text-xs px-2 py-1 rounded font-medium transition #{if @agent_filter == nil, do: "bg-violet-600 text-white", else: "bg-gray-800 text-gray-400 hover:text-gray-200"}"}
-        >
-          All
-        </button>
-        <button
-          :for={agent <- @known_agents}
-          phx-click="filter_agent"
-          phx-value-agent={agent}
-          phx-target={@myself}
-          class={"flex items-center gap-1.5 text-xs px-2 py-1 rounded font-medium transition #{if @agent_filter == agent, do: "bg-gray-700 text-white", else: "bg-gray-800 text-gray-400 hover:text-gray-200"}"}
-        >
-          <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(agent)}"}></span>
-          {agent}
-        </button>
+      <%!-- Filter Bar --%>
+      <div class="flex flex-col border-b border-gray-800">
+        <%!-- Agent Filters --%>
+        <div class="flex flex-wrap items-center gap-1.5 px-4 py-2">
+          <button
+            phx-click="filter_agent"
+            phx-value-agent=""
+            phx-target={@myself}
+            class={"text-xs px-2.5 py-1 rounded-full font-medium transition #{if @agent_filter == nil, do: "bg-violet-600 text-white", else: "bg-gray-800 text-gray-400 hover:text-gray-200"}"}
+          >
+            All
+          </button>
+          <button
+            :for={agent <- @known_agents}
+            phx-click="filter_agent"
+            phx-value-agent={agent}
+            phx-target={@myself}
+            class={"flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full font-medium transition #{if @agent_filter == agent, do: "bg-gray-700 text-white ring-1 ring-gray-600", else: "bg-gray-800 text-gray-400 hover:text-gray-200"}"}
+          >
+            <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(agent)}"}></span>
+            {agent}
+          </button>
+        </div>
+
+        <%!-- Type Filters --%>
+        <div class="flex flex-wrap items-center gap-1.5 px-4 py-1.5 border-t border-gray-800/50">
+          <button
+            :for={{type, config} <- type_config_list()}
+            phx-click="toggle_type"
+            phx-value-type={type}
+            phx-target={@myself}
+            class={"text-xs px-2 py-0.5 rounded-full font-medium transition #{if MapSet.size(@type_filter) > 0 && !MapSet.member?(@type_filter, type), do: "opacity-30", else: ""} #{config.bg} #{config.text}"}
+          >
+            {config.label}
+          </button>
+        </div>
       </div>
 
-      <!-- Type Filters -->
-      <div class="flex flex-wrap items-center gap-1.5 px-3 py-1.5 border-b border-gray-800/50">
-        <button
-          :for={{type, config} <- type_config_list()}
-          phx-click="toggle_type"
-          phx-value-type={type}
-          phx-target={@myself}
-          class={"text-xs px-1.5 py-0.5 rounded font-medium transition #{if MapSet.size(@type_filter) > 0 && !MapSet.member?(@type_filter, type), do: "opacity-30", else: ""} #{config.bg} #{config.text}"}
-        >
-          {config.label}
-        </button>
-      </div>
-
-      <!-- Event Feed -->
+      <%!-- Event Feed --%>
       <div class="flex-1 overflow-auto" id={"activity-feed-#{@id}"} phx-hook="ScrollToBottom">
-        <div class="flex flex-col gap-0.5 p-2">
+        <div class="flex flex-col gap-1.5 p-3">
           <div
             :if={@filtered_events == []}
-            class="flex items-center justify-center h-32 text-gray-500 text-sm"
+            class="flex items-center justify-center h-48 text-gray-500"
           >
-            No activity yet
-          </div>
-
-          <div
-            :for={event <- @filtered_events}
-            class="flex items-start gap-2 px-2 py-1.5 rounded bg-gray-900/50 hover:bg-gray-900/80 transition"
-          >
-            <!-- Agent dot -->
-            <span
-              class="w-2 h-2 rounded-full mt-1.5 flex-shrink-0"
-              style={"background-color: #{agent_color(event.agent)}"}
-            >
-            </span>
-
-            <!-- Content -->
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <span class="text-xs font-medium text-gray-200">{event.agent}</span>
-                <span class={"text-xs px-1.5 py-0.5 rounded font-medium #{type_badge_class(event.type)}"}>
-                  {type_label(event.type)}
-                </span>
-                <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
-                  {relative_time(event.timestamp)}
-                </span>
-              </div>
-              <p class={"text-sm text-gray-300 #{if !Map.get(event, :expanded, false), do: "truncate"}"}>
-                {event.content}
-              </p>
-              <button
-                :if={String.length(event.content) > 120 && !Map.get(event, :expanded, false)}
-                phx-click="expand_event"
-                phx-value-id={event.id}
-                phx-target={@myself}
-                class="text-xs text-violet-400 hover:text-violet-300 mt-0.5"
-              >
-                show more
-              </button>
+            <div class="text-center space-y-2">
+              <div class="text-3xl opacity-50">&#9673;</div>
+              <p class="text-sm">No activity yet</p>
+              <p class="text-xs text-gray-600">Events will appear here as your team works</p>
             </div>
           </div>
+
+          <div :for={event <- @filtered_events}>
+            {render_event_card(assigns, event)}
+          </div>
         </div>
+      </div>
+    </div>
+    """
+  end
+
+  # --- Card Renderers ---
+
+  defp render_event_card(assigns, %{type: :tool_call} = event) do
+    meta = Map.get(event, :metadata, %{})
+    tool_name = meta[:tool_name] || extract_tool_name(event.content)
+    file_path = meta[:file_path]
+    result_preview = meta[:result] || meta[:result_preview]
+    has_result = is_binary(result_preview) and result_preview != ""
+    expanded = Map.get(event, :expanded, false)
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:tool_name, tool_name)
+      |> assign(:file_path, file_path)
+      |> assign(:result_preview, result_preview)
+      |> assign(:has_result, has_result)
+      |> assign(:expanded, expanded)
+
+    ~H"""
+    <div class="rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 border-violet-500/40 overflow-hidden">
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@event.agent}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@event.agent}
+        </button>
+        <span class="text-xs px-1.5 py-0.5 rounded bg-violet-400/20 text-violet-400 font-medium">
+          {tool_icon(@tool_name)} {@tool_name}
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div :if={@file_path} class="px-3 pb-1">
+        <button
+          phx-click="inspect_file"
+          phx-value-path={@file_path}
+          phx-target={@myself}
+          class="text-xs text-violet-400 hover:text-violet-300 font-mono transition"
+        >
+          &#128196; {@file_path}
+        </button>
+      </div>
+      <div :if={@has_result} class="px-3 pb-2">
+        <div :if={!@expanded} class="mt-1">
+          <pre class="text-xs text-gray-400 font-mono whitespace-pre-wrap bg-gray-950/50 rounded p-2 max-h-20 overflow-hidden">{String.slice(@result_preview, 0, 500)}</pre>
+          <button
+            :if={String.length(@result_preview) > 500}
+            phx-click="expand_event"
+            phx-value-id={@event.id}
+            phx-target={@myself}
+            class="text-xs text-violet-400 hover:text-violet-300 mt-1 transition"
+          >
+            Show full result ({format_result_size(@result_preview)})
+          </button>
+        </div>
+        <div :if={@expanded} class="mt-1">
+          <pre class="text-xs text-gray-400 font-mono whitespace-pre-wrap bg-gray-950/50 rounded p-2 max-h-96 overflow-auto">{@result_preview}</pre>
+          <button
+            phx-click="expand_event"
+            phx-value-id={@event.id}
+            phx-target={@myself}
+            class="text-xs text-gray-500 hover:text-gray-300 mt-1 transition"
+          >
+            Collapse
+          </button>
+        </div>
+      </div>
+      <div :if={!@has_result && String.length(@event.content) > 0} class="px-3 pb-2">
+        <p class="text-sm text-gray-300">{@event.content}</p>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: :message} = event) do
+    meta = Map.get(event, :metadata, %{})
+    from = meta[:from] || event.agent
+    to = meta[:to]
+    display_to = if to, do: to, else: "Team"
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:from, from)
+      |> assign(:display_to, display_to)
+
+    ~H"""
+    <div class="rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 border-emerald-500/40 overflow-hidden">
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@from}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@from}
+        </button>
+        <span class="text-xs text-gray-500">&#8594;</span>
+        <span class="text-xs font-medium text-emerald-400">{@display_to}</span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div class="px-3 pb-2.5">
+        <p class="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{@event.content}</p>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: type} = event)
+       when type in [:task_created, :task_assigned, :task_started, :task_complete, :task_failed] do
+    meta = Map.get(event, :metadata, %{})
+    config = Map.get(@type_config, type, %{label: to_string(type), bg: "bg-gray-400/20", text: "text-gray-400", border: "border-gray-500/40"})
+    title = meta[:title]
+    owner = meta[:owner]
+    result = meta[:result]
+    expanded = Map.get(event, :expanded, false)
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:config, config)
+      |> assign(:title, title)
+      |> assign(:owner, owner)
+      |> assign(:result, result)
+      |> assign(:expanded, expanded)
+
+    ~H"""
+    <div class={"rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 #{@config.border} overflow-hidden"}>
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@event.agent}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@event.agent}
+        </button>
+        <span class={"text-xs px-1.5 py-0.5 rounded font-medium #{@config.bg} #{@config.text}"}>
+          {@config.label}
+        </span>
+        <span :if={@title} class="text-xs text-gray-300 truncate">&quot;{@title}&quot;</span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div :if={@owner || (!@title && @event.content != "")} class="px-3 pb-2">
+        <p :if={@owner} class="text-xs text-gray-500">
+          &#8594; assigned to <span class="text-gray-300">{@owner}</span>
+        </p>
+        <p :if={!@title} class="text-sm text-gray-400">{@event.content}</p>
+      </div>
+      <div :if={@result && @event.type == :task_complete} class="px-3 pb-2">
+        <button
+          :if={!@expanded}
+          phx-click="expand_event"
+          phx-value-id={@event.id}
+          phx-target={@myself}
+          class="text-xs text-gray-500 hover:text-gray-300 transition"
+        >
+          &#9656; Show result
+        </button>
+        <div :if={@expanded}>
+          <pre class="text-xs text-gray-400 font-mono whitespace-pre-wrap bg-gray-950/50 rounded p-2 max-h-48 overflow-auto">{@result}</pre>
+          <button
+            phx-click="expand_event"
+            phx-value-id={@event.id}
+            phx-target={@myself}
+            class="text-xs text-gray-500 hover:text-gray-300 mt-1 transition"
+          >
+            &#9662; Collapse
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: :discovery} = event) do
+    assigns = assign(assigns, :event, event)
+
+    ~H"""
+    <div class="rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 border-yellow-500/40 overflow-hidden">
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@event.agent}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@event.agent}
+        </button>
+        <span class="text-xs px-1.5 py-0.5 rounded font-medium bg-yellow-400/20 text-yellow-400">
+          discovery
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div class="px-3 pb-2.5">
+        <p class="text-sm text-yellow-200/80 leading-relaxed whitespace-pre-wrap">&#11088; {@event.content}</p>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: :agent_spawn} = event) do
+    meta = Map.get(event, :metadata, %{})
+    role = meta[:role]
+    model = meta[:model]
+    agent_name = meta[:agent_name] || event.agent
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:agent_name, agent_name)
+      |> assign(:role, role)
+      |> assign(:model, model)
+
+    ~H"""
+    <div class="rounded-lg bg-teal-500/5 border border-teal-500/20 overflow-hidden">
+      <div class="flex items-center justify-center gap-2 px-3 py-2.5">
+        <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@agent_name)}"}></span>
+        <span class="text-sm font-medium text-teal-300">{@agent_name} joined the team</span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div :if={@role || @model} class="flex items-center justify-center gap-3 px-3 pb-2 text-xs text-gray-500">
+        <span :if={@role}>Role: <span class="text-gray-400">{@role}</span></span>
+        <span :if={@role && @model}>|</span>
+        <span :if={@model}>Model: <span class="text-gray-400">{@model}</span></span>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: :error} = event) do
+    meta = Map.get(event, :metadata, %{})
+    details = meta[:details]
+    expanded = Map.get(event, :expanded, false)
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:details, details)
+      |> assign(:expanded, expanded)
+
+    ~H"""
+    <div class="rounded-lg bg-red-950/30 hover:bg-red-950/50 transition border-l-2 border-red-500/40 overflow-hidden">
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@event.agent}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@event.agent}
+        </button>
+        <span class="text-xs px-1.5 py-0.5 rounded font-medium bg-red-400/20 text-red-400">
+          error
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div class="px-3 pb-2">
+        <p class="text-sm text-red-300/90">&#9888; {@event.content}</p>
+      </div>
+      <div :if={@details} class="px-3 pb-2">
+        <button
+          :if={!@expanded}
+          phx-click="expand_event"
+          phx-value-id={@event.id}
+          phx-target={@myself}
+          class="text-xs text-gray-500 hover:text-gray-300 transition"
+        >
+          &#9656; Show details
+        </button>
+        <div :if={@expanded}>
+          <pre class="text-xs text-red-300/70 font-mono whitespace-pre-wrap bg-gray-950/50 rounded p-2 max-h-48 overflow-auto">{@details}</pre>
+          <button
+            phx-click="expand_event"
+            phx-value-id={@event.id}
+            phx-target={@myself}
+            class="text-xs text-gray-500 hover:text-gray-300 mt-1 transition"
+          >
+            &#9662; Collapse
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: type} = event) when type in [:thinking, :streaming] do
+    meta = Map.get(event, :metadata, %{})
+    streaming_content = meta[:content]
+    is_live = type == :streaming
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:streaming_content, streaming_content)
+      |> assign(:is_live, is_live)
+
+    ~H"""
+    <div class={"rounded-lg bg-gray-900/50 transition border-l-2 border-indigo-500/40 overflow-hidden #{if @is_live, do: "ring-1 ring-indigo-500/20 animate-pulse-subtle"}"}>
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@event.agent}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@event.agent}
+        </button>
+        <span class="text-xs px-1.5 py-0.5 rounded font-medium bg-indigo-400/20 text-indigo-400">
+          thinking
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div :if={@streaming_content || @event.content != ""} class="px-3 pb-2.5">
+        <p class="text-sm text-gray-400 leading-relaxed whitespace-pre-wrap">
+          {@streaming_content || @event.content}<span :if={@is_live} class="inline-block w-1.5 h-3.5 bg-indigo-400 animate-pulse ml-0.5 align-text-bottom"></span>
+        </p>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: :context_offload} = event) do
+    meta = Map.get(event, :metadata, %{})
+    topic = meta[:topic]
+    token_count = meta[:token_count]
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:topic, topic)
+      |> assign(:token_count, token_count)
+
+    ~H"""
+    <div class="rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 border-amber-500/40 overflow-hidden">
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@event.agent}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@event.agent}
+        </button>
+        <span class="text-xs px-1.5 py-0.5 rounded font-medium bg-amber-400/20 text-amber-400">
+          offload
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div class="px-3 pb-2">
+        <p class="text-sm text-gray-400">
+          {@event.content}
+          <span :if={@topic} class="text-amber-400/70"> ({@topic})</span>
+          <span :if={@token_count} class="text-xs text-gray-500 ml-1">{format_tokens(@token_count)} tokens</span>
+        </p>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: :question} = event) do
+    meta = Map.get(event, :metadata, %{})
+    from = meta[:from] || event.agent
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:from, from)
+
+    ~H"""
+    <div class="rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 border-sky-500/40 overflow-hidden">
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@from}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@from}
+        </button>
+        <span class="text-xs px-1.5 py-0.5 rounded font-medium bg-sky-400/20 text-sky-400">
+          question
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div class="px-3 pb-2.5">
+        <p class="text-sm text-sky-200/80 leading-relaxed whitespace-pre-wrap">&#10068; {@event.content}</p>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event_card(assigns, %{type: :answer} = event) do
+    meta = Map.get(event, :metadata, %{})
+    from = meta[:from] || event.agent
+    to = meta[:to]
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:from, from)
+      |> assign(:to, to)
+
+    ~H"""
+    <div class="rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 border-sky-500/40 overflow-hidden">
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@from}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@from}
+        </button>
+        <span class="text-xs text-gray-500">&#8594;</span>
+        <span :if={@to} class="text-xs font-medium text-sky-400">{@to}</span>
+        <span class="text-xs px-1.5 py-0.5 rounded font-medium bg-sky-400/20 text-sky-400">
+          answer
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div class="px-3 pb-2.5">
+        <p class="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{@event.content}</p>
+      </div>
+    </div>
+    """
+  end
+
+  # Fallback for any unknown event type
+  defp render_event_card(assigns, event) do
+    config = Map.get(@type_config, event.type, %{label: to_string(event.type), bg: "bg-gray-400/20", text: "text-gray-400", border: "border-gray-500/40"})
+    expanded = Map.get(event, :expanded, false)
+
+    assigns =
+      assigns
+      |> assign(:event, event)
+      |> assign(:config, config)
+      |> assign(:expanded, expanded)
+
+    ~H"""
+    <div class={"rounded-lg bg-gray-900/50 hover:bg-gray-900/80 transition border-l-2 #{@config.border} overflow-hidden"}>
+      <div class="flex items-center gap-2 px-3 py-2">
+        <span class="w-2 h-2 rounded-full flex-shrink-0" style={"background-color: #{agent_color(@event.agent)}"}></span>
+        <button
+          phx-click="focus_agent"
+          phx-value-agent={@event.agent}
+          phx-target={@myself}
+          class="text-xs font-semibold text-gray-200 hover:text-white transition"
+        >
+          {@event.agent}
+        </button>
+        <span class={"text-xs px-1.5 py-0.5 rounded font-medium #{@config.bg} #{@config.text}"}>
+          {@config.label}
+        </span>
+        <span class="text-xs text-gray-500 ml-auto flex-shrink-0">
+          {relative_time(@event.timestamp)}
+        </span>
+      </div>
+      <div class="px-3 pb-2">
+        <p class={"text-sm text-gray-400 leading-relaxed #{if !@expanded, do: "line-clamp-3"}"}>
+          {@event.content}
+        </p>
+        <button
+          :if={String.length(@event.content || "") > 200 && !@expanded}
+          phx-click="expand_event"
+          phx-value-id={@event.id}
+          phx-target={@myself}
+          class="text-xs text-violet-400 hover:text-violet-300 mt-0.5 transition"
+        >
+          show more
+        </button>
       </div>
     </div>
     """
@@ -208,7 +716,7 @@ defmodule LoomkinWeb.TeamActivityComponent do
     diff = DateTime.diff(DateTime.utc_now(), datetime, :second)
 
     cond do
-      diff < 5 -> "just now"
+      diff < 3 -> "now"
       diff < 60 -> "#{diff}s ago"
       diff < 3600 -> "#{div(diff, 60)}m ago"
       true -> "#{div(diff, 3600)}h ago"
@@ -220,30 +728,61 @@ defmodule LoomkinWeb.TeamActivityComponent do
     Enum.at(@agent_colors, index)
   end
 
-  defp type_badge_class(type) do
-    case Map.get(@type_config, type) do
-      %{bg: bg, text: text} -> "#{bg} #{text}"
-      nil -> "bg-gray-400/20 text-gray-400"
+  defp extract_tool_name(content) when is_binary(content) do
+    case Regex.run(~r/^used (\S+)/, content) do
+      [_, name] -> name
+      _ ->
+        case Regex.run(~r/^(\S+) done:/, content) do
+          [_, name] -> name
+          _ -> "tool"
+        end
     end
   end
 
-  defp type_label(type) do
-    case Map.get(@type_config, type) do
-      %{label: label} -> label
-      nil -> to_string(type)
+  defp extract_tool_name(_), do: "tool"
+
+  defp tool_icon(name) when is_binary(name) do
+    cond do
+      name in ~w(Read Write Edit Glob) -> "&#128196;"
+      name in ~w(Bash shell exec) -> "&#9889;"
+      name in ~w(Grep search) -> "&#128269;"
+      name in ~w(decision plan) -> "&#129504;"
+      true -> "&#9881;"
     end
   end
+
+  defp tool_icon(_), do: "&#9881;"
+
+  defp format_tokens(n) when is_integer(n) and n >= 1000, do: "#{Float.round(n / 1000, 1)}k"
+  defp format_tokens(n) when is_integer(n), do: to_string(n)
+  defp format_tokens(_), do: "?"
+
+  defp format_result_size(str) when is_binary(str) do
+    lines = str |> String.split("\n") |> length()
+    chars = String.length(str)
+
+    cond do
+      lines > 1 -> "#{lines} lines"
+      chars > 1000 -> "#{Float.round(chars / 1000, 1)}k chars"
+      true -> "#{chars} chars"
+    end
+  end
+
+  defp format_result_size(_), do: ""
 
   defp type_config_list do
     [
       {:tool_call, @type_config.tool_call},
       {:message, @type_config.message},
-      {:decision, @type_config.decision},
-      {:task_complete, @type_config.task_complete},
+      {:task_created, @type_config.task_created},
       {:task_assigned, @type_config.task_assigned},
+      {:task_complete, @type_config.task_complete},
       {:discovery, @type_config.discovery},
       {:error, @type_config.error},
-      {:thinking, @type_config.thinking}
+      {:thinking, @type_config.thinking},
+      {:agent_spawn, @type_config.agent_spawn},
+      {:context_offload, @type_config.context_offload},
+      {:question, @type_config.question}
     ]
   end
 end

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -35,7 +35,15 @@ defmodule LoomkinWeb.WorkspaceLive do
         plan_steps: [],
         current_step: nil,
         activity_events: [],
-        activity_known_agents: []
+        activity_known_agents: [],
+        # Mission control assigns
+        mode: :solo,
+        focused_agent: nil,
+        inspector_mode: :auto_follow,
+        active_inspector_tab: :files,
+        collapsed_inspector: false,
+        streaming_agent: nil,
+        streaming_thoughts: ""
       )
 
     case socket.assigns.live_action do
@@ -126,6 +134,31 @@ defmodule LoomkinWeb.WorkspaceLive do
     # Optimistically show user message + thinking state immediately
     user_msg = %{role: :user, content: trimmed}
 
+    # In mission control mode, also show user message in the activity feed
+    socket =
+      if socket.assigns.mode == :mission_control do
+        user_event = %{
+          id: Ecto.UUID.generate(),
+          type: :message,
+          agent: "You",
+          content: trimmed,
+          timestamp: DateTime.utc_now(),
+          expanded: false,
+          metadata: %{from: "You", to: "Team"}
+        }
+
+        events = socket.assigns.activity_events ++ [user_event]
+
+        events =
+          if length(events) > @max_activity_events,
+            do: Enum.drop(events, length(events) - @max_activity_events),
+            else: events
+
+        assign(socket, activity_events: events)
+      else
+        socket
+      end
+
     {:noreply,
      socket
      |> assign(
@@ -197,6 +230,28 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, assign(socket, active_team_id: team_id)}
   end
 
+  def handle_event("toggle_mode", _, socket) do
+    new_mode = if socket.assigns.mode == :solo, do: :mission_control, else: :solo
+    {:noreply, assign(socket, mode: new_mode)}
+  end
+
+  def handle_event("keyboard_shortcut", %{"key" => "toggle_mode"}, socket) do
+    handle_event("toggle_mode", %{}, socket)
+  end
+
+  def handle_event("keyboard_shortcut", %{"key" => "cancel"}, socket) do
+    handle_event("cancel", %{}, socket)
+  end
+
+  def handle_event("keyboard_shortcut", %{"key" => "escape"}, socket) do
+    {:noreply,
+     assign(socket, focused_agent: nil, inspector_mode: :auto_follow, permission_request: nil)}
+  end
+
+  def handle_event("keyboard_shortcut", %{"key" => "focus_input"}, socket) do
+    {:noreply, push_event(socket, "focus-input", %{})}
+  end
+
   # --- PubSub Info ---
 
   def handle_info({:new_message, _session_id, %{role: :user}}, socket) do
@@ -223,21 +278,23 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, assign(socket, status: status)}
   end
 
-  def handle_info({:tool_executing, _source, %{tool_name: name, tool_target: target}} = event, socket) do
+  def handle_info({:tool_executing, source, %{tool_name: name, tool_target: target}} = event, socket) do
     display = if target && target != "*", do: "#{name}: #{target}", else: name
 
     socket =
       socket
       |> forward_to_activity(event)
+      |> maybe_auto_follow(source, %{tool_name: name, path: target})
       |> assign(current_tool: display, current_tool_name: name)
 
     {:noreply, socket}
   end
 
-  def handle_info({:tool_executing, _source, %{tool_name: name}} = event, socket) do
+  def handle_info({:tool_executing, source, %{tool_name: name}} = event, socket) do
     socket =
       socket
       |> forward_to_activity(event)
+      |> maybe_auto_follow(source, %{tool_name: name})
       |> assign(current_tool: name, current_tool_name: name)
 
     {:noreply, socket}
@@ -305,7 +362,7 @@ defmodule LoomkinWeb.WorkspaceLive do
   def handle_info({:team_available, _session_id, team_id}, socket) do
     # Auto-subscribe to backing team events when the team is created
     if connected?(socket), do: subscribe_to_team(team_id)
-    {:noreply, assign(socket, team_id: team_id, active_team_id: team_id)}
+    {:noreply, assign(socket, team_id: team_id, active_team_id: team_id, mode: :mission_control)}
   end
 
   def handle_info({:child_team_available, _session_id, child_team_id}, socket) do
@@ -318,7 +375,7 @@ defmodule LoomkinWeb.WorkspaceLive do
         socket.assigns.child_teams ++ [child_team_id]
       end
 
-    {:noreply, assign(socket, :child_teams, child_teams)}
+    {:noreply, assign(socket, child_teams: child_teams, mode: :mission_control)}
   end
 
   # --- Errors ---
@@ -419,25 +476,25 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, forward_to_activity(socket, event)}
   end
 
-  def handle_info({:task_started, _task_id, _owner}, socket) do
+  def handle_info({:task_started, _task_id, _owner} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, socket}
+    {:noreply, forward_to_activity(socket, event)}
   end
 
-  def handle_info({:task_failed, _task_id, _owner, _reason}, socket) do
+  def handle_info({:task_failed, _task_id, _owner, _reason} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, socket}
+    {:noreply, forward_to_activity(socket, event)}
   end
 
-  def handle_info({:role_changed, _agent_name, _old, _new}, socket) do
+  def handle_info({:role_changed, _agent_name, _old, _new} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, socket}
+    {:noreply, forward_to_activity(socket, event)}
   end
 
-  def handle_info({:agent_escalation, _agent_name, _old, _new}, socket) do
+  def handle_info({:agent_escalation, _agent_name, _old, _new} = event, socket) do
     forward_to_dashboard(socket)
     forward_to_cost(socket)
-    {:noreply, socket}
+    {:noreply, forward_to_activity(socket, event)}
   end
 
   def handle_info({:usage, _agent_name, _payload}, socket) do
@@ -445,17 +502,69 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, socket}
   end
 
-  # Agent streaming events — buffered for activity feed
-  def handle_info({:agent_stream_start, _agent_name, _payload}, socket) do
-    {:noreply, socket}
+  # Agent streaming events — show thoughts live in activity feed
+  def handle_info({:agent_stream_start, agent_name, _payload}, socket) do
+    # Start accumulating this agent's thoughts
+    {:noreply, assign(socket, streaming_agent: agent_name, streaming_thoughts: "")}
   end
 
-  def handle_info({:agent_stream_delta, _agent_name, _payload}, socket) do
-    {:noreply, socket}
+  def handle_info({:agent_stream_delta, agent_name, payload}, socket) do
+    chunk =
+      case payload do
+        %{text: t} when is_binary(t) -> t
+        %{content: c} when is_binary(c) -> c
+        %{delta: d} when is_binary(d) -> d
+        c when is_binary(c) -> c
+        _ -> ""
+      end
+
+    current = socket.assigns[:streaming_thoughts] || ""
+    updated = current <> chunk
+
+    # Update or insert a live "thinking" event in the activity feed
+    thinking_id = "thinking-#{agent_name}"
+    events = socket.assigns.activity_events
+
+    existing_idx = Enum.find_index(events, &(&1.id == thinking_id))
+
+    events =
+      if existing_idx do
+        List.update_at(events, existing_idx, fn ev ->
+          %{ev | content: updated, timestamp: DateTime.utc_now()}
+        end)
+      else
+        events ++
+          [
+            %{
+              id: thinking_id,
+              type: :thinking,
+              agent: agent_name,
+              content: updated,
+              timestamp: DateTime.utc_now(),
+              expanded: true,
+              metadata: %{live: true}
+            }
+          ]
+      end
+
+    {:noreply, assign(socket, activity_events: events, streaming_thoughts: updated)}
   end
 
-  def handle_info({:agent_stream_end, _agent_name, _payload} = event, socket) do
-    {:noreply, forward_to_activity(socket, event)}
+  def handle_info({:agent_stream_end, agent_name, _payload}, socket) do
+    # Finalize the thinking event — mark it as no longer live
+    thinking_id = "thinking-#{agent_name}"
+    events = socket.assigns.activity_events
+
+    events =
+      Enum.map(events, fn ev ->
+        if ev.id == thinking_id do
+          %{ev | metadata: Map.delete(ev.metadata || %{}, :live)}
+        else
+          ev
+        end
+      end)
+
+    {:noreply, assign(socket, activity_events: events, streaming_agent: nil, streaming_thoughts: "")}
   end
 
   def handle_info({:child_team_created, child_team_id}, socket) do
@@ -474,7 +583,15 @@ defmodule LoomkinWeb.WorkspaceLive do
   def handle_info({:team_dissolved, team_id}, socket) do
     if team_id == socket.assigns.team_id do
       {:noreply,
-       assign(socket, team_id: nil, child_teams: [], active_team_id: nil, active_tab: :files)}
+       assign(socket,
+         team_id: nil,
+         child_teams: [],
+         active_team_id: nil,
+         active_tab: :files,
+         mode: :solo,
+         focused_agent: nil,
+         inspector_mode: :auto_follow
+       )}
     else
       child_teams = List.delete(socket.assigns.child_teams, team_id)
 
@@ -483,7 +600,13 @@ defmodule LoomkinWeb.WorkspaceLive do
           do: socket.assigns.team_id,
           else: socket.assigns.active_team_id
 
-      {:noreply, assign(socket, child_teams: child_teams, active_team_id: active_team_id)}
+      # Switch back to solo if no teams remain
+      mode =
+        if child_teams == [] && socket.assigns.team_id == nil,
+          do: :solo,
+          else: socket.assigns.mode
+
+      {:noreply, assign(socket, child_teams: child_teams, active_team_id: active_team_id, mode: mode)}
     end
   end
 
@@ -547,6 +670,38 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, forward_to_activity(socket, event)}
   end
 
+  # Messages from AgentRosterComponent
+  def handle_info({:focus_agent, agent_name}, socket) do
+    {:noreply, assign(socket, focused_agent: agent_name, inspector_mode: :pinned)}
+  end
+
+  def handle_info({:unpin_agent}, socket) do
+    {:noreply, assign(socket, focused_agent: nil, inspector_mode: :auto_follow)}
+  end
+
+  # Messages from ContextInspectorComponent
+  def handle_info({:inspector_tab, tab}, socket) do
+    {:noreply, assign(socket, active_inspector_tab: tab, inspector_mode: :pinned)}
+  end
+
+  def handle_info({:resume_follow}, socket) do
+    {:noreply, assign(socket, inspector_mode: :auto_follow)}
+  end
+
+  # From activity feed file clicks
+  def handle_info({:inspector_file, path}, socket) do
+    {:noreply, assign(socket, active_inspector_tab: :files, selected_file: path)}
+  end
+
+  # New event types for activity feed
+  def handle_info({:keeper_created, _payload} = event, socket) do
+    {:noreply, forward_to_activity(socket, event)}
+  end
+
+  def handle_info({:tasks_unblocked, _task_ids} = event, socket) do
+    {:noreply, forward_to_activity(socket, event)}
+  end
+
   # Catch-all for unhandled PubSub messages (team events, etc.)
   def handle_info(_msg, socket) do
     {:noreply, socket}
@@ -556,7 +711,11 @@ defmodule LoomkinWeb.WorkspaceLive do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col h-screen bg-gray-950 text-gray-100">
+    <div
+      class="flex flex-col h-screen bg-gray-950 text-gray-100"
+      phx-hook="KeyboardShortcuts"
+      id="workspace-shortcuts"
+    >
       <%!-- Permission modal overlay --%>
       <.live_component
         :if={@permission_request}
@@ -592,9 +751,44 @@ defmodule LoomkinWeb.WorkspaceLive do
             id="model-selector"
             model={@model}
           />
+
+          <%!-- Team indicator (mission control mode) --%>
+          <div :if={@mode == :mission_control && @active_team_id} class="flex items-center gap-2">
+            <span class="text-xs text-violet-400 font-medium">
+              Team: {short_team_id(@active_team_id)}
+            </span>
+            <span class="text-xs text-gray-500">
+              {length(@activity_known_agents)} agents
+            </span>
+            <select
+              :if={@child_teams != []}
+              phx-change="switch_team"
+              name="team-id"
+              class="text-xs bg-gray-800 border border-gray-700 rounded px-1.5 py-0.5 text-gray-300 focus:outline-none focus:ring-1 focus:ring-violet-500/50"
+            >
+              <option
+                :for={tid <- [@team_id | @child_teams]}
+                value={tid}
+                selected={tid == @active_team_id}
+              >
+                {short_team_id(tid)}
+              </option>
+            </select>
+          </div>
         </div>
 
         <div class="flex items-center gap-3">
+          <%!-- Mode toggle (visible when team exists) --%>
+          <button
+            :if={@team_id}
+            phx-click="toggle_mode"
+            class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 bg-gray-800/60 hover:bg-gray-800 text-gray-300 hover:text-violet-400"
+          >
+            <span :if={@mode == :solo} class="hero-user-group-mini inline-block w-3.5 h-3.5" />
+            <span :if={@mode == :mission_control} class="hero-chat-bubble-left-right-mini inline-block w-3.5 h-3.5" />
+            {if @mode == :mission_control, do: "Solo", else: "Mission Control"}
+          </button>
+
           <%!-- Cost pill --%>
           <a
             href="/dashboard"
@@ -625,106 +819,175 @@ defmodule LoomkinWeb.WorkspaceLive do
         </div>
       </header>
 
-      <%!-- ── Main Content ── --%>
+      <%!-- ── Main Content — branches on mode ── --%>
       <div class="flex flex-1 overflow-hidden">
-        <%!-- Left: Chat + Input --%>
-        <div class="flex-1 flex flex-col min-w-0">
-          <.live_component
-            module={LoomkinWeb.ChatComponent}
-            id="chat"
-            messages={@messages}
-            status={@status}
-            current_tool={@current_tool}
-            streaming={@streaming}
-            streaming_content={@streaming_content}
-            architect_phase={@architect_phase}
-            plan_steps={@plan_steps}
-            current_step={@current_step}
-          />
-
-          <%!-- Input area --%>
-          <form phx-submit="send_message" class="p-4 border-t border-gray-800 bg-gray-900/80">
-            <div class="flex gap-3 items-end">
-              <div class="flex-1 relative">
-                <textarea
-                  name="text"
-                  rows="1"
-                  placeholder="What should we work on?"
-                  class="w-full bg-gray-800/60 border border-gray-700/50 rounded-xl px-4 py-3 text-sm text-gray-100 resize-none placeholder-gray-500 placeholder:italic focus:outline-none focus:ring-2 focus:ring-violet-500/30 focus:border-violet-500/50 transition-shadow"
-                  phx-hook="ShiftEnterSubmit"
-                  id="message-input"
-                ><%= @input_text %></textarea>
-              </div>
-              <button
-                :if={@status != :thinking}
-                type="submit"
-                class={"flex items-center justify-center w-10 h-10 rounded-xl transition-all duration-200 " <>
-                  if(@status == :idle, do: "bg-violet-600 hover:bg-violet-500 text-white send-btn-ready", else: "bg-gray-800 text-gray-600 cursor-not-allowed")}
-                disabled={@status != :idle}
-              >
-                <svg
-                  class="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2.5"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
-                  />
-                </svg>
-              </button>
-              <button
-                :if={@status == :thinking}
-                type="button"
-                phx-click="cancel"
-                class="flex items-center justify-center w-10 h-10 rounded-xl bg-red-600 hover:bg-red-500 text-white transition-all duration-200"
-              >
-                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                  <rect x="6" y="6" width="12" height="12" rx="2" />
-                </svg>
-              </button>
-            </div>
-            <p class="text-[10px] text-gray-600 mt-1.5 pl-1">
-              <kbd class="px-1 py-0.5 bg-gray-800/60 rounded text-gray-500 font-mono text-[9px]">
-                Shift+Enter
-              </kbd>
-              for new line
-            </p>
-          </form>
-        </div>
-
-        <%!-- Right: Sidebar --%>
-        <div class="w-96 border-l border-gray-800 flex flex-col bg-gray-900/50">
-          <%!-- Sidebar tab bar --%>
-          <div class="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/80">
-            <button
-              :for={tab <- [:files, :diff, :terminal, :graph, :team]}
-              phx-click="switch_tab"
-              phx-value-tab={tab}
-              class={"flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 " <>
-                if(@active_tab == tab,
-                  do: "bg-gray-800 text-violet-400",
-                  else: "text-gray-500 hover:text-gray-300 hover:bg-gray-800/40")}
-            >
-              <span class="text-sm">{tab_icon(tab)}</span>
-              {tab_label(tab)}
-            </button>
-          </div>
-
-          <%!-- Sidebar content with transition --%>
-          <div
-            class="flex-1 overflow-auto p-4 tab-content-enter"
-            phx-hook="TabTransition"
-            id={"tab-content-#{@active_tab}"}
-          >
-            {render_tab(@active_tab, assigns)}
-          </div>
-        </div>
+        {render_mode(@mode, assigns)}
       </div>
     </div>
+    """
+  end
+
+  # --- Solo Mode (current layout, minus :team tab) ---
+
+  defp render_mode(:solo, assigns) do
+    ~H"""
+    <%!-- Left: Chat + Input --%>
+    <div class="flex-1 flex flex-col min-w-0">
+      <.live_component
+        module={LoomkinWeb.ChatComponent}
+        id="chat"
+        messages={@messages}
+        status={@status}
+        current_tool={@current_tool}
+        streaming={@streaming}
+        streaming_content={@streaming_content}
+        architect_phase={@architect_phase}
+        plan_steps={@plan_steps}
+        current_step={@current_step}
+      />
+
+      {render_input_bar(assigns)}
+    </div>
+
+    <%!-- Right: Sidebar --%>
+    <div class="w-96 border-l border-gray-800 flex flex-col bg-gray-900/50">
+      <%!-- Sidebar tab bar (no :team tab — that's in mission control) --%>
+      <div class="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/80">
+        <button
+          :for={tab <- [:files, :diff, :terminal, :graph]}
+          phx-click="switch_tab"
+          phx-value-tab={tab}
+          class={"flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 " <>
+            if(@active_tab == tab,
+              do: "bg-gray-800 text-violet-400",
+              else: "text-gray-500 hover:text-gray-300 hover:bg-gray-800/40")}
+        >
+          <span class="text-sm">{tab_icon(tab)}</span>
+          {tab_label(tab)}
+        </button>
+      </div>
+
+      <%!-- Sidebar content with transition --%>
+      <div
+        class="flex-1 overflow-auto p-4 tab-content-enter"
+        phx-hook="TabTransition"
+        id={"tab-content-#{@active_tab}"}
+      >
+        {render_tab(@active_tab, assigns)}
+      </div>
+    </div>
+    """
+  end
+
+  # --- Mission Control Mode (three-panel layout) ---
+
+  defp render_mode(:mission_control, assigns) do
+    ~H"""
+    <%!-- Left: Agent Roster (w-56) --%>
+    <.live_component
+      module={LoomkinWeb.AgentRosterComponent}
+      id="agent-roster"
+      team_id={@active_team_id}
+      agents={roster_agents(@active_team_id)}
+      tasks={roster_tasks(@active_team_id)}
+      budget={roster_budget(@active_team_id)}
+      focused_agent={@focused_agent}
+    />
+
+    <%!-- Center: Activity Feed (flex-1) + Input Bar --%>
+    <div class="flex-1 flex flex-col min-w-0">
+      <.live_component
+        module={LoomkinWeb.TeamActivityComponent}
+        id="activity-feed"
+        team_id={@active_team_id}
+        events={@activity_events}
+        known_agents={@activity_known_agents}
+        focused_agent={@focused_agent}
+      />
+      {render_input_bar(assigns)}
+    </div>
+
+    <%!-- Right: Context Inspector (w-80, collapsible) --%>
+    <.live_component
+      module={LoomkinWeb.ContextInspectorComponent}
+      id="context-inspector"
+      active_inspector_tab={@active_inspector_tab}
+      focused_agent={@focused_agent}
+      inspector_mode={@inspector_mode}
+      file_tree_version={@file_tree_version}
+      selected_file={@selected_file}
+      file_content={@file_content}
+      diffs={@diffs}
+      shell_commands={@shell_commands}
+      messages={@messages}
+      status={@status}
+      current_tool={@current_tool}
+      streaming={@streaming}
+      streaming_content={@streaming_content}
+      architect_phase={@architect_phase}
+      plan_steps={@plan_steps}
+      current_step={@current_step}
+      team_id={@active_team_id}
+      project_path={@project_path}
+    />
+    """
+  end
+
+  # --- Shared input bar (used by both modes) ---
+
+  defp render_input_bar(assigns) do
+    ~H"""
+    <form phx-submit="send_message" class="p-4 border-t border-gray-800 bg-gray-900/80">
+      <div class="flex gap-3 items-end">
+        <div class="flex-1 relative">
+          <textarea
+            name="text"
+            rows="1"
+            placeholder="What should we work on?"
+            class="w-full bg-gray-800/60 border border-gray-700/50 rounded-xl px-4 py-3 text-sm text-gray-100 resize-none placeholder-gray-500 placeholder:italic focus:outline-none focus:ring-2 focus:ring-violet-500/30 focus:border-violet-500/50 transition-shadow"
+            phx-hook="ShiftEnterSubmit"
+            id="message-input"
+          ><%= @input_text %></textarea>
+        </div>
+        <button
+          :if={@status != :thinking}
+          type="submit"
+          class={"flex items-center justify-center w-10 h-10 rounded-xl transition-all duration-200 " <>
+            if(@status == :idle, do: "bg-violet-600 hover:bg-violet-500 text-white send-btn-ready", else: "bg-gray-800 text-gray-600 cursor-not-allowed")}
+          disabled={@status != :idle}
+        >
+          <svg
+            class="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+            />
+          </svg>
+        </button>
+        <button
+          :if={@status == :thinking}
+          type="button"
+          phx-click="cancel"
+          class="flex items-center justify-center w-10 h-10 rounded-xl bg-red-600 hover:bg-red-500 text-white transition-all duration-200"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <rect x="6" y="6" width="12" height="12" rx="2" />
+          </svg>
+        </button>
+      </div>
+      <p class="text-[10px] text-gray-600 mt-1.5 pl-1">
+        <kbd class="px-1 py-0.5 bg-gray-800/60 rounded text-gray-500 font-mono text-[9px]">
+          Shift+Enter
+        </kbd>
+        for new line
+      </p>
+    </form>
     """
   end
 
@@ -941,6 +1204,8 @@ defmodule LoomkinWeb.WorkspaceLive do
   defp subscribe_to_team(team_id) do
     Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}")
     Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:tasks")
+    Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:context")
+    Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:decisions")
   end
 
   @max_activity_events 200
@@ -949,6 +1214,9 @@ defmodule LoomkinWeb.WorkspaceLive do
     case activity_event_from(pubsub_event) do
       nil ->
         socket
+
+      :merge_tool_result ->
+        merge_tool_result(socket, pubsub_event)
 
       event ->
         events = socket.assigns.activity_events ++ [event]
@@ -965,67 +1233,298 @@ defmodule LoomkinWeb.WorkspaceLive do
     end
   end
 
-  defp activity_event_from({:tool_executing, agent, %{tool_name: name, tool_target: target}}) do
-    display = if target && target != "*", do: "#{name} on #{target}", else: name
-    %{id: Ecto.UUID.generate(), type: :tool_call, agent: agent, content: "used #{display}", timestamp: DateTime.utc_now(), expanded: false}
-  end
+  # Merge tool_complete result into the most recent tool_executing event for that agent
+  defp merge_tool_result(socket, {:tool_complete, agent, %{result: result} = payload}) do
+    tool_name = payload[:tool_name]
+    result_str = to_string(result)
 
-  defp activity_event_from({:tool_complete, agent, %{tool_name: name, result: result}}) do
-    truncated = String.slice(to_string(result), 0, 200)
-    %{id: Ecto.UUID.generate(), type: :tool_call, agent: agent, content: "#{name} done: #{truncated}", timestamp: DateTime.utc_now(), expanded: false}
-  end
-
-  defp activity_event_from({:agent_status, agent, status}) do
-    {type, content} =
-      case status do
-        :idle -> {:message, "is now idle"}
-        :working -> {:message, "started working"}
-        :blocked -> {:message, "is blocked"}
-        :error -> {:error, "encountered an error"}
-        _ -> {:message, "status: #{status}"}
+    # Truncate very long results but keep enough to be useful
+    truncated =
+      if String.length(result_str) > 2000 do
+        String.slice(result_str, 0, 2000) <> "\n... (truncated)"
+      else
+        result_str
       end
 
-    %{id: Ecto.UUID.generate(), type: type, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false}
+    events = socket.assigns.activity_events
+
+    # Find the last tool_call event from this agent (most recent match)
+    match_idx =
+      events
+      |> Enum.with_index()
+      |> Enum.reverse()
+      |> Enum.find_value(fn {ev, idx} ->
+        if ev.type == :tool_call && ev.agent == agent &&
+             (is_nil(tool_name) || (ev.metadata || %{})[:tool_name] == tool_name) &&
+             is_nil((ev.metadata || %{})[:result]) do
+          idx
+        end
+      end)
+
+    events =
+      if match_idx do
+        List.update_at(events, match_idx, fn ev ->
+          metadata = Map.put(ev.metadata || %{}, :result, truncated)
+          %{ev | metadata: metadata, expanded: false}
+        end)
+      else
+        # No matching executing event — create standalone result event
+        events ++
+          [
+            %{
+              id: Ecto.UUID.generate(),
+              type: :tool_call,
+              agent: agent,
+              content: tool_name || "tool result",
+              timestamp: DateTime.utc_now(),
+              expanded: false,
+              metadata: %{tool_name: tool_name, result: truncated}
+            }
+          ]
+      end
+
+    assign(socket, activity_events: events)
   end
 
-  defp activity_event_from({:task_assigned, task_id, agent}) do
-    %{id: Ecto.UUID.generate(), type: :task_assigned, agent: agent, content: "picked up task #{task_id}", timestamp: DateTime.utc_now(), expanded: false}
+  defp merge_tool_result(socket, _), do: socket
+
+  # --- Tool events: executing creates the card, complete merges result into it ---
+
+  defp activity_event_from({:tool_executing, agent, %{tool_name: name} = payload}) do
+    target = payload[:tool_target]
+    content = tool_display_content(name, target, payload)
+
+    %{
+      id: "tool-#{agent}-#{System.unique_integer([:positive])}",
+      type: :tool_call,
+      agent: agent,
+      content: content,
+      timestamp: DateTime.utc_now(),
+      expanded: false,
+      metadata: %{
+        tool_name: name,
+        file_path: target,
+        result: nil
+      }
+    }
   end
 
-  defp activity_event_from({:task_completed, task_id, agent, result}) do
+  # tool_complete is handled specially — not via activity_event_from, see forward_to_activity
+  defp activity_event_from({:tool_complete, _agent, _payload}), do: :merge_tool_result
+
+  # --- Agent status: only surface meaningful transitions, skip noisy ones ---
+
+  defp activity_event_from({:agent_status, _agent, status}) when status in [:idle, :working], do: nil
+
+  defp activity_event_from({:agent_status, agent, :blocked}) do
+    %{id: Ecto.UUID.generate(), type: :error, agent: agent, content: "Blocked — waiting for input", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
+  end
+
+  defp activity_event_from({:agent_status, agent, :error}) do
+    %{id: Ecto.UUID.generate(), type: :error, agent: agent, content: "Encountered an error", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
+  end
+
+  defp activity_event_from({:agent_status, _agent, _}), do: nil
+
+  # --- Streaming: skip start/end noise ---
+
+  defp activity_event_from({:agent_stream_start, _agent, _payload}), do: nil
+  defp activity_event_from({:agent_stream_delta, _agent, _payload}), do: nil
+  defp activity_event_from({:agent_stream_end, _agent, _payload}), do: nil
+
+  # --- Task lifecycle: human-readable content ---
+
+  defp activity_event_from({:task_assigned, _task_id, agent}) do
+    %{id: Ecto.UUID.generate(), type: :task_assigned, agent: agent, content: "Picked up a task", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
+  end
+
+  defp activity_event_from({:task_started, _task_id, agent}) do
+    nil
+    # Task start is redundant with task_assigned — skip to reduce noise
+    |> then(fn _ -> nil end)
+  end
+
+  defp activity_event_from({:task_completed, _task_id, agent, result}) do
     content =
       case result do
-        r when is_binary(r) -> "completed task #{task_id}: #{String.slice(r, 0, 200)}"
-        _ -> "completed task #{task_id}"
+        r when is_binary(r) and byte_size(r) > 0 -> "Completed: #{String.slice(r, 0, 300)}"
+        _ -> "Task completed"
       end
 
-    %{id: Ecto.UUID.generate(), type: :task_complete, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false}
+    %{id: Ecto.UUID.generate(), type: :task_complete, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
   end
 
-  defp activity_event_from({:decision_logged, node_id, agent}) do
-    %{id: Ecto.UUID.generate(), type: :decision, agent: agent, content: "logged decision #{node_id}", timestamp: DateTime.utc_now(), expanded: false}
+  defp activity_event_from({:task_failed, _task_id, agent, reason}) do
+    content = "Task failed: #{String.slice(to_string(reason), 0, 300)}"
+    %{id: Ecto.UUID.generate(), type: :error, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
+  end
+
+  # --- Inter-agent communication ---
+
+  defp activity_event_from({:decision_logged, _node_id, agent}) do
+    %{id: Ecto.UUID.generate(), type: :decision, agent: agent, content: "Logged a decision", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
   end
 
   defp activity_event_from({:context_update, agent, payload}) do
     content =
       case payload do
-        %{type: :discovery, content: c} -> c
-        %{content: c} -> c
-        _ -> inspect(payload)
+        %{type: :discovery, content: c} when is_binary(c) -> c
+        %{content: c} when is_binary(c) -> c
+        _ -> "Shared a discovery"
       end
 
-    %{id: Ecto.UUID.generate(), type: :discovery, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false}
+    %{id: Ecto.UUID.generate(), type: :discovery, agent: agent, content: content, timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
   end
 
-  defp activity_event_from({:context_offloaded, agent, _payload}) do
-    %{id: Ecto.UUID.generate(), type: :discovery, agent: agent, content: "offloaded context to keeper", timestamp: DateTime.utc_now(), expanded: false}
+  defp activity_event_from({:context_offloaded, agent, payload}) do
+    topic = if is_map(payload), do: payload[:topic] || "context", else: "context"
+    %{id: Ecto.UUID.generate(), type: :context_offload, agent: agent, content: "Stored context: #{topic}", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
   end
 
-  defp activity_event_from({:agent_stream_end, agent, _payload}) do
-    %{id: Ecto.UUID.generate(), type: :thinking, agent: agent, content: "finished thinking", timestamp: DateTime.utc_now(), expanded: false}
+  defp activity_event_from({:role_changed, agent, old_role, new_role}) do
+    %{id: Ecto.UUID.generate(), type: :message, agent: agent, content: "Changed role: #{old_role} → #{new_role}", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
+  end
+
+  defp activity_event_from({:agent_escalation, agent, from, to}) do
+    %{id: Ecto.UUID.generate(), type: :message, agent: agent, content: "Escalated model: #{from} → #{to}", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
+  end
+
+  defp activity_event_from({:keeper_created, payload}) do
+    agent = if is_map(payload), do: payload[:agent] || payload[:source] || "system", else: "system"
+    topic = if is_map(payload), do: payload[:topic] || "context", else: "context"
+    tokens = if is_map(payload), do: payload[:tokens], else: nil
+    suffix = if tokens, do: " (#{format_token_count(tokens)} tokens)", else: ""
+    %{id: Ecto.UUID.generate(), type: :context_offload, agent: agent, content: "Created keeper: #{topic}#{suffix}", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
+  end
+
+  defp activity_event_from({:tasks_unblocked, task_ids}) do
+    count = length(task_ids)
+    %{id: Ecto.UUID.generate(), type: :message, agent: "system", content: "#{count} task#{if count == 1, do: "", else: "s"} unblocked", timestamp: DateTime.utc_now(), expanded: false, metadata: %{}}
   end
 
   defp activity_event_from(_), do: nil
+
+  # --- Human-readable tool descriptions ---
+
+  defp tool_display_content("file_read", target, _payload) when is_binary(target),
+    do: "Reading #{target}"
+
+  defp tool_display_content("file_read", _, _), do: "Reading a file"
+
+  defp tool_display_content("file_write", target, _payload) when is_binary(target),
+    do: "Writing #{target}"
+
+  defp tool_display_content("file_edit", target, _payload) when is_binary(target),
+    do: "Editing #{target}"
+
+  defp tool_display_content("file_search", _, payload) do
+    pattern = payload[:pattern] || payload[:args] || ""
+    "Searching files: #{pattern}"
+  end
+
+  defp tool_display_content("content_search", _, payload) do
+    pattern = payload[:pattern] || payload[:query] || ""
+    "Searching content: #{pattern}"
+  end
+
+  defp tool_display_content("directory_list", target, _payload) when is_binary(target),
+    do: "Listing #{target}/"
+
+  defp tool_display_content("directory_list", _, _), do: "Listing directory"
+
+  defp tool_display_content("shell", _, payload) do
+    cmd = payload[:command] || ""
+    "Running: #{String.slice(to_string(cmd), 0, 80)}"
+  end
+
+  defp tool_display_content("git", _, payload) do
+    op = payload[:operation] || ""
+    "Git #{op}"
+  end
+
+  defp tool_display_content("decision_log", _, _), do: "Logging decision"
+  defp tool_display_content("decision_query", _, _), do: "Querying decisions"
+  defp tool_display_content("peer_message", _, _), do: "Sending message"
+  defp tool_display_content("peer_discovery", _, _), do: "Broadcasting discovery"
+  defp tool_display_content("peer_create_task", _, _), do: "Creating task"
+  defp tool_display_content("peer_complete_task", _, _), do: "Completing task"
+  defp tool_display_content("peer_ask_question", _, _), do: "Asking the team"
+  defp tool_display_content("context_offload", _, _), do: "Offloading context"
+  defp tool_display_content("context_retrieve", _, _), do: "Retrieving context"
+
+  defp tool_display_content(name, target, _payload) when is_binary(target),
+    do: "#{name} on #{target}"
+
+  defp tool_display_content(name, _, _), do: name
+
+  defp format_token_count(n) when is_integer(n) and n >= 1000,
+    do: "#{Float.round(n / 1000, 1)}k"
+
+  defp format_token_count(n) when is_integer(n), do: "#{n}"
+  defp format_token_count(_), do: "?"
+
+  # --- Auto-follow logic for mission control ---
+
+  defp maybe_auto_follow(socket, agent_name, payload) do
+    agent = if is_binary(agent_name), do: agent_name, else: nil
+
+    if socket.assigns.mode == :mission_control && socket.assigns.inspector_mode == :auto_follow do
+      case payload[:tool_name] do
+        name when name in ["file_read", "content_search", "file_search"] ->
+          assign(socket,
+            active_inspector_tab: :files,
+            focused_agent: agent,
+            selected_file: payload[:path]
+          )
+
+        name when name in ["file_write", "file_edit"] ->
+          assign(socket, active_inspector_tab: :diff, focused_agent: agent)
+
+        "shell" ->
+          assign(socket, active_inspector_tab: :terminal, focused_agent: agent)
+
+        "decision_log" ->
+          assign(socket, active_inspector_tab: :graph, focused_agent: agent)
+
+        _ ->
+          if agent, do: assign(socket, focused_agent: agent), else: socket
+      end
+    else
+      socket
+    end
+  end
+
+  # --- Roster data helpers (for AgentRosterComponent) ---
+
+  defp roster_agents(nil), do: []
+
+  defp roster_agents(team_id) do
+    case Loomkin.Teams.Manager.list_agents(team_id) do
+      {:ok, agents} -> agents
+      _ -> []
+    end
+  end
+
+  defp roster_tasks(nil), do: []
+
+  defp roster_tasks(team_id) do
+    Loomkin.Teams.Tasks.list_all(team_id)
+  end
+
+  defp roster_budget(nil), do: %{spent: 0.0, limit: 5.0}
+
+  defp roster_budget(team_id) do
+    summary = Loomkin.Teams.CostTracker.team_cost_summary(team_id)
+
+    spent =
+      case summary[:total_cost_usd] do
+        %Decimal{} = d -> Decimal.to_float(d)
+        n when is_number(n) -> n / 1
+        _ -> 0.0
+      end
+
+    %{spent: spent, limit: 5.0}
+  end
 
   defp forward_to_team_components(socket) do
     forward_to_dashboard(socket)
@@ -1047,7 +1546,8 @@ defmodule LoomkinWeb.WorkspaceLive do
     end
   end
 
-  defp team_tab_visible?(socket), do: socket.assigns[:active_tab] == :team
+  defp team_tab_visible?(socket),
+    do: socket.assigns[:active_tab] == :team || socket.assigns[:mode] == :mission_control
 
   defp short_team_id(id) when is_binary(id), do: String.slice(id, 0, 8)
   defp short_team_id(_), do: "?"

--- a/test/loomkin_web/live/team_activity_component_test.exs
+++ b/test/loomkin_web/live/team_activity_component_test.exs
@@ -34,11 +34,15 @@ defmodule LoomkinWeb.TeamActivityComponentTest do
 
       assert html =~ "tool"
       assert html =~ "message"
-      assert html =~ "decision"
+      assert html =~ "created"
       assert html =~ "done"
       assert html =~ "assigned"
       assert html =~ "discovery"
       assert html =~ "error"
+      assert html =~ "thinking"
+      assert html =~ "joined"
+      assert html =~ "offload"
+      assert html =~ "question"
     end
   end
 


### PR DESCRIPTION
## Summary

- **New three-panel Mission Control layout** that auto-activates when agents spawn — agent roster (left), activity feed (center, PRIMARY), context inspector (right)
- **Activity feed is now THE interface** — rich event cards for tool calls with inline results, streaming agent thoughts, inter-agent messages, task lifecycle, discoveries, and 11+ event types
- **Agent roster** with live status dots, task progress, budget bar — click an agent to filter the feed and pin the inspector to what they're looking at
- **Context inspector** auto-follows agent activity (file reads → files tab, edits → diff tab, shell → terminal) with pin/unpin modes
- **Bug fixes**: LLMRetry crash on ReqLLM error structs (429 rate limits), budget key mismatch crash, user messages invisible in MC mode

### Files changed (9 files, +1,952 / -244)

| File | Change |
|------|--------|
| `agent_roster_component.ex` | **New** (253 LOC) |
| `context_inspector_component.ex` | **New** (271 LOC) |
| `team_activity_component.ex` | Rewritten (249 → 767 LOC) |
| `workspace_live.ex` | Restructured (1,102 → 1,400+ LOC) |
| `app.css` | +83 LOC (animations) |
| `app.js` | +45 LOC (keyboard shortcuts) |
| `llm_retry.ex` | +11 LOC (struct fix) |
| `README.md` | Discord badge |
| `team_activity_component_test.exs` | Updated assertions |

## Test plan

- [x] `mix compile` — clean
- [x] `mix test test/loomkin_web/live/` — 34 tests, 0 failures
- [ ] Manual: send message → verify team spawns → MC mode activates
- [ ] Manual: verify activity feed shows tool calls with results, agent thoughts streaming
- [ ] Manual: click agent in roster → feed filters, inspector follows
- [ ] Manual: keyboard shortcuts (Cmd+M toggle, / focus, Esc unpin)
- [ ] Manual: team dissolves → auto-return to Solo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)