### PR TITLE
Fix community-reported UI issues #55-#59

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,18 +28,27 @@ Hooks.ShiftEnterSubmit = {
   }
 }
 
-// ScrollToBottom: auto-scrolls container to bottom when content updates
+// ScrollToBottom: auto-scrolls container to bottom when content updates (only if near bottom)
 Hooks.ScrollToBottom = {
   mounted() {
     this.scrollToBottom()
-    this.observer = new MutationObserver(() => this.scrollToBottom())
+    this.observer = new MutationObserver(() => this.maybeScrollToBottom())
     this.observer.observe(this.el, { childList: true, subtree: true })
   },
   updated() {
-    this.scrollToBottom()
+    this.maybeScrollToBottom()
   },
   destroyed() {
     if (this.observer) this.observer.disconnect()
+  },
+  isNearBottom() {
+    const threshold = 100
+    return this.el.scrollHeight - this.el.scrollTop - this.el.clientHeight < threshold
+  },
+  maybeScrollToBottom() {
+    if (this.isNearBottom()) {
+      this.scrollToBottom()
+    }
   },
   scrollToBottom() {
     this.el.scrollTop = this.el.scrollHeight

--- a/lib/loomkin/agent_loop.ex
+++ b/lib/loomkin/agent_loop.ex
@@ -423,6 +423,10 @@ defmodule Loomkin.AgentLoop do
   defp record_tool_result(messages, config, tool_name, tool_call_id, result_text) do
     emit(config, :tool_complete, %{tool_name: tool_name, result: result_text})
 
+    if String.starts_with?(result_text || "", "Error:") do
+      emit(config, :tool_error, %{tool_name: tool_name, error: result_text})
+    end
+
     tool_msg = %{role: :tool, content: result_text, tool_call_id: tool_call_id}
     emit(config, :new_message, tool_msg)
 

--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -983,6 +983,9 @@ defmodule Loomkin.Teams.Agent do
       :context_offloaded ->
         Phoenix.PubSub.broadcast(Loomkin.PubSub, topic, {:context_offloaded, agent_name, payload})
 
+      :tool_error ->
+        Phoenix.PubSub.broadcast(Loomkin.PubSub, topic, {:agent_error, agent_name, payload})
+
       :max_iterations_exceeded ->
         Phoenix.PubSub.broadcast(Loomkin.PubSub, topic, {:agent_error, agent_name, payload})
 

--- a/lib/loomkin_web/live/chat_component.ex
+++ b/lib/loomkin_web/live/chat_component.ex
@@ -67,19 +67,29 @@ defmodule LoomkinWeb.ChatComponent do
 
             <% :tool -> %>
               <div class="max-w-[85%] ml-10 animate-fade-in-up">
-                <div class={"tool-card rounded-xl overflow-hidden border transition-all duration-200 #{tool_card_border(msg)}"}>
-                  <div
-                    class={"flex items-center gap-2 px-3 py-2 cursor-pointer select-none text-xs font-medium #{tool_card_header(msg)}"}
-                    onclick="this.parentElement.classList.toggle('tool-expanded')"
-                  >
-                    <span class="tool-card-icon">{tool_icon(msg)}</span>
-                    <span>{tool_display_name(msg)}</span>
-                    <span class="ml-auto text-gray-500 tool-card-chevron transition-transform duration-200">&#9656;</span>
+                <%= if String.starts_with?(msg.content || "", "Error:") do %>
+                  <div class="rounded-xl overflow-hidden border border-red-500/30 bg-red-950/20 px-3 py-2">
+                    <div class="flex items-center gap-2 text-xs font-medium text-red-400">
+                      <span class="text-red-400">&#9888;</span>
+                      <span>{tool_display_name(msg)}</span>
+                    </div>
+                    <pre class="text-xs text-red-300/80 whitespace-pre-wrap mt-1">{msg.content}</pre>
                   </div>
-                  <div class="tool-card-body px-3 py-2 border-t border-gray-800/50 bg-gray-900/30">
-                    <pre class="text-xs text-gray-400 whitespace-pre-wrap overflow-x-auto font-mono leading-relaxed tool-file-paths">{truncate_result(msg.content)}</pre>
+                <% else %>
+                  <div class={"tool-card rounded-xl overflow-hidden border transition-all duration-200 #{tool_card_border(msg)}"}>
+                    <div
+                      class={"flex items-center gap-2 px-3 py-2 cursor-pointer select-none text-xs font-medium #{tool_card_header(msg)}"}
+                      onclick="this.parentElement.classList.toggle('tool-expanded')"
+                    >
+                      <span class="tool-card-icon">{tool_icon(msg)}</span>
+                      <span>{tool_display_name(msg)}</span>
+                      <span class="ml-auto text-gray-500 tool-card-chevron transition-transform duration-200">&#9656;</span>
+                    </div>
+                    <div class="tool-card-body px-3 py-2 border-t border-gray-800/50 bg-gray-900/30">
+                      <pre class="text-xs text-gray-400 whitespace-pre-wrap overflow-x-auto font-mono leading-relaxed tool-file-paths">{truncate_result(msg.content)}</pre>
+                    </div>
                   </div>
-                </div>
+                <% end %>
               </div>
 
             <% _ -> %>
@@ -162,7 +172,7 @@ defmodule LoomkinWeb.ChatComponent do
     streaming = Keyword.get(opts, :streaming, false)
 
     doc =
-      MDEx.new(streaming: streaming)
+      MDEx.new(streaming: streaming, render: [unsafe_: true])
       |> MDEx.Document.put_markdown(content)
 
     case MDEx.to_html(doc) do

--- a/lib/loomkin_web/live/file_tree_component.ex
+++ b/lib/loomkin_web/live/file_tree_component.ex
@@ -91,14 +91,17 @@ defmodule LoomkinWeb.FileTreeComponent do
         <h3 class="text-[10px] font-semibold text-gray-500 uppercase tracking-widest mb-2">Explorer</h3>
         <div class="relative">
           <.icon name="hero-magnifying-glass-mini" class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500" />
-          <input
-            type="text"
-            placeholder="Filter files..."
-            value={@filter}
-            phx-keyup="filter"
-            phx-target={@myself}
-            class="w-full pl-8 pr-8 py-1.5 text-xs bg-gray-800/60 border border-gray-700/50 rounded-lg text-gray-200 placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-violet-500/30 focus:border-violet-500/50 transition-shadow"
-          />
+          <form phx-change="filter" phx-target={@myself} phx-submit="filter">
+            <input
+              type="text"
+              name="filter"
+              placeholder="Filter files..."
+              value={@filter}
+              class="w-full pl-8 pr-8 py-1.5 text-xs bg-gray-800/60 border border-gray-700/50 rounded-lg text-gray-200 placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-violet-500/30 focus:border-violet-500/50 transition-shadow"
+              autocomplete="off"
+              phx-debounce="200"
+            />
+          </form>
           <button
             :if={@filter != ""}
             phx-click="clear_filter"

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -113,6 +113,7 @@ defmodule LoomkinWeb.WorkspaceLive do
     assign(socket,
       session_id: session_id,
       project_path: project_path,
+      editing_project_path: false,
       model: effective_model,
       messages: messages,
       session_cost: session_metrics.cost_usd,
@@ -228,6 +229,33 @@ defmodule LoomkinWeb.WorkspaceLive do
 
   def handle_event("switch_team", %{"team-id" => team_id}, socket) do
     {:noreply, assign(socket, active_team_id: team_id)}
+  end
+
+  def handle_event("edit_project_path", _params, socket) do
+    {:noreply, assign(socket, editing_project_path: true)}
+  end
+
+  def handle_event("cancel_edit_project", _params, socket) do
+    {:noreply, assign(socket, editing_project_path: false)}
+  end
+
+  def handle_event("set_project_path", %{"path" => path}, socket) do
+    path = String.trim(path)
+
+    if File.dir?(path) do
+      {:noreply,
+       socket
+       |> assign(
+         project_path: path,
+         editing_project_path: false,
+         file_tree_version: (socket.assigns[:file_tree_version] || 0) + 1
+       )}
+    else
+      {:noreply,
+       socket
+       |> assign(editing_project_path: false)
+       |> put_flash(:error, "Directory not found: #{path}")}
+    end
   end
 
   def handle_event("toggle_mode", _, socket) do
@@ -773,6 +801,26 @@ defmodule LoomkinWeb.WorkspaceLive do
             model={@model}
           />
 
+          <%!-- Project path switcher --%>
+          <div class="flex items-center gap-2 text-sm text-gray-400">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+            </svg>
+            <%= if @editing_project_path do %>
+              <form phx-submit="set_project_path" class="flex items-center gap-1">
+                <input type="text" name="path" value={@project_path}
+                  class="bg-gray-800 border border-gray-700 rounded px-2 py-0.5 text-sm text-gray-200 w-64"
+                  autofocus />
+                <button type="submit" class="text-xs text-violet-400 hover:text-violet-300">Go</button>
+                <button type="button" phx-click="cancel_edit_project" class="text-xs text-gray-500 hover:text-gray-400">Cancel</button>
+              </form>
+            <% else %>
+              <button phx-click="edit_project_path" class="hover:text-gray-200 transition truncate max-w-xs" title={@project_path}>
+                {@project_path}
+              </button>
+            <% end %>
+          </div>
+
           <%!-- Team indicator (mission control mode) --%>
           <div :if={@mode == :mission_control && @active_team_id} class="flex items-center gap-2">
             <span class="text-xs text-violet-400 font-medium">
@@ -841,7 +889,7 @@ defmodule LoomkinWeb.WorkspaceLive do
       </header>
 
       <%!-- ── Main Content — branches on mode ── --%>
-      <div class="flex flex-1 overflow-hidden">
+      <div class="flex flex-1 min-h-0">
         {render_mode(@mode, assigns)}
       </div>
     </div>
@@ -873,7 +921,7 @@ defmodule LoomkinWeb.WorkspaceLive do
     <%!-- Right: Sidebar --%>
     <div class="w-96 border-l border-gray-800 flex flex-col bg-gray-900/50">
       <%!-- Sidebar tab bar (no :team tab — that's in mission control) --%>
-      <div class="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/80">
+      <div class="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/80 overflow-x-auto flex-shrink-0">
         <button
           :for={tab <- [:files, :diff, :terminal, :graph]}
           phx-click="switch_tab"
@@ -1352,6 +1400,9 @@ defmodule LoomkinWeb.WorkspaceLive do
       cond do
         is_map(payload) && payload[:max] ->
           "Exceeded max iterations (#{payload[:max]})"
+
+        is_map(payload) && payload[:error] ->
+          "#{payload[:tool_name] || "Tool"}: #{String.slice(to_string(payload[:error]), 0, 300)}"
 
         is_map(payload) && payload[:reason] ->
           "Error: #{String.slice(to_string(payload[:reason]), 0, 300)}"


### PR DESCRIPTION
## Summary

- **#55** — Sidebar tab bar no longer clips on narrow viewports (added `overflow-x-auto flex-shrink-0`, replaced `overflow-hidden` with `min-h-0`)
- **#56** — Added project path switcher to workspace header (click-to-edit with directory validation)
- **#57** — File filter no longer crashes LiveView (wrapped input in `<form phx-change>` to match handler pattern)
- **#58** — `ScrollToBottom` hook respects user scroll position (only auto-scrolls when within 100px of bottom)
- **#59** — Tool errors show red error cards in chat, emit `:tool_error` to activity feed, and MDEx renders HTML entities correctly

Closes #55, closes #56, closes #57, closes #58, closes #59

## Test plan

- [ ] Narrow viewport: all sidebar tabs (files, diff, terminal, graph) visible, horizontal scroll if needed
- [ ] Header dropdowns (model selector, session switcher) still render correctly after `overflow-hidden` removal
- [ ] Click project path in header → edit input appears; enter valid dir → file tree updates; invalid → error flash
- [ ] Type in file filter → files filter in real-time without page reload or crash
- [ ] Scroll up in chat/activity feed while messages arrive → position stays put; scroll to bottom → auto-follow resumes
- [ ] Trigger a tool error → red error card in chat, error event in activity feed
- [ ] LLM markdown with `&`, `'`, `<` renders correctly without escaped entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)