### PR TITLE
Propagate directory changes to running agents and sub-teams

### DIFF
--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -217,6 +217,12 @@ defmodule Loomkin.Teams.Agent do
   end
 
   @impl true
+  def handle_cast({:update_project_path, new_path}, state) do
+    Logger.debug("[Agent:#{state.name}] Updated project_path to #{new_path}")
+    {:noreply, %{state | project_path: new_path}}
+  end
+
+  @impl true
   def handle_cast({:peer_message, from, content}, state) do
     peer_msg = %{role: :user, content: "[Peer #{from}]: #{content}"}
     {:noreply, %{state | messages: state.messages ++ [peer_msg]}}

--- a/lib/loomkin/teams/conflict_detector.ex
+++ b/lib/loomkin/teams/conflict_detector.ex
@@ -139,7 +139,7 @@ defmodule Loomkin.Teams.ConflictDetector do
   end
 
   @impl true
-  def handle_info({:tool_complete, agent_name, %{tool_name: tool}}, state)
+  def handle_info({:tool_complete, _agent_name, %{tool_name: tool}}, state)
       when tool in ["file_write", "file_edit"] do
     # tool_complete doesn't carry file_path, but tool_executing already tracked it
     {:noreply, state}

--- a/lib/loomkin/teams/manager.ex
+++ b/lib/loomkin/teams/manager.ex
@@ -159,6 +159,42 @@ defmodule Loomkin.Teams.Manager do
     Loomkin.Teams.ContextRetrieval.list_keepers(team_id)
   end
 
+  @doc """
+  Update the project path for a team and all its running agents.
+
+  Also recursively updates any sub-teams so the entire team tree uses the
+  new directory.
+  """
+  @spec update_project_path(String.t(), String.t()) :: :ok | {:error, :not_found}
+  def update_project_path(team_id, new_path) do
+    case TableRegistry.get_table(team_id) do
+      {:ok, table} ->
+        # Update team ETS metadata
+        case :ets.lookup(table, :meta) do
+          [{:meta, meta}] ->
+            :ets.insert(table, {:meta, %{meta | project_path: new_path}})
+
+          _ ->
+            :ok
+        end
+
+        # Notify all running agents in this team
+        for %{pid: pid} <- list_agents(team_id) do
+          GenServer.cast(pid, {:update_project_path, new_path})
+        end
+
+        # Recursively update sub-teams
+        for sub_id <- list_sub_teams(team_id) do
+          update_project_path(sub_id, new_path)
+        end
+
+        :ok
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
   @doc "Stop an agent gracefully."
   def stop_agent(team_id, name) do
     case find_agent(team_id, name) do

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -253,6 +253,11 @@ defmodule LoomkinWeb.WorkspaceLive do
     path = String.trim(path)
 
     if File.dir?(path) do
+      # Propagate new directory to backing team and all agents
+      if team_id = socket.assigns[:team_id] do
+        Teams.Manager.update_project_path(team_id, path)
+      end
+
       {:noreply,
        socket
        |> assign(


### PR DESCRIPTION
## Summary
- Adds `Manager.update_project_path/2` to propagate directory changes to ETS metadata, all running agents, and sub-teams recursively
- Adds `handle_cast({:update_project_path, ...})` in agent.ex so agents update their state
- Calls `Manager.update_project_path/2` from the LiveView `"set_project_path"` event handler
- Fixes a pre-existing unused variable warning in `conflict_detector.ex`

## Root cause
The `"set_project_path"` event in `WorkspaceLive` only updated the socket assigns (so the file explorer refreshed), but never propagated the new path to the team ETS metadata or running agent GenServers. Agents kept using the stale `project_path` from their initial state.

## Test plan
- [ ] Change directory in the UI bar
- [ ] Verify file explorer shows new project files
- [ ] Send a task to an agent — agent should operate in the new directory
- [ ] Spawn a new agent after directory change — should use the new directory
- [ ] Verify `mix compile --warnings-as-errors` passes

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)