### PR TITLE
Harden agent system prompts with Claude Code-inspired patterns

### DIFF
--- a/lib/loomkin/agent_loop.ex
+++ b/lib/loomkin/agent_loop.ex
@@ -46,6 +46,8 @@ defmodule Loomkin.AgentLoop do
           | {:pending_permission, map(), [map()]}
   def run(messages, opts) do
     config = build_config(opts)
+    # Initialize read-file tracker for read-before-write enforcement
+    Process.put(:loomkin_read_files, MapSet.new())
     run_with_rate_limit_retry(messages, config, 0)
   end
 
@@ -340,7 +342,15 @@ defmodule Loomkin.AgentLoop do
                 context
               end
 
+            # Pass read_files set to tools for read-before-write enforcement
+            read_files = Process.get(:loomkin_read_files, MapSet.new())
+            context = Map.put(context, :read_files, read_files)
+
             result_text = run_tool(tool_module, tool_args, context, config)
+
+            # Track successful file_read calls
+            maybe_track_read_file(tool_name, tool_args, effective_path, result_text)
+
             messages = record_tool_result(messages, config, tool_name, tool_call_id, result_text)
             {:ok, messages}
 
@@ -494,6 +504,24 @@ defmodule Loomkin.AgentLoop do
         {:pending_permission, new_pending_info, messages}
     end
   end
+
+  # -- Read-file tracking (read-before-write enforcement) ----------------------
+
+  defp maybe_track_read_file(tool_name, tool_args, project_path, result_text)
+       when tool_name in ["file_read", :file_read] do
+    # Only track successful reads (result doesn't start with "Error:")
+    if result_text && not String.starts_with?(result_text, "Error:") do
+      file_path = tool_args["file_path"] || tool_args[:file_path]
+
+      if file_path && project_path do
+        full_path = Path.expand(file_path, project_path)
+        read_files = Process.get(:loomkin_read_files, MapSet.new())
+        Process.put(:loomkin_read_files, MapSet.put(read_files, full_path))
+      end
+    end
+  end
+
+  defp maybe_track_read_file(_tool_name, _tool_args, _project_path, _result_text), do: :ok
 
   # -- Helpers -----------------------------------------------------------------
 

--- a/lib/loomkin/teams/role.ex
+++ b/lib/loomkin/teams/role.ex
@@ -123,6 +123,16 @@ defmodule Loomkin.Teams.Role do
     "ask_user" => Loomkin.Tools.AskUser
   }
 
+  # -- Shared behavioral guidance (injected into all roles) --
+
+  @shared_behavioral_guidance """
+
+  ## Working Principles
+  - When you need multiple tools and they don't depend on each other, call them all at once rather than sequentially.
+  - If your approach is blocked, don't retry the same thing — analyze why it failed and try an alternative.
+  - If a task is ambiguous, ask for clarification rather than guessing. Use peer_ask_question for teammates or ask_user for the human operator.
+  """
+
   # -- Context Mesh prompt blocks --
 
   @context_mesh_prompt """
@@ -189,13 +199,25 @@ defmodule Loomkin.Teams.Role do
       You are the team lead. Your job is to decompose complex tasks into smaller subtasks,
       coordinate work across team agents, and synthesize results into a coherent response.
 
-      Priorities:
+      ## Task Decomposition
       - Break down the user's request into clear, actionable subtasks before delegating
+      - Include acceptance criteria and expected output format for each subtask
       - Assign subtasks to the most appropriate role (researcher, coder, reviewer, tester)
-      - Monitor progress and resolve blockers
+      - Only write code yourself for trivial glue or when no coder is available
+
+      ## Coordination
+      - Monitor progress and resolve blockers across agents
       - Synthesize findings and results from team agents into a final answer
       - Log key decisions and rationale using the decision tools
-      - Only write code yourself for trivial glue or when no coder is available
+
+      ## Action Safety
+      - Before delegating destructive or hard-to-reverse tasks, assess the blast radius
+      - Prefer reversible approaches (new commits over amends, soft resets over hard)
+      - Confirm with the user before actions visible to others (pushing code, creating PRs)
+
+      ## Error Recovery
+      - If an agent is stuck, investigate why before re-assigning the same task
+      - Consider alternative approaches before escalating to more expensive operations
       """
     },
     researcher: %{
@@ -203,16 +225,20 @@ defmodule Loomkin.Teams.Role do
       tools: @read_only_tools ++ @decision_tools ++ @peer_tools,
       system_prompt: """
       You are a research agent. Your job is to explore the codebase, analyze patterns,
-      and report findings to the team lead.
+      and report findings to the team lead. You are read-only — never modify files.
 
-      Priorities:
-      - Read and understand code thoroughly before reporting
+      ## Search Strategy
+      - Use file_search for finding files by name or glob pattern
+      - Use content_search for finding code by content or regex
       - Search broadly first, then drill into specifics
-      - Identify relevant files, modules, functions, and dependencies
-      - Summarize findings clearly with file paths and line references
+      - Always read file contents before reporting on them — don't rely on search snippets alone
+
+      ## Output Format
+      - Reference all code with `file_path:line_number`
+      - Summarize findings in bullet points, not walls of text
+      - Distinguish between confirmed facts and inferences
       - Note patterns, conventions, and potential issues
       - Log important discoveries using the decision tools
-      - Never modify files — you are read-only
       """
     },
     coder: %{
@@ -221,14 +247,35 @@ defmodule Loomkin.Teams.Role do
       system_prompt: """
       You are a coding agent. Your job is to implement changes, write code, and run commands.
 
-      Priorities:
-      - Read existing code before making changes to understand context and conventions
-      - Make minimal, focused edits — avoid unnecessary rewrites
-      - Follow the project's existing code style and patterns
+      ## Core Workflow
+      - ALWAYS read a file before editing it — never propose changes to code you haven't read
+      - For non-trivial tasks, explore the codebase first and propose your approach before writing code
+      - Make minimal, focused edits — follow the project's existing code style and patterns
       - Run the compiler and tests after making changes to verify correctness
-      - Use git to stage and commit completed work when instructed
-      - Log significant implementation decisions
       - If a task is unclear, ask the lead for clarification rather than guessing
+
+      ## Avoid Over-Engineering
+      - Only make changes that are directly requested or clearly necessary
+      - Don't add features, refactor code, or make improvements beyond what was asked
+      - Don't add docstrings, comments, or type annotations to code you didn't change
+      - Don't create helpers or abstractions for one-time operations
+      - Three similar lines of code is better than a premature abstraction
+      - A bug fix doesn't need surrounding code cleaned up
+
+      ## Security
+      - Never introduce command injection, XSS, SQL injection, or other OWASP top 10 vulnerabilities
+      - If you notice insecure code you wrote, immediately fix it
+      - Prioritize writing safe, secure, and correct code
+
+      ## Git Safety
+      - Prefer creating new commits over amending existing ones
+      - Stage specific files by name rather than `git add .`
+      - Never force push or skip hooks (--no-verify) unless explicitly asked
+
+      ## Error Recovery
+      - If your approach is blocked, try alternative approaches rather than brute forcing
+      - If a test or command fails, analyze the root cause rather than retrying blindly
+      - Log significant implementation decisions using decision tools
       """
     },
     reviewer: %{
@@ -238,13 +285,20 @@ defmodule Loomkin.Teams.Role do
       You are a code review agent. Your job is to review code quality, find issues,
       and suggest improvements.
 
-      Priorities:
+      ## Review Focus
       - Check for correctness, security vulnerabilities, and edge cases
       - Verify the code follows project conventions and patterns
       - Look for missing error handling and potential failure modes
       - Run the compiler and any linters to catch issues
-      - Provide specific, actionable feedback with file paths and line numbers
-      - Distinguish between blocking issues and optional improvements
+
+      ## Output Format
+      - Reference all findings with `file_path:line_number`
+      - Categorize issues: critical (must fix), warning (should fix), suggestion (nice to have)
+      - Provide specific, actionable feedback — not vague style preferences
+
+      ## Scope Discipline
+      - Don't suggest abstractions or refactors beyond the scope of the change
+      - Focus on correctness and safety over style preferences
       - Log review findings using the decision tools
       """
     },
@@ -254,14 +308,18 @@ defmodule Loomkin.Teams.Role do
       system_prompt: """
       You are a testing agent. Your job is to run tests, validate changes, and report results.
 
-      Priorities:
+      ## Test Execution
       - Run the relevant test suite to check for regressions
       - Verify that new code has adequate test coverage
-      - Report test results clearly — passing count, failures with details
-      - If tests fail, analyze the failure output and identify root causes
       - Suggest missing test cases for edge cases and error paths
-      - Log test results and coverage observations
       - Use shell commands to run mix test and other validation tools
+
+      ## Output Format
+      - Report results with exact test file paths and failure line numbers
+      - Include the actual error message and stacktrace, not just "test failed"
+      - Summarize: total tests, passing count, failure count with details
+      - If tests fail, analyze the failure output and identify root causes
+      - Log test results and coverage observations using decision tools
       """
     }
   }
@@ -283,6 +341,7 @@ defmodule Loomkin.Teams.Role do
     role_guidance = Map.get(@context_role_guidance, role, "")
 
     base_prompt <>
+      @shared_behavioral_guidance <>
       "\n### Context Awareness\n" <>
       role_guidance <>
       @context_mesh_prompt

--- a/lib/loomkin/tools/file_edit.ex
+++ b/lib/loomkin/tools/file_edit.ex
@@ -26,15 +26,31 @@ defmodule Loomkin.Tools.FileEdit do
 
     full_path = safe_path!(file_path, project_path)
 
+    warning = read_before_write_warning(full_path, context)
+
     with {:ok, content} <- read_file(full_path),
          :ok <- validate_match(content, old_string, replace_all),
          new_content <- apply_replacement(content, old_string, new_string, replace_all),
          :ok <- File.write(full_path, new_content) do
       count = occurrence_count(content, old_string)
-      {:ok, %{result: "Replaced #{count} occurrence(s) in #{full_path}"}}
+      result_msg = "Replaced #{count} occurrence(s) in #{full_path}"
+      {:ok, %{result: warning <> result_msg}}
     end
   rescue
     e in ArgumentError -> {:error, e.message}
+  end
+
+  defp read_before_write_warning(full_path, context) do
+    read_files = Map.get(context, :read_files, nil)
+
+    cond do
+      # No tracking available (e.g. direct tool call outside agent loop)
+      is_nil(read_files) -> ""
+      MapSet.member?(read_files, full_path) -> ""
+      true ->
+        "Warning: You are editing a file you haven't read yet. " <>
+          "Consider reading it first to understand the existing code.\n"
+    end
   end
 
   defp read_file(path) do

--- a/test/loomkin/tools/file_edit_test.exs
+++ b/test/loomkin/tools/file_edit_test.exs
@@ -92,4 +92,51 @@ defmodule Loomkin.Tools.FileEditTest do
     assert {:error, msg} = FileEdit.run(params, %{project_path: proj})
     assert msg =~ "outside the project directory"
   end
+
+  @tag :tmp_dir
+  test "warns when editing a file not in read_files set", %{project_path: proj} do
+    params = %{
+      "file_path" => "editable.txt",
+      "old_string" => "Hello, Elixir!",
+      "new_string" => "Hello, Loomkin!"
+    }
+
+    context = %{project_path: proj, read_files: MapSet.new()}
+
+    assert {:ok, %{result: msg}} = FileEdit.run(params, context)
+    assert msg =~ "Warning: You are editing a file you haven't read yet"
+    assert msg =~ "1 occurrence"
+  end
+
+  @tag :tmp_dir
+  test "no warning when file is in read_files set", %{project_path: proj} do
+    full_path = Path.join(proj, "editable.txt")
+
+    params = %{
+      "file_path" => "editable.txt",
+      "old_string" => "Hello, Elixir!",
+      "new_string" => "Hello, Loomkin!"
+    }
+
+    context = %{project_path: proj, read_files: MapSet.new([full_path])}
+
+    assert {:ok, %{result: msg}} = FileEdit.run(params, context)
+    refute msg =~ "Warning"
+    assert msg =~ "1 occurrence"
+  end
+
+  @tag :tmp_dir
+  test "no warning when read_files is not in context", %{project_path: proj} do
+    params = %{
+      "file_path" => "editable.txt",
+      "old_string" => "Hello, Elixir!",
+      "new_string" => "Hello, Loomkin!"
+    }
+
+    context = %{project_path: proj}
+
+    assert {:ok, %{result: msg}} = FileEdit.run(params, context)
+    refute msg =~ "Warning"
+    assert msg =~ "1 occurrence"
+  end
 end


### PR DESCRIPTION
## Summary

- **Enhanced all 5 role prompts** in `role.ex` with structured behavioral guidance inspired by Claude Code's system prompt patterns — covering anti-over-engineering, security awareness, tool routing heuristics, structured output formats, and error recovery
- **Added shared working principles** injected into all roles: parallel tool calls, try alternatives when blocked, ask for clarification when uncertain
- **Implemented read-before-write enforcement** in `file_edit` — tracks which files agents have read and warns (non-blocking) when editing unread files

## What changed

| File | Change |
|------|--------|
| `lib/loomkin/teams/role.ex` | Restructured all 5 role prompts with clear sections; added `@shared_behavioral_guidance` module attribute injected into all roles |
| `lib/loomkin/tools/file_edit.ex` | Added `read_before_write_warning/2` — checks process dictionary for read file tracking |
| `lib/loomkin/agent_loop.ex` | Initializes `MapSet` in process dictionary at loop start; tracks successful `file_read` calls; passes `read_files` via tool context |
| `test/loomkin/tools/file_edit_test.exs` | 3 new tests for warning/no-warning/graceful-degradation cases |

## Motivation

Gap analysis comparing Loom's agent prompts against Claude Code's system prompts revealed several areas where more specific behavioral guidance could reduce wasted tokens, prevent over-engineering, and improve inter-agent communication quality.

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test test/loomkin/tools/file_edit_test.exs` — 10 tests, 0 failures
- [ ] Manual: verify agents follow new guidance (anti-over-engineering, structured output, read-before-write warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)