### PR TITLE
Prevent roster crash when current_task is absent

### DIFF
--- a/lib/loomkin_web/live/agent_roster_component.ex
+++ b/lib/loomkin_web/live/agent_roster_component.ex
@@ -93,7 +93,7 @@ defmodule LoomkinWeb.AgentRosterComponent do
             <%!-- Row 2: current task --%>
             <div class="mt-0.5 pl-4">
               <span class={"text-xs #{status_text_color(agent.status)}"}>
-                {agent.current_task || status_label(agent.status)}
+                {Map.get(agent, :current_task) || status_label(agent.status)}
               </span>
             </div>
           </button>


### PR DESCRIPTION
## Summary
- fix a LiveView crash in `AgentRosterComponent` when agent entries do not include `:current_task`
- replace strict field access (`agent.current_task`) with safe lookup (`Map.get(agent, :current_task)`)
- preserve existing fallback behavior to `status_label(agent.status)`

## Root Cause
`Teams.Manager.list_agents/1` returns lightweight agent maps without `:current_task`, which caused a `KeyError` during render.

## Validation
- `mix compile`
- `mix test test/loomkin_web/live` (34 tests, 0 failures)
