### PR TITLE
Fix model propagation — team agents respect user's provider selection

### DIFF
--- a/lib/loomkin/agent_loop.ex
+++ b/lib/loomkin/agent_loop.ex
@@ -366,14 +366,40 @@ defmodule Loomkin.AgentLoop do
     Map.new(args, fn
       {k, v} when is_binary(k) ->
         case Map.fetch(known_strings, k) do
-          {:ok, atom_key} -> {atom_key, v}
-          :error -> {k, v}
+          {:ok, atom_key} -> {atom_key, deep_atomize_value(v)}
+          :error -> {k, deep_atomize_value(v)}
         end
 
       {k, v} ->
-        {k, v}
+        {k, deep_atomize_value(v)}
     end)
   end
+
+  # Recursively atomize string keys in nested maps and lists.
+  # LLM tool calls return JSON with string keys at every nesting level,
+  # but Jido/NimbleOptions validation expects atom keys for maps.
+  defp deep_atomize_value(list) when is_list(list) do
+    Enum.map(list, &deep_atomize_value/1)
+  end
+
+  defp deep_atomize_value(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_binary(k) ->
+        atom_key =
+          try do
+            String.to_existing_atom(k)
+          rescue
+            ArgumentError -> k
+          end
+
+        {atom_key, deep_atomize_value(v)}
+
+      {k, v} ->
+        {k, deep_atomize_value(v)}
+    end)
+  end
+
+  defp deep_atomize_value(value), do: value
 
   defp record_tool_result(messages, config, tool_name, tool_call_id, result_text) do
     emit(config, :tool_complete, %{tool_name: tool_name, result: result_text})

--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -222,7 +222,9 @@ defmodule Loomkin.Teams.Agent do
   @impl true
   def handle_cast({:assign_task, task}, state) do
     Logger.info("[Agent:#{state.name}] Assigned task: #{inspect(task[:id] || task)}")
-    model = ModelRouter.select(state.role, task)
+    # Only override model if the task has an explicit model_hint;
+    # otherwise preserve the agent's current model (set at spawn from user's selection)
+    model = if task[:model_hint], do: ModelRouter.select(state.role, task), else: state.model
     state = %{state | task: task, model: model}
 
     messages = maybe_prefetch_context(state, task)
@@ -313,8 +315,11 @@ defmodule Loomkin.Teams.Agent do
 
       case Loomkin.Teams.Tasks.get_task(task_id) do
         {:ok, task} ->
-          model = ModelRouter.select(state.role, %{id: task.id, description: task.description})
-          state = %{state | task: %{id: task.id, description: task.description, title: task.title}, model: model}
+          # Only override model if the task has an explicit model_hint;
+          # otherwise preserve the agent's current model (set at spawn from user's selection)
+          task_map = %{id: task.id, description: task.description, title: task.title, model_hint: task.model_hint}
+          model = if task.model_hint, do: ModelRouter.select(state.role, task_map), else: state.model
+          state = %{state | task: task_map, model: model}
           messages = maybe_prefetch_context(state, state.task)
           state = %{state | messages: messages}
 

--- a/lib/loomkin/tools/file_read.ex
+++ b/lib/loomkin/tools/file_read.ex
@@ -74,27 +74,14 @@ defmodule Loomkin.Tools.FileRead do
       {:error, :eisdir} ->
         rel_path = Path.relative_to(full_path, project_path)
 
-        {:ok,
-         %{
-           result:
-             "Path is a directory, not a file: #{full_path}\n" <>
-               "Use directory_list with path: #{rel_path}"
-         }}
+        {:error,
+         "Path is a directory, not a file: #{full_path}\n" <>
+           "Use directory_list with path: #{rel_path}"}
 
       {:error, reason} ->
         {:error, "Failed to read #{full_path}: #{reason}"}
     end
   rescue
-    e in ArgumentError ->
-      if String.contains?(e.message, "outside the project directory") do
-        {:ok,
-         %{
-           result:
-             "#{e.message}\n" <>
-               "Use a path relative to the project root or move the file into this project."
-         }}
-      else
-        {:error, e.message}
-      end
+    e in ArgumentError -> {:error, e.message}
   end
 end

--- a/lib/loomkin/tools/sub_agent.ex
+++ b/lib/loomkin/tools/sub_agent.ex
@@ -43,7 +43,7 @@ defmodule Loomkin.Tools.SubAgent do
       raise "Scope '#{scope}' is outside the project directory"
     end
 
-    model = weak_model()
+    model = param(context, :model, nil) || weak_model()
     tool_defs = build_tool_definitions()
 
     system_content =

--- a/test/loomkin/teams/context_keeper_test.exs
+++ b/test/loomkin/teams/context_keeper_test.exs
@@ -6,11 +6,13 @@ defmodule Loomkin.Teams.ContextKeeperTest do
   setup do
     # Ensure supervisor tree is available
     on_exit(fn ->
-      # Clean up any keepers we spawned
-      DynamicSupervisor.which_children(Loomkin.Teams.AgentSupervisor)
-      |> Enum.each(fn {_, pid, _, _} ->
-        DynamicSupervisor.terminate_child(Loomkin.Teams.AgentSupervisor, pid)
-      end)
+      # Clean up any keepers we spawned (supervisor may already be down during teardown)
+      if Process.whereis(Loomkin.Teams.AgentSupervisor) do
+        DynamicSupervisor.which_children(Loomkin.Teams.AgentSupervisor)
+        |> Enum.each(fn {_, pid, _, _} ->
+          DynamicSupervisor.terminate_child(Loomkin.Teams.AgentSupervisor, pid)
+        end)
+      end
     end)
 
     :ok


### PR DESCRIPTION
## Summary

- **Sub-agents now inherit the user's selected model** instead of hardcoding `anthropic:claude-haiku-4-5`. The `sub_agent` tool reads `context[:model]` (set from the UI dropdown) with `weak_model()` as fallback only.
- **Task assignment no longer overwrites agent model**. Both `assign_task` and `task_assigned` handlers were calling `ModelRouter.select()` → `default_model()` → `anthropic:claude-sonnet-4-6`, overriding the model passed at spawn time. Now preserves the agent's model unless the task has an explicit `model_hint`.
- **Deep key atomization for nested tool args**. LLM tool calls with nested maps (e.g. `team_spawn` roles list) failed NimbleOptions validation because only top-level keys were converted from strings to atoms. Added recursive `deep_atomize_value` to handle nested maps and lists.
- **3 pre-existing test failures fixed**: FileRead error handling consistency (`{:ok}` → `{:error}` for error conditions) and ContextKeeper test teardown crash.

## Test plan

- [x] `mix test` — 923 tests, 0 failures
- [ ] Manual: select a non-Anthropic model (e.g. `zai:glm-4.7`), spawn a team, verify all agents use the selected model in logs
- [ ] Manual: verify `team_spawn` tool works with multi-agent roles
- [ ] Manual: verify `sub_agent` tool works without `ANTHROPIC_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)