### PR TITLE
Fix project-switching bugs + remove chat inspector tab

### DIFF
--- a/lib/loomkin/session/session.ex
+++ b/lib/loomkin/session/session.ex
@@ -102,6 +102,19 @@ defmodule Loomkin.Session do
     end
   end
 
+  @doc "Update the project path for a running session."
+  @spec update_project_path(pid() | String.t(), String.t()) :: :ok | {:error, term()}
+  def update_project_path(pid, path) when is_pid(pid) do
+    GenServer.call(pid, {:update_project_path, path})
+  end
+
+  def update_project_path(session_id, path) when is_binary(session_id) do
+    case Loomkin.Session.Manager.find_session(session_id) do
+      {:ok, pid} -> update_project_path(pid, path)
+      :error -> {:error, :not_found}
+    end
+  end
+
   @doc "Send a permission response to the session."
   def permission_response(session_id, action, tool_name, tool_path) when is_binary(session_id) do
     case Loomkin.Session.Manager.find_session(session_id) do
@@ -184,6 +197,12 @@ defmodule Loomkin.Session do
   @impl true
   def handle_call(:get_team_id, _from, state) do
     {:reply, Map.get(state, :team_id), state}
+  end
+
+  @impl true
+  def handle_call({:update_project_path, path}, _from, state) do
+    Logger.debug("[Session] Updated project_path to #{path}")
+    {:reply, :ok, %{state | project_path: path}}
   end
 
   @impl true

--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -191,7 +191,15 @@ defmodule Loomkin.Teams.Agent do
         task_id = state.task && state.task[:id]
         if original_from, do: GenServer.reply(original_from, {:error, :cancelled})
         if !original_from && task_id, do: Loomkin.Teams.Tasks.fail_task(task_id, "cancelled")
-        state = %{state | loop_task: nil, pending_updates: [], priority_queue: []}
+        state = %{state | loop_task: nil, pending_permission: nil, pending_updates: [], priority_queue: []}
+        state = set_status(state, :idle)
+        broadcast_team(state, {:agent_status, state.name, :idle})
+        {:reply, :ok, state}
+
+      nil when state.pending_permission != nil ->
+        # Agent is waiting on permission — clear it and go idle
+        Logger.info("[Agent:#{state.name}] Cancelling pending permission")
+        state = %{state | pending_permission: nil, pending_updates: [], priority_queue: []}
         state = set_status(state, :idle)
         broadcast_team(state, {:agent_status, state.name, :idle})
         {:reply, :ok, state}

--- a/lib/loomkin/teams/manager.ex
+++ b/lib/loomkin/teams/manager.ex
@@ -234,6 +234,19 @@ defmodule Loomkin.Teams.Manager do
     end)
   end
 
+  @doc "List all agents in a team and its sub-teams recursively."
+  @spec list_all_agents(String.t()) :: [map()]
+  def list_all_agents(team_id) do
+    own = list_agents(team_id)
+
+    sub =
+      for sub_id <- list_sub_teams(team_id),
+          agent <- list_all_agents(sub_id),
+          do: agent
+
+    own ++ sub
+  end
+
   @doc "Find an agent by team and name."
   def find_agent(team_id, name) do
     case Registry.lookup(Loomkin.Teams.AgentRegistry, {team_id, name}) do

--- a/lib/loomkin_web/live/context_inspector_component.ex
+++ b/lib/loomkin_web/live/context_inspector_component.ex
@@ -2,14 +2,14 @@ defmodule LoomkinWeb.ContextInspectorComponent do
   @moduledoc """
   Right-panel context inspector for Mission Control mode.
 
-  Hosts existing components (FileTree, Diff, Terminal, Graph, Chat) in a tabbed
+  Hosts existing components (FileTree, Diff, Terminal, Graph) in a tabbed
   layout with auto-follow and pin modes. Delegates all rendering to the child
   components — does not rebuild any of them.
   """
 
   use LoomkinWeb, :live_component
 
-  @tabs [:files, :diff, :terminal, :graph, :chat]
+  @tabs [:files, :diff, :terminal, :graph]
 
   @impl true
   def mount(socket) do
@@ -207,23 +207,6 @@ defmodule LoomkinWeb.ContextInspectorComponent do
     """
   end
 
-  defp render_inspector_tab(:chat, assigns) do
-    ~H"""
-    <.live_component
-      module={LoomkinWeb.ChatComponent}
-      id="inspector-chat"
-      messages={@messages}
-      status={@status}
-      current_tool={@current_tool}
-      streaming={@streaming}
-      streaming_content={@streaming_content}
-      architect_phase={@architect_phase}
-      plan_steps={@plan_steps}
-      current_step={@current_step}
-    />
-    """
-  end
-
   # --- Styling helpers ---
 
   defp panel_class(true = _collapsed),
@@ -267,12 +250,8 @@ defmodule LoomkinWeb.ContextInspectorComponent do
   defp tab_icon(:graph),
     do: raw("<span class=\"hero-share-mini inline-block w-3.5 h-3.5\"></span>")
 
-  defp tab_icon(:chat),
-    do: raw("<span class=\"hero-chat-bubble-left-right-mini inline-block w-3.5 h-3.5\"></span>")
-
   defp tab_label(:files), do: "Files"
   defp tab_label(:diff), do: "Diff"
   defp tab_label(:terminal), do: "Terminal"
   defp tab_label(:graph), do: "Graph"
-  defp tab_label(:chat), do: "Chat"
 end

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -333,7 +333,8 @@ defmodule LoomkinWeb.WorkspaceLive do
   end
 
   def handle_event("keyboard_shortcut", %{"key" => "focus_panel_5"}, socket) do
-    {:noreply, assign(socket, active_inspector_tab: :chat, inspector_mode: :pinned)}
+    # Chat tab removed from inspector — ignore shortcut
+    {:noreply, socket}
   end
 
   def handle_event("keyboard_shortcut", %{"key" => "jump_active_agent"}, socket) do
@@ -373,7 +374,7 @@ defmodule LoomkinWeb.WorkspaceLive do
      )}
   end
 
-  @palette_valid_tabs ~w(files diff terminal graph chat)
+  @palette_valid_tabs ~w(files diff terminal graph)
   def handle_event("palette_select", %{"type" => "tab", "value" => tab}, socket)
       when tab in @palette_valid_tabs do
     {:noreply,
@@ -684,7 +685,8 @@ defmodule LoomkinWeb.WorkspaceLive do
       {:noreply, put_flash(socket, :error, "Directory not found: #{path}")}
     else
       team_id = socket.assigns[:team_id]
-      agents = if team_id, do: Teams.Manager.list_agents(team_id), else: []
+      # Include sub-team agents so we don't skip confirmation while child agents are running
+      agents = if team_id, do: Teams.Manager.list_all_agents(team_id), else: []
       active = Enum.filter(agents, fn a -> a.status not in [:idle] end)
 
       if active == [] do
@@ -1277,6 +1279,15 @@ defmodule LoomkinWeb.WorkspaceLive do
         plan_steps={@plan_steps}
         current_step={@current_step}
       />
+
+      <%!-- Pending ask_user questions (also shown in solo mode) --%>
+      <div :if={@pending_questions != []} class="border-t border-violet-500/20 bg-gray-900/90 px-3 py-2">
+        <.live_component
+          module={LoomkinWeb.AskUserComponent}
+          id="ask-user-questions-solo"
+          questions={@pending_questions}
+        />
+      </div>
 
       {render_input_bar(assigns)}
     </div>
@@ -2235,6 +2246,9 @@ defmodule LoomkinWeb.WorkspaceLive do
       Teams.Manager.update_project_path(team_id, path)
     end
 
+    # Update the Session GenServer so the Architect uses the new path
+    Session.update_project_path(socket.assigns.session_id, path)
+
     # Track in recent projects (dedup, max 5)
     recent =
       [socket.assigns.project_path | socket.assigns.recent_projects]
@@ -2414,7 +2428,7 @@ defmodule LoomkinWeb.WorkspaceLive do
       end)
 
     tabs =
-      Enum.map([:files, :diff, :terminal, :graph, :chat], fn tab ->
+      Enum.map([:files, :diff, :terminal, :graph], fn tab ->
         %{type: :tab, label: Atom.to_string(tab), detail: "Inspector Tab", value: Atom.to_string(tab)}
       end)
 

--- a/test/loomkin/teams/agent_project_path_test.exs
+++ b/test/loomkin/teams/agent_project_path_test.exs
@@ -101,6 +101,45 @@ defmodule Loomkin.Teams.AgentProjectPathTest do
     end
   end
 
+  describe "cancel clears pending_permission" do
+    test "cancels agent that is waiting on permission" do
+      team_id = create_team(project_path: "/tmp/test")
+      %{pid: pid} = start_agent_in_team(team_id)
+
+      # Simulate pending permission state (no loop_task, but pending_permission set)
+      :sys.replace_state(pid, fn state ->
+        %{state | pending_permission: %{some: :data}, status: :waiting_permission}
+      end)
+
+      state = :sys.get_state(pid)
+      assert state.pending_permission != nil
+
+      assert :ok = GenServer.call(pid, :cancel)
+
+      state = :sys.get_state(pid)
+      assert state.pending_permission == nil
+      assert state.status == :idle
+    end
+  end
+
+  describe "Manager.list_all_agents/1" do
+    test "includes agents from sub-teams" do
+      parent_id = create_team(project_path: "/tmp/test")
+      {:ok, child_id} = Manager.create_sub_team(parent_id, "test", name: "child-team", project_path: "/tmp/test")
+
+      start_agent_in_team(parent_id, name: "parent-agent")
+      start_agent_in_team(child_id, name: "child-agent")
+
+      parent_only = Manager.list_agents(parent_id)
+      assert length(parent_only) == 1
+
+      all = Manager.list_all_agents(parent_id)
+      assert length(all) == 2
+      names = Enum.map(all, & &1.name) |> Enum.sort()
+      assert names == ["child-agent", "parent-agent"]
+    end
+  end
+
   describe "AgentLoop.current_project_path/1" do
     test "returns static path when no resolver is provided" do
       config = %{project_path: "/static/path", project_path_resolver: nil}


### PR DESCRIPTION
## Summary

Followup fixes from #75 testing. Addresses 4 bugs found during manual verification + removes legacy chat tab.

- **Session path not updated**: Sub-teams spawned with stale `project_path` because `Architect.run` reads from `Session` state, which was never updated on switch. Added `Session.update_project_path/2` API.
- **Sub-team agents ignored in switch confirmation**: `list_agents(team_id)` only checks the parent team. Added `Manager.list_all_agents/1` (recursive) so the confirmation modal includes child-team agents.
- **Cancel doesn't stop permission-waiting agents**: `Agent.cancel` only handled `loop_task != nil`. Agents with `pending_permission` set (but no loop task) survived "Stop Agents & Switch". Added a `nil when state.pending_permission != nil` clause.
- **ask_user questions invisible in solo mode**: `pending_questions` UI was only rendered in mission control layout. Added it to solo mode too.
- **Removed Chat tab from Context Inspector**: Legacy tab, not suited for mission control paradigm.

## Test plan

- [x] `mix test test/loomkin/teams/agent_project_path_test.exs` — 13 tests pass (2 new)
- [x] `mix compile --warnings-as-errors` — clean
- [x] 74 agent-related tests pass, 0 failures
- [ ] Manual: Switch project, spawn team — verify sub-team uses new path
- [ ] Manual: Switch project with child-team agents running — verify confirmation modal lists them
- [ ] Manual: Cancel agent in waiting_permission state — verify it goes idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)