### PR TITLE
Robust project switching: dynamic path resolution + switch modal

### DIFF
--- a/lib/loomkin/agent_loop.ex
+++ b/lib/loomkin/agent_loop.ex
@@ -92,6 +92,7 @@ defmodule Loomkin.AgentLoop do
       tools: Keyword.get(opts, :tools, []),
       system_prompt: Keyword.fetch!(opts, :system_prompt),
       project_path: Keyword.get(opts, :project_path),
+      project_path_resolver: Keyword.get(opts, :project_path_resolver),
       session_id: Keyword.get(opts, :session_id),
       agent_name: Keyword.get(opts, :agent_name),
       team_id: Keyword.get(opts, :team_id),
@@ -101,6 +102,20 @@ defmodule Loomkin.AgentLoop do
       check_permission: Keyword.get(opts, :check_permission),
       rate_limiter: Keyword.get(opts, :rate_limiter)
     }
+  end
+
+  @doc """
+  Returns the current project path, preferring the dynamic resolver over
+  the static value captured at loop-spawn time.
+  """
+  def current_project_path(config) do
+    case config[:project_path_resolver] do
+      resolver when is_function(resolver, 0) ->
+        resolver.() || config.project_path
+
+      _ ->
+        config.project_path
+    end
   end
 
   # -- Loop --------------------------------------------------------------------
@@ -126,12 +141,14 @@ defmodule Loomkin.AgentLoop do
     # Auto-offload context if agent is above threshold
     messages = maybe_auto_offload(messages, config)
 
-    # Build windowed messages with context enrichment
+    # Build windowed messages with context enrichment (use dynamic path)
+    effective_project_path = current_project_path(config)
+
     windowed =
       ContextWindow.build_messages(messages, config.system_prompt,
         model: config.model,
         session_id: config.session_id,
-        project_path: config.project_path,
+        project_path: effective_project_path,
         team_id: config[:team_id]
       )
 
@@ -279,8 +296,11 @@ defmodule Loomkin.AgentLoop do
     tool_call_id = tool_call[:id] || "call_#{Ecto.UUID.generate()}"
     tool_path = tool_args["file_path"] || tool_args["path"] || "*"
 
+    # Dynamically resolve project_path at each tool execution
+    effective_path = current_project_path(config)
+
     context = %{
-      project_path: config.project_path,
+      project_path: effective_path,
       session_id: config.session_id,
       agent_name: config.agent_name,
       team_id: config.team_id,
@@ -309,13 +329,13 @@ defmodule Loomkin.AgentLoop do
           :allowed ->
             # Tag context for permitted external reads so file_read can bypass safe_path!
             context =
-              if config.project_path &&
+              if effective_path &&
                    Loomkin.Tool.outside_project?(
-                     Loomkin.Tool.resolve_path(tool_path, config.project_path),
-                     config.project_path
+                     Loomkin.Tool.resolve_path(tool_path, effective_path),
+                     effective_path
                    ) do
                 Map.put(context, :allowed_external_path,
-                  Loomkin.Tool.resolve_path(tool_path, config.project_path))
+                  Loomkin.Tool.resolve_path(tool_path, effective_path))
               else
                 context
               end

--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -10,7 +10,7 @@ defmodule Loomkin.Teams.Agent do
   use GenServer
 
   alias Loomkin.AgentLoop
-  alias Loomkin.Teams.{Comms, Context, ContextRetrieval, CostTracker, ModelRouter, PriorityRouter, RateLimiter, Role}
+  alias Loomkin.Teams.{Comms, Context, ContextRetrieval, CostTracker, Manager, ModelRouter, PriorityRouter, RateLimiter, Role}
 
   require Logger
 
@@ -243,12 +243,16 @@ defmodule Loomkin.Teams.Agent do
         # Resume in a task to avoid blocking the GenServer
         agent_pid = self()
         messages = state.messages
+        team_id = state.team_id
 
         Task.Supervisor.start_child(Loomkin.Teams.TaskSupervisor, fn ->
           tool_result =
             if action in ["allow_once", "allow_always"] do
               pd = pending_info.pending_data
-              AgentLoop.default_run_tool(pd.tool_module, pd.tool_args, pd.context)
+              # Refresh project_path in the tool context before re-executing
+              fresh_path = resolve_project_path(team_id, pd.context[:project_path])
+              context = Map.put(pd.context, :project_path, fresh_path)
+              AgentLoop.default_run_tool(pd.tool_module, pd.tool_args, context)
             else
               "Error: Permission denied for #{tool_name}"
             end
@@ -996,7 +1000,13 @@ defmodule Loomkin.Teams.Agent do
           {:agent_escalation, snapshot.name, old_model, next_model}
         )
 
-        new_loop_opts = Keyword.put(loop_opts, :model, next_model)
+        # Refresh project_path from ETS so escalation uses the latest directory
+        fresh_path = resolve_project_path(snapshot.team_id, Keyword.get(loop_opts, :project_path))
+
+        new_loop_opts =
+          loop_opts
+          |> Keyword.put(:model, next_model)
+          |> Keyword.put(:project_path, fresh_path)
 
         case AgentLoop.run(messages, new_loop_opts) do
           {:ok, text, msgs, meta} ->
@@ -1077,17 +1087,27 @@ defmodule Loomkin.Teams.Agent do
 
   defp handle_urgent(_msg, state), do: {:noreply, state}
 
+  @doc false
+  def resolve_project_path(team_id, fallback) do
+    Manager.get_team_project_path(team_id) || fallback
+  end
+
   defp build_loop_opts(state) do
     team_id = state.team_id
     name = state.name
     system_prompt = inject_keeper_index(state.role_config.system_prompt, team_id)
     permission_callback = build_permission_callback(state)
 
+    # A resolver fn allows AgentLoop to read the latest project_path from
+    # team ETS at every tool call, even when the Task captured stale opts.
+    project_path_resolver = fn -> resolve_project_path(team_id, state.project_path) end
+
     [
       model: state.model,
       tools: state.tools,
       system_prompt: system_prompt,
       project_path: state.project_path,
+      project_path_resolver: project_path_resolver,
       agent_name: state.name,
       team_id: state.team_id,
       check_permission: permission_callback,
@@ -1131,13 +1151,15 @@ defmodule Loomkin.Teams.Agent do
   defp build_permission_callback(%{
          permission_mode: :session,
          team_id: team_id,
-         name: name,
-         project_path: project_path
+         name: name
        }) do
     agent_name = name
 
     fn tool_name, tool_path ->
       tool_name_str = to_string(tool_name)
+
+      # Dynamically resolve project_path so permission checks use the latest directory
+      project_path = resolve_project_path(team_id, nil)
 
       # Resolve path to absolute for display and permission checking
       resolved_path =

--- a/lib/loomkin/teams/manager.ex
+++ b/lib/loomkin/teams/manager.ex
@@ -195,6 +195,24 @@ defmodule Loomkin.Teams.Manager do
     end
   end
 
+  @doc "Cancel active agent loops across a team and its sub-teams."
+  @spec cancel_all_loops(String.t()) :: :ok
+  def cancel_all_loops(team_id) do
+    for %{pid: pid} <- list_agents(team_id) do
+      try do
+        GenServer.call(pid, :cancel, 5_000)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+
+    for sub_id <- list_sub_teams(team_id) do
+      cancel_all_loops(sub_id)
+    end
+
+    :ok
+  end
+
   @doc "Stop an agent gracefully."
   def stop_agent(team_id, name) do
     case find_agent(team_id, name) do
@@ -274,7 +292,9 @@ defmodule Loomkin.Teams.Manager do
     "#{sanitized}-#{suffix}"
   end
 
-  defp get_team_project_path(team_id) do
+  @doc "Get the project path for a team from ETS metadata."
+  @spec get_team_project_path(String.t()) :: String.t() | nil
+  def get_team_project_path(team_id) do
     case get_team_meta(team_id) do
       {:ok, meta} -> meta[:project_path]
       :error -> nil

--- a/lib/loomkin_web/live/switch_project_component.ex
+++ b/lib/loomkin_web/live/switch_project_component.ex
@@ -1,0 +1,175 @@
+defmodule LoomkinWeb.SwitchProjectComponent do
+  @moduledoc """
+  Modal component for switching the active project directory.
+
+  Two-phase UX:
+    1. Path input (pre-filled with current explorer_path)
+    2. Confirmation with active agent list (only when agents are running)
+  """
+  use LoomkinWeb, :live_component
+
+  def update(assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 animate-fade-in">
+      <div class="bg-gray-900 border border-gray-700/50 rounded-2xl shadow-2xl p-6 max-w-lg w-full mx-4 animate-scale-in">
+        <%= case @modal.phase do %>
+          <% :input -> %>
+            {render_input_phase(assigns)}
+          <% :confirm -> %>
+            {render_confirm_phase(assigns)}
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_input_phase(assigns) do
+    ~H"""
+    <%!-- Header --%>
+    <div class="flex items-center gap-3 mb-4">
+      <div class="w-10 h-10 rounded-xl bg-violet-500/10 flex items-center justify-center flex-shrink-0">
+        <.icon name="hero-folder-arrow-down" class="w-5 h-5 text-violet-400" />
+      </div>
+      <div>
+        <h3 class="text-sm font-semibold text-gray-100">Switch Project</h3>
+        <p class="text-[10px] text-gray-500 mt-0.5">Change the working directory for all agents</p>
+      </div>
+    </div>
+
+    <%!-- Recent projects --%>
+    <div :if={@recent_projects != []} class="mb-3">
+      <p class="text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">Recent</p>
+      <div class="flex flex-col gap-1">
+        <button
+          :for={rp <- @recent_projects}
+          phx-click="switch_project_set_path"
+          phx-value-path={rp}
+          phx-target={@myself}
+          class="flex items-center gap-2 text-left px-3 py-1.5 rounded-lg text-xs font-mono text-gray-300 bg-gray-800/40 hover:bg-gray-800 transition truncate"
+        >
+          <.icon name="hero-clock-mini" class="w-3 h-3 text-gray-500 flex-shrink-0" />
+          {rp}
+        </button>
+      </div>
+    </div>
+
+    <%!-- Path input --%>
+    <form phx-submit="switch_project_set_path" phx-target={@myself} class="space-y-4">
+      <div>
+        <label class="text-[10px] text-gray-500 uppercase tracking-wider">Project directory</label>
+        <input
+          type="text"
+          name="path"
+          value={@modal.target_path || @explorer_path}
+          class="mt-1 w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 font-mono focus:outline-none focus:ring-2 focus:ring-violet-500/30 focus:border-violet-500/50"
+          autofocus
+          placeholder="/path/to/project"
+        />
+      </div>
+      <div class="flex gap-2 justify-end">
+        <button
+          type="button"
+          phx-click="cancel_switch_project"
+          phx-target={@myself}
+          class="px-4 py-2 text-xs font-medium text-gray-400 bg-gray-800/60 hover:bg-gray-800 hover:text-gray-300 border border-gray-700/50 rounded-xl transition-all duration-200"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          class="px-4 py-2 text-xs font-medium text-white bg-violet-600 hover:bg-violet-500 rounded-xl transition-all duration-200 shadow-lg shadow-violet-500/20"
+        >
+          Continue
+        </button>
+      </div>
+    </form>
+    """
+  end
+
+  defp render_confirm_phase(assigns) do
+    ~H"""
+    <%!-- Header --%>
+    <div class="flex items-center gap-3 mb-4">
+      <div class="w-10 h-10 rounded-xl bg-amber-500/10 flex items-center justify-center flex-shrink-0">
+        <.icon name="hero-exclamation-triangle" class="w-5 h-5 text-amber-400" />
+      </div>
+      <div>
+        <h3 class="text-sm font-semibold text-gray-100">Active Agents Detected</h3>
+        <p class="text-[10px] text-gray-500 mt-0.5">
+          Switching will stop all running agents in the current project
+        </p>
+      </div>
+    </div>
+
+    <%!-- Target path --%>
+    <div class="mb-4 px-3 py-2 bg-gray-800/60 rounded-lg border border-gray-700/30">
+      <span class="text-[10px] text-gray-500 uppercase tracking-wider">New project</span>
+      <p class="text-sm font-mono text-violet-400 mt-0.5 truncate">{@modal.target_path}</p>
+    </div>
+
+    <%!-- Active agents list --%>
+    <div class="mb-5">
+      <p class="text-[10px] text-gray-500 uppercase tracking-wider mb-2">
+        Active agents ({length(@modal.active_agents)})
+      </p>
+      <div class="max-h-40 overflow-auto space-y-1">
+        <div
+          :for={agent <- @modal.active_agents}
+          class="flex items-center gap-2 px-3 py-1.5 bg-gray-800/40 rounded-lg"
+        >
+          <span class="w-2 h-2 rounded-full bg-violet-400 animate-pulse flex-shrink-0"></span>
+          <span class="text-xs text-gray-200 font-medium">{agent.name}</span>
+          <span class="text-[10px] text-gray-500">{agent.role}</span>
+          <span class={"ml-auto text-[10px] " <> agent_status_class(agent.status)}>
+            {agent.status}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <%!-- Action buttons --%>
+    <div class="flex gap-2 justify-end">
+      <button
+        phx-click="cancel_switch_project"
+        phx-target={@myself}
+        class="px-4 py-2 text-xs font-medium text-gray-400 bg-gray-800/60 hover:bg-gray-800 hover:text-gray-300 border border-gray-700/50 rounded-xl transition-all duration-200"
+      >
+        Cancel
+      </button>
+      <button
+        phx-click="confirm_switch_project"
+        phx-target={@myself}
+        class="px-4 py-2 text-xs font-medium text-white bg-amber-600 hover:bg-amber-500 rounded-xl transition-all duration-200 shadow-lg shadow-amber-500/20"
+      >
+        Stop Agents & Switch
+      </button>
+    </div>
+    """
+  end
+
+  # Events
+
+  def handle_event("switch_project_set_path", %{"path" => path}, socket) do
+    send(self(), {:switch_project_set_path, String.trim(path)})
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel_switch_project", _params, socket) do
+    send(self(), :cancel_switch_project)
+    {:noreply, socket}
+  end
+
+  def handle_event("confirm_switch_project", _params, socket) do
+    send(self(), :confirm_switch_project)
+    {:noreply, socket}
+  end
+
+  defp agent_status_class(:idle), do: "text-green-400"
+  defp agent_status_class(:working), do: "text-violet-400"
+  defp agent_status_class(:thinking), do: "text-violet-400"
+  defp agent_status_class(_), do: "text-gray-400"
+end

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -123,14 +123,17 @@ defmodule LoomkinWeb.WorkspaceLive do
     assign(socket,
       session_id: session_id,
       project_path: project_path,
-      editing_project_path: false,
+      explorer_path: project_path,
+      editing_explorer_path: false,
       model: effective_model,
       messages: messages,
       session_cost: session_metrics.cost_usd,
       session_tokens: session_metrics.prompt_tokens + session_metrics.completion_tokens,
       page_title: "Loomkin - #{short_id(session_id)}",
       child_teams: child_teams,
-      active_team_id: active_team_id
+      active_team_id: active_team_id,
+      switch_project_modal: nil,
+      recent_projects: []
     )
   end
 
@@ -241,34 +244,29 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, assign(socket, active_team_id: team_id)}
   end
 
-  def handle_event("edit_project_path", _params, socket) do
-    {:noreply, assign(socket, editing_project_path: true)}
+  def handle_event("edit_explorer_path", _params, socket) do
+    {:noreply, assign(socket, editing_explorer_path: true)}
   end
 
-  def handle_event("cancel_edit_project", _params, socket) do
-    {:noreply, assign(socket, editing_project_path: false)}
+  def handle_event("cancel_edit_explorer", _params, socket) do
+    {:noreply, assign(socket, editing_explorer_path: false)}
   end
 
-  def handle_event("set_project_path", %{"path" => path}, socket) do
+  def handle_event("set_explorer_path", %{"path" => path}, socket) do
     path = String.trim(path)
 
     if File.dir?(path) do
-      # Propagate new directory to backing team and all agents
-      if team_id = socket.assigns[:team_id] do
-        Teams.Manager.update_project_path(team_id, path)
-      end
-
       {:noreply,
        socket
        |> assign(
-         project_path: path,
-         editing_project_path: false,
+         explorer_path: path,
+         editing_explorer_path: false,
          file_tree_version: (socket.assigns[:file_tree_version] || 0) + 1
        )}
     else
       {:noreply,
        socket
-       |> assign(editing_project_path: false)
+       |> assign(editing_explorer_path: false)
        |> put_flash(:error, "Directory not found: #{path}")}
     end
   end
@@ -276,6 +274,17 @@ defmodule LoomkinWeb.WorkspaceLive do
   def handle_event("toggle_mode", _, socket) do
     new_mode = if socket.assigns.mode == :solo, do: :mission_control, else: :solo
     {:noreply, assign(socket, mode: new_mode)}
+  end
+
+  def handle_event("initiate_switch_project", _params, socket) do
+    {:noreply,
+     assign(socket,
+       switch_project_modal: %{
+         phase: :input,
+         target_path: socket.assigns.explorer_path,
+         active_agents: []
+       }
+     )}
   end
 
   def handle_event("keyboard_shortcut", %{"key" => "toggle_mode"}, socket) do
@@ -386,6 +395,21 @@ defmodule LoomkinWeb.WorkspaceLive do
        command_palette_open: false,
        command_palette_query: "",
        command_palette_results: []
+     )}
+  end
+
+  def handle_event("palette_select", %{"type" => "action", "value" => "switch_project"}, socket) do
+    {:noreply,
+     socket
+     |> assign(
+       command_palette_open: false,
+       command_palette_query: "",
+       command_palette_results: [],
+       switch_project_modal: %{
+         phase: :input,
+         target_path: socket.assigns.explorer_path,
+         active_agents: []
+       }
      )}
   end
 
@@ -626,7 +650,7 @@ defmodule LoomkinWeb.WorkspaceLive do
   end
 
   def handle_info({:select_file, path}, socket) do
-    abs_path = Path.join(socket.assigns.project_path, path)
+    abs_path = Path.join(socket.assigns.explorer_path, path)
 
     file_content =
       case File.read(abs_path) do
@@ -651,6 +675,47 @@ defmodule LoomkinWeb.WorkspaceLive do
        messages: socket.assigns.messages ++ [user_msg]
      )
      |> push_event("clear-input", %{})}
+  end
+
+  # --- Switch Project modal messages ---
+
+  def handle_info({:switch_project_set_path, path}, socket) do
+    if !File.dir?(path) do
+      {:noreply, put_flash(socket, :error, "Directory not found: #{path}")}
+    else
+      team_id = socket.assigns[:team_id]
+      agents = if team_id, do: Teams.Manager.list_agents(team_id), else: []
+      active = Enum.filter(agents, fn a -> a.status not in [:idle] end)
+
+      if active == [] do
+        {:noreply, do_switch_project(socket, path)}
+      else
+        {:noreply,
+         assign(socket,
+           switch_project_modal: %{
+             phase: :confirm,
+             target_path: path,
+             active_agents: active
+           }
+         )}
+      end
+    end
+  end
+
+  def handle_info(:cancel_switch_project, socket) do
+    {:noreply, assign(socket, switch_project_modal: nil)}
+  end
+
+  def handle_info(:confirm_switch_project, socket) do
+    modal = socket.assigns.switch_project_modal
+
+    if modal do
+      team_id = socket.assigns[:team_id]
+      if team_id, do: Teams.Manager.cancel_all_loops(team_id)
+      {:noreply, do_switch_project(socket, modal.target_path)}
+    else
+      {:noreply, socket}
+    end
   end
 
   # Messages from child components
@@ -1007,6 +1072,16 @@ defmodule LoomkinWeb.WorkspaceLive do
         tool_path={@permission_request.tool_path}
       />
 
+      <%!-- Switch Project modal overlay --%>
+      <.live_component
+        :if={@switch_project_modal}
+        module={LoomkinWeb.SwitchProjectComponent}
+        id="switch-project-modal"
+        modal={@switch_project_modal}
+        explorer_path={@explorer_path}
+        recent_projects={@recent_projects}
+      />
+
       <%!-- Command palette overlay --%>
       {render_command_palette(assigns)}
 
@@ -1037,7 +1112,26 @@ defmodule LoomkinWeb.WorkspaceLive do
             model={@model}
           />
 
-          <%!-- Project path switcher --%>
+          <%!-- Project indicator + Switch button --%>
+          <div class="hidden items-center gap-2 text-sm text-gray-400 md:flex">
+            <div class="flex items-center gap-1.5">
+              <span class="relative flex h-2 w-2">
+                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-50"></span>
+                <span class="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+              </span>
+              <span class="text-xs text-gray-300 font-mono truncate max-w-[12rem]" title={@project_path}>
+                {Path.basename(@project_path)}
+              </span>
+            </div>
+            <button
+              phx-click="initiate_switch_project"
+              class="text-[10px] text-violet-400 hover:text-violet-300 border border-violet-500/30 rounded px-1.5 py-0.5 transition"
+            >
+              Switch
+            </button>
+          </div>
+
+          <%!-- File explorer path (browse only) --%>
           <div class="hidden items-center gap-2 text-sm text-gray-400 md:flex">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -1053,12 +1147,12 @@ defmodule LoomkinWeb.WorkspaceLive do
                 d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
               />
             </svg>
-            <%= if @editing_project_path do %>
-              <form phx-submit="set_project_path" class="flex items-center gap-1">
+            <%= if @editing_explorer_path do %>
+              <form phx-submit="set_explorer_path" class="flex items-center gap-1">
                 <input
                   type="text"
                   name="path"
-                  value={@project_path}
+                  value={@explorer_path}
                   class="bg-gray-800 border border-gray-700 rounded px-2 py-0.5 text-sm text-gray-200 w-64"
                   autofocus
                 />
@@ -1067,7 +1161,7 @@ defmodule LoomkinWeb.WorkspaceLive do
                 </button>
                 <button
                   type="button"
-                  phx-click="cancel_edit_project"
+                  phx-click="cancel_edit_explorer"
                   class="text-xs text-gray-500 hover:text-gray-400"
                 >
                   Cancel
@@ -1075,11 +1169,11 @@ defmodule LoomkinWeb.WorkspaceLive do
               </form>
             <% else %>
               <button
-                phx-click="edit_project_path"
+                phx-click="edit_explorer_path"
                 class="hover:text-gray-200 transition truncate max-w-xs"
-                title={@project_path}
+                title={@explorer_path}
               >
-                {@project_path}
+                {@explorer_path}
               </button>
             <% end %>
           </div>
@@ -1278,7 +1372,7 @@ defmodule LoomkinWeb.WorkspaceLive do
       current_step={@current_step}
       session_id={@session_id}
       team_id={@active_team_id}
-      project_path={@project_path}
+      project_path={@explorer_path}
     />
     """
   end
@@ -1387,7 +1481,7 @@ defmodule LoomkinWeb.WorkspaceLive do
         <.live_component
           module={LoomkinWeb.FileTreeComponent}
           id="file-tree"
-          project_path={assigns[:project_path] || File.cwd!()}
+          project_path={assigns[:explorer_path] || assigns[:project_path] || File.cwd!()}
           session_id={@session_id}
           version={@file_tree_version}
         />
@@ -2134,6 +2228,30 @@ defmodule LoomkinWeb.WorkspaceLive do
   defp short_team_id(id) when is_binary(id), do: String.slice(id, 0, 8)
   defp short_team_id(_), do: "?"
 
+  defp do_switch_project(socket, path) do
+    team_id = socket.assigns[:team_id]
+
+    if team_id do
+      Teams.Manager.update_project_path(team_id, path)
+    end
+
+    # Track in recent projects (dedup, max 5)
+    recent =
+      [socket.assigns.project_path | socket.assigns.recent_projects]
+      |> Enum.uniq()
+      |> Enum.reject(&(&1 == path))
+      |> Enum.take(5)
+
+    socket
+    |> assign(
+      project_path: path,
+      explorer_path: path,
+      switch_project_modal: nil,
+      file_tree_version: (socket.assigns[:file_tree_version] || 0) + 1,
+      recent_projects: recent
+    )
+  end
+
   defp ensure_index_started(project_path) do
     case GenServer.whereis(Loomkin.RepoIntel.Index) do
       nil ->
@@ -2307,6 +2425,7 @@ defmodule LoomkinWeb.WorkspaceLive do
 
     actions = [
       %{type: :action, label: "Toggle Mode (Solo/Mission Control)", detail: "Action", value: "toggle_mode"},
+      %{type: :action, label: "Switch Project", detail: "Action", value: "switch_project"},
       %{type: :action, label: "Focus Input", detail: "Action", value: "focus_input"}
     ]
 

--- a/test/loomkin/teams/agent_project_path_test.exs
+++ b/test/loomkin/teams/agent_project_path_test.exs
@@ -1,0 +1,141 @@
+defmodule Loomkin.Teams.AgentProjectPathTest do
+  use ExUnit.Case, async: false
+
+  alias Loomkin.Teams.{Agent, Manager}
+
+  defp create_team(opts) do
+    name = Keyword.get(opts, :name, "test-team")
+    project_path = Keyword.get(opts, :project_path, "/tmp/project-a")
+    {:ok, team_id} = Manager.create_team(name: name, project_path: project_path)
+    team_id
+  end
+
+  defp start_agent_in_team(team_id, overrides \\ []) do
+    name = Keyword.get(overrides, :name, "agent-#{:erlang.unique_integer([:positive])}")
+    role = Keyword.get(overrides, :role, :coder)
+    project_path = Manager.get_team_project_path(team_id)
+
+    opts =
+      [team_id: team_id, name: name, role: role, project_path: project_path]
+      |> Keyword.merge(overrides)
+
+    {:ok, pid} = start_supervised({Agent, opts}, id: {team_id, name})
+    %{pid: pid, team_id: team_id, name: name}
+  end
+
+  describe "resolve_project_path/2" do
+    test "returns team ETS path when available" do
+      team_id = create_team(project_path: "/tmp/project-a")
+
+      assert Agent.resolve_project_path(team_id, "/fallback") == "/tmp/project-a"
+    end
+
+    test "returns fallback when team ETS has no path" do
+      assert Agent.resolve_project_path("nonexistent-team-id", "/fallback") == "/fallback"
+    end
+
+    test "returns updated path after Manager.update_project_path" do
+      team_id = create_team(project_path: "/tmp/project-a")
+
+      assert Agent.resolve_project_path(team_id, "/fallback") == "/tmp/project-a"
+
+      Manager.update_project_path(team_id, "/tmp/project-b")
+
+      assert Agent.resolve_project_path(team_id, "/fallback") == "/tmp/project-b"
+    end
+  end
+
+  describe "get_team_project_path/1 (now public)" do
+    test "returns the project path from team ETS" do
+      team_id = create_team(project_path: "/tmp/my-project")
+
+      assert Manager.get_team_project_path(team_id) == "/tmp/my-project"
+    end
+
+    test "returns nil for non-existent team" do
+      assert Manager.get_team_project_path("does-not-exist") == nil
+    end
+  end
+
+  describe "agent state updates on project path change" do
+    test "handle_cast :update_project_path updates agent state" do
+      team_id = create_team(project_path: "/tmp/project-a")
+      %{pid: pid} = start_agent_in_team(team_id)
+
+      state_before = :sys.get_state(pid)
+      assert state_before.project_path == "/tmp/project-a"
+
+      GenServer.cast(pid, {:update_project_path, "/tmp/project-b"})
+      Process.sleep(50)
+
+      state_after = :sys.get_state(pid)
+      assert state_after.project_path == "/tmp/project-b"
+    end
+  end
+
+  describe "Manager.cancel_all_loops/1" do
+    test "cancels active loops across team agents" do
+      team_id = create_team(project_path: "/tmp/test")
+      %{pid: pid} = start_agent_in_team(team_id)
+
+      # Simulate an active loop task
+      :sys.replace_state(pid, fn state ->
+        task =
+          Task.Supervisor.async_nolink(Loomkin.Teams.TaskSupervisor, fn ->
+            Process.sleep(:infinity)
+          end)
+
+        %{state | loop_task: {task, nil}, status: :working}
+      end)
+
+      state = :sys.get_state(pid)
+      assert state.loop_task != nil
+
+      Manager.cancel_all_loops(team_id)
+
+      Process.sleep(100)
+
+      state = :sys.get_state(pid)
+      assert state.loop_task == nil
+      assert state.status == :idle
+    end
+  end
+
+  describe "AgentLoop.current_project_path/1" do
+    test "returns static path when no resolver is provided" do
+      config = %{project_path: "/static/path", project_path_resolver: nil}
+      assert Loomkin.AgentLoop.current_project_path(config) == "/static/path"
+    end
+
+    test "returns resolver result when resolver is provided" do
+      config = %{
+        project_path: "/static/path",
+        project_path_resolver: fn -> "/dynamic/path" end
+      }
+
+      assert Loomkin.AgentLoop.current_project_path(config) == "/dynamic/path"
+    end
+
+    test "falls back to static path when resolver returns nil" do
+      config = %{
+        project_path: "/static/path",
+        project_path_resolver: fn -> nil end
+      }
+
+      assert Loomkin.AgentLoop.current_project_path(config) == "/static/path"
+    end
+
+    test "resolver tracks ETS changes dynamically" do
+      team_id = create_team(project_path: "/tmp/original")
+
+      resolver = fn -> Manager.get_team_project_path(team_id) end
+      config = %{project_path: "/tmp/fallback", project_path_resolver: resolver}
+
+      assert Loomkin.AgentLoop.current_project_path(config) == "/tmp/original"
+
+      Manager.update_project_path(team_id, "/tmp/switched")
+
+      assert Loomkin.AgentLoop.current_project_path(config) == "/tmp/switched"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #75 — When users change the project directory in the workspace header, agents continue working in the old directory because `build_loop_opts` captures `project_path` by value at loop-spawn time.

This PR fixes all 6 stale-path vectors with a 4-phase approach:

- **Phase 1 — Dynamic resolution**: Introduces `project_path_resolver` fn that reads the latest path from team ETS at every tool call. Fixes tool execution context, context enrichment, permission callback, escalation, and permission resume.
- **Phase 2 — Separate browsing from switching**: `explorer_path` (file tree browsing) is now independent from `project_path` (agent working directory). Editing the path in the header only changes what the file explorer shows.
- **Phase 3 — Switch Project modal**: New `SwitchProjectComponent` with two-phase UX — path input, then confirmation with active agent list when agents are running. Adds `Manager.cancel_all_loops/1` for graceful shutdown.
- **Phase 4 — Polish**: Recent projects tracking (last 5), "Switch Project" entry in command palette.

### Key changes
- `AgentLoop.current_project_path/1` — prefers dynamic resolver over static captured value
- `Agent.resolve_project_path/2` — reads from team ETS with fallback
- `Manager.get_team_project_path/1` — now public
- `Manager.cancel_all_loops/1` — cancels active loops across team + sub-teams
- `SwitchProjectComponent` — new modal component (follows PermissionComponent pattern)

### Files changed
| File | Change |
|------|--------|
| `lib/loomkin/agent_loop.ex` | `project_path_resolver` in config, `current_project_path/1`, dynamic path in `execute_single_tool` and `do_loop` |
| `lib/loomkin/teams/agent.ex` | `resolve_project_path/2`, updated `build_loop_opts`, `build_permission_callback`, escalation, permission resume |
| `lib/loomkin/teams/manager.ex` | Public `get_team_project_path/1`, `cancel_all_loops/1` |
| `lib/loomkin_web/live/workspace_live.ex` | `explorer_path` assign, switch project modal + events, recent projects, command palette entry |
| `lib/loomkin_web/live/switch_project_component.ex` | **New** — two-phase modal component |
| `test/loomkin/teams/agent_project_path_test.exs` | **New** — 11 tests for dynamic path resolution |

## Test plan

- [x] `mix test test/loomkin/teams/agent_project_path_test.exs` — 11 tests pass
- [x] `mix test` — 1098 tests, 0 regressions (1 pre-existing flaky test)
- [ ] Manual: Start agents exploring project A. Switch to project B via modal. Verify next tool call uses project B.
- [ ] Manual: Change explorer path in header. Verify file tree updates but agents keep original project_path.
- [ ] Manual: Click "Switch" with active agents. Verify confirmation modal shows agent list. Confirm and verify agents stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)