### PR TITLE
Epic 6.1 + 6.2: Async agent loop & priority message router

### DIFF
--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -188,7 +188,9 @@ defmodule Loomkin.Teams.Agent do
       {%Task{} = task, original_from} ->
         Logger.info("[Agent:#{state.name}] Cancelling agent loop")
         Task.shutdown(task, :brutal_kill)
+        task_id = state.task && state.task[:id]
         if original_from, do: GenServer.reply(original_from, {:error, :cancelled})
+        if !original_from && task_id, do: Loomkin.Teams.Tasks.fail_task(task_id, "cancelled")
         state = %{state | loop_task: nil, pending_updates: [], priority_queue: []}
         state = set_status(state, :idle)
         broadcast_team(state, {:agent_status, state.name, :idle})
@@ -359,12 +361,17 @@ defmodule Loomkin.Teams.Agent do
     case state.loop_task do
       {%Task{ref: ^ref}, from} ->
         Logger.error("[Agent:#{state.name}] Loop task crashed: #{inspect(reason)}")
+        task_id = state.task && state.task[:id]
 
         state = %{state | loop_task: nil}
         state = set_status(state, :idle)
         broadcast_team(state, {:agent_status, state.name, :idle})
 
-        if from, do: GenServer.reply(from, {:error, :crashed})
+        if from do
+          GenServer.reply(from, {:error, :crashed})
+        else
+          if task_id, do: Loomkin.Teams.Tasks.fail_task(task_id, "crashed: #{inspect(reason)}")
+        end
 
         {:noreply, drain_queues(state)}
 
@@ -782,6 +789,12 @@ defmodule Loomkin.Teams.Agent do
   end
 
   @impl true
+  def handle_info({:inject_system_message, content}, state) do
+    msg = %{role: :system, content: content}
+    {:noreply, %{state | messages: state.messages ++ [msg]}}
+  end
+
+  @impl true
   def handle_info(_msg, state) do
     {:noreply, state}
   end
@@ -985,7 +998,9 @@ defmodule Loomkin.Teams.Agent do
     case state.loop_task do
       {%Task{} = task, from} ->
         Task.shutdown(task, :brutal_kill)
+        task_id = state.task && state.task[:id]
         if from, do: GenServer.reply(from, {:error, :budget_exceeded})
+        if !from && task_id, do: Loomkin.Teams.Tasks.fail_task(task_id, "budget exceeded")
         state = %{state | loop_task: nil, pending_updates: [], priority_queue: []}
         state = set_status(state, :idle)
         broadcast_team(state, {:agent_status, state.name, :idle})
@@ -997,12 +1012,10 @@ defmodule Loomkin.Teams.Agent do
   end
 
   defp handle_urgent({:file_conflict, details}, state) do
-    warning = %{
-      role: :system,
-      content: "[URGENT] File conflict detected: #{inspect(details)}"
-    }
-
-    {:noreply, %{state | messages: state.messages ++ [warning]}}
+    # Queue as an internal message so it survives the loop result handler
+    # (which overwrites state.messages with the task-returned msgs).
+    inject = {:inject_system_message, "[URGENT] File conflict detected: #{inspect(details)}"}
+    {:noreply, %{state | priority_queue: state.priority_queue ++ [inject]}}
   end
 
   defp handle_urgent(_msg, state), do: {:noreply, state}

--- a/lib/loomkin/teams/priority_router.ex
+++ b/lib/loomkin/teams/priority_router.ex
@@ -38,7 +38,7 @@ defmodule Loomkin.Teams.PriorityRouter do
       {:ignore, :agent_status}
   """
   @spec classify(tuple()) :: {:urgent | :high | :normal | :ignore, atom()}
-  def classify(msg) when is_tuple(msg) do
+  def classify(msg) when is_tuple(msg) and tuple_size(msg) > 0 do
     type = elem(msg, 0)
 
     cond do

--- a/lib/loomkin/teams/tasks.ex
+++ b/lib/loomkin/teams/tasks.ex
@@ -37,32 +37,44 @@ defmodule Loomkin.Teams.Tasks do
   end
 
   def complete_task(task_id, result) do
-    get_task!(task_id)
-    |> TeamTask.changeset(%{status: :completed, result: result})
-    |> Repo.update()
-    |> tap_ok(fn task ->
-      # Persist accumulated cost/tokens from CostTracker for the owning agent
-      if task.owner do
-        usage = CostTracker.get_agent_usage(task.team_id, task.owner)
-        CostTracker.persist_task_cost(task.id, usage.cost, usage.input_tokens + usage.output_tokens)
-      end
+    task = get_task!(task_id)
 
-      Comms.broadcast_task_event(task.team_id, {:task_completed, task.id, task.owner, result})
-      Context.cache_task(task.team_id, task.id, %{title: task.title, status: :completed, owner: task.owner})
-      record_learning_metric(task, true)
-      auto_schedule_unblocked(task.team_id)
-    end)
+    if task.status in [:completed, :failed] do
+      {:ok, task}
+    else
+      task
+      |> TeamTask.changeset(%{status: :completed, result: result})
+      |> Repo.update()
+      |> tap_ok(fn task ->
+        # Persist accumulated cost/tokens from CostTracker for the owning agent
+        if task.owner do
+          usage = CostTracker.get_agent_usage(task.team_id, task.owner)
+          CostTracker.persist_task_cost(task.id, usage.cost, usage.input_tokens + usage.output_tokens)
+        end
+
+        Comms.broadcast_task_event(task.team_id, {:task_completed, task.id, task.owner, result})
+        Context.cache_task(task.team_id, task.id, %{title: task.title, status: :completed, owner: task.owner})
+        record_learning_metric(task, true)
+        auto_schedule_unblocked(task.team_id)
+      end)
+    end
   end
 
   def fail_task(task_id, reason) do
-    get_task!(task_id)
-    |> TeamTask.changeset(%{status: :failed, result: reason})
-    |> Repo.update()
-    |> tap_ok(fn task ->
-      Comms.broadcast_task_event(task.team_id, {:task_failed, task.id, task.owner, reason})
-      Context.cache_task(task.team_id, task.id, %{title: task.title, status: :failed, owner: task.owner})
-      record_learning_metric(task, false)
-    end)
+    task = get_task!(task_id)
+
+    if task.status in [:completed, :failed] do
+      {:ok, task}
+    else
+      task
+      |> TeamTask.changeset(%{status: :failed, result: reason})
+      |> Repo.update()
+      |> tap_ok(fn task ->
+        Comms.broadcast_task_event(task.team_id, {:task_failed, task.id, task.owner, reason})
+        Context.cache_task(task.team_id, task.id, %{title: task.title, status: :failed, owner: task.owner})
+        record_learning_metric(task, false)
+      end)
+    end
   end
 
   def add_dependency(task_id, depends_on_id, dep_type \\ :blocks) do

--- a/test/loomkin/teams/agent_async_test.exs
+++ b/test/loomkin/teams/agent_async_test.exs
@@ -200,7 +200,7 @@ defmodule Loomkin.Teams.AgentAsyncTest do
       refute Process.alive?(task.pid)
     end
 
-    test "handles urgent file_conflict by injecting warning (loop continues)" do
+    test "handles urgent file_conflict by queuing injection (loop continues)" do
       %{pid: pid, team_id: team_id} = start_agent()
       task = simulate_active_loop(pid)
 
@@ -217,9 +217,37 @@ defmodule Loomkin.Teams.AgentAsyncTest do
       assert state.loop_task != nil
       assert Process.alive?(task.pid)
 
-      # Warning should be injected
+      # Warning should be queued as inject_system_message (not in messages yet)
+      assert Enum.any?(state.priority_queue, fn
+        {:inject_system_message, content} -> String.contains?(content, "File conflict")
+        _ -> false
+      end)
+    end
+
+    test "file_conflict warning survives loop completion via drain" do
+      %{pid: pid} = start_agent()
+
+      ref = make_ref()
+      fake_task = %Task{pid: self(), ref: ref, owner: self(), mfa: {__MODULE__, :fake, []}}
+
+      # Simulate active loop with a queued file_conflict inject
+      :sys.replace_state(pid, fn state ->
+        %{state |
+          loop_task: {fake_task, nil},
+          status: :working,
+          priority_queue: [
+            {:inject_system_message, "[URGENT] File conflict detected: %{file: \"lib/foo.ex\"}"}
+          ]
+        }
+      end)
+
+      # Complete the loop — messages get set from loop result, then drain replays inject
+      send(pid, {ref, {:loop_ok, "done", [%{role: :assistant, content: "done"}], %{usage: %{}}}})
+      Process.sleep(100)
+
+      state = :sys.get_state(pid)
       assert Enum.any?(state.messages, fn msg ->
-        msg.role == :system && String.contains?(msg.content, "[URGENT] File conflict")
+        msg.role == :system && String.contains?(msg.content, "File conflict")
       end)
     end
 

--- a/test/loomkin/teams/priority_router_test.exs
+++ b/test/loomkin/teams/priority_router_test.exs
@@ -140,5 +140,9 @@ defmodule Loomkin.Teams.PriorityRouterTest do
       assert {:normal, :unknown} = PriorityRouter.classify("not a tuple")
       assert {:normal, :unknown} = PriorityRouter.classify(42)
     end
+
+    test "empty tuple returns normal unknown instead of crashing" do
+      assert {:normal, :unknown} = PriorityRouter.classify({})
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Epic 6.1 — Async Agent Loop**: `send_message` and `auto_execute_task` now run `AgentLoop` via `Task.Supervisor.async_nolink`, unblocking the Agent GenServer during LLM calls (30s–5m+). Results collected via `handle_info`, with deferred reply to callers. Adds `cancel/1` API, busy guard, and queue drain on completion.
- **Epic 6.2 — Priority Message Router**: New `PriorityRouter` module classifies PubSub messages into urgent/high/normal/ignore. A dispatcher in `agent.ex` intercepts messages during active loops — urgent messages kill the loop immediately, high/normal get queued and replayed after completion, ignore messages are dropped. Idle agents are completely unaffected (zero behavior change).
- Escalation logic extracted into `run_loop_with_escalation/3` running inside the async Task, using a snapshot map instead of full GenServer state.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test test/loomkin/teams/priority_router_test.exs` — 19 tests (all priorities)
- [x] `mix test test/loomkin/teams/agent_async_test.exs` — 17 tests (async, cancel, busy, routing, drain)
- [x] `mix test test/loomkin/teams/agent_test.exs` — 28 existing tests pass (no regressions)
- [x] `mix test test/loomkin/teams/` — full suite 439 tests, 0 failures

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)