### PR TITLE
Fix Discord badge with real server ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Loomkin
 
-[![Discord](https://img.shields.io/discord/1234567890?color=5865F2&logo=discord&logoColor=white&label=Discord)](https://discord.gg/WUVneqArVD)
+[![Discord](https://img.shields.io/discord/1465498806698119317?color=5865F2&logo=discord&logoColor=white&label=Discord)](https://discord.gg/WUVneqArVD)
 
 **The AI coding assistant with a nervous system.**
 


### PR DESCRIPTION
## Summary
- Replace placeholder Discord server ID (`1234567890`) with the actual server ID (`1465498806698119317`)
- Badge now displays the server name and live online member count via Shields.io

## Test plan
- [ ] Verify the badge renders correctly on the GitHub README
- [ ] Confirm the Discord Server Widget is enabled (Server Settings → Widget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)