### PR TITLE
Fix role test regression and read-before-write tracker bugs

### DIFF
--- a/lib/loomkin/agent_loop.ex
+++ b/lib/loomkin/agent_loop.ex
@@ -483,6 +483,11 @@ defmodule Loomkin.AgentLoop do
     tool_call_id = pending_info.pending_data.tool_call_id
     tool_name = pending_info.pending_data.tool_name
 
+    # Restore read-file tracker from pending context (may have been lost across process boundary)
+    if read_files = get_in(pending_info, [:pending_data, :context, :read_files]) do
+      Process.put(:loomkin_read_files, read_files)
+    end
+
     # Record the tool result
     messages = record_tool_result(messages, config, tool_name, tool_call_id, tool_result_text)
 
@@ -514,11 +519,15 @@ defmodule Loomkin.AgentLoop do
       file_path = tool_args["file_path"] || tool_args[:file_path]
 
       if file_path && project_path do
-        full_path = Path.expand(file_path, project_path)
+        # Use safe_path! to canonicalize (resolve symlinks) — matches file_edit's path form
+        full_path = Loomkin.Tool.safe_path!(file_path, project_path)
         read_files = Process.get(:loomkin_read_files, MapSet.new())
         Process.put(:loomkin_read_files, MapSet.put(read_files, full_path))
       end
     end
+  rescue
+    # safe_path! raises on paths outside the project — skip tracking
+    ArgumentError -> :ok
   end
 
   defp maybe_track_read_file(_tool_name, _tool_args, _project_path, _result_text), do: :ok

--- a/test/loomkin/teams/role_test.exs
+++ b/test/loomkin/teams/role_test.exs
@@ -138,10 +138,10 @@ defmodule Loomkin.Teams.RoleTest do
       end
     end
 
-    test "lead prompt mentions decompose and coordinate" do
+    test "lead prompt mentions decomposition and coordination" do
       {:ok, lead} = Role.get(:lead)
-      assert lead.system_prompt =~ "decompose"
-      assert lead.system_prompt =~ "coordinate"
+      assert lead.system_prompt =~ "decomposition"
+      assert lead.system_prompt =~ "coordination"
     end
 
     test "researcher prompt mentions explore and read-only" do
@@ -150,10 +150,10 @@ defmodule Loomkin.Teams.RoleTest do
       assert researcher.system_prompt =~ "read-only"
     end
 
-    test "coder prompt mentions implement and conventions" do
+    test "coder prompt mentions implement and code style" do
       {:ok, coder} = Role.get(:coder)
       assert coder.system_prompt =~ "implement"
-      assert coder.system_prompt =~ "conventions"
+      assert coder.system_prompt =~ "code style"
     end
 
     test "reviewer prompt mentions review and security" do


### PR DESCRIPTION
## Summary

Follow-up fixes for issues introduced in #84:

- **P1 — Role test regression**: Updated assertions in `role_test.exs` to match rewritten prompts (lead: "decomposition"/"coordination", coder: "code style")
- **P2 — False warnings after permission resume**: `resume/3` now restores the read-file tracker from `pending_data.context.read_files`, preventing false "haven't read yet" warnings after a permission pause
- **P2 — False warnings with symlinked paths**: Read-file tracker now uses `Loomkin.Tool.safe_path!/2` to canonicalize paths (resolving symlinks), matching the same form `FileEdit` uses for comparison

## Test plan

- [ ] `mix test test/loomkin/teams/role_test.exs` — all 27 pass (was 2 failures)
- [ ] `mix test test/loomkin/tools/file_edit_test.exs` — all 10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)