### PR TITLE
Guard list_agents and team_progress against keeper crashes (#89, #90, #91)

### DIFF
--- a/lib/loomkin/teams/manager.ex
+++ b/lib/loomkin/teams/manager.ex
@@ -224,13 +224,17 @@ defmodule Loomkin.Teams.Manager do
     end
   end
 
-  @doc "List all agents in a team."
+  @doc "List all agents in a team (excludes keepers and other non-agent entries)."
   def list_agents(team_id) do
     Registry.select(Loomkin.Teams.AgentRegistry, [
       {{{team_id, :"$1"}, :"$2", :"$3"}, [], [%{name: :"$1", pid: :"$2", meta: :"$3"}]}
     ])
+    |> Enum.filter(fn %{meta: meta} ->
+      is_map(meta) and meta[:type] != :keeper and
+        (Map.has_key?(meta, :role) or Map.has_key?(meta, "role"))
+    end)
     |> Enum.map(fn %{name: name, pid: pid, meta: meta} ->
-      %{name: name, pid: pid, role: meta[:role] || meta.role, status: meta[:status] || meta.status}
+      %{name: name, pid: pid, role: meta[:role] || meta["role"], status: meta[:status] || meta["status"] || :idle}
     end)
   end
 

--- a/lib/loomkin/tools/team_progress.ex
+++ b/lib/loomkin/tools/team_progress.ex
@@ -18,7 +18,7 @@ defmodule Loomkin.Tools.TeamProgress do
   def run(params, _context) do
     team_id = param!(params, :team_id)
 
-    agents = Manager.list_agents(team_id)
+    agents = safe_list_agents(team_id)
     tasks = Tasks.list_all(team_id)
     claims = Context.list_all_claims(team_id)
     budget = RateLimiter.get_budget(team_id)
@@ -28,7 +28,7 @@ defmodule Loomkin.Tools.TeamProgress do
         "  (none)"
       else
         Enum.map_join(agents, "\n", fn a ->
-          "  - #{a.name} (#{a.role}): #{a.status}"
+          "  - #{Map.get(a, :name, "?")} (#{Map.get(a, :role, "?")}): #{Map.get(a, :status, "?")}"
         end)
       end
 
@@ -71,5 +71,11 @@ defmodule Loomkin.Tools.TeamProgress do
     """
 
     {:ok, %{result: String.trim(summary)}}
+  end
+
+  defp safe_list_agents(team_id) do
+    Manager.list_agents(team_id)
+  rescue
+    _ -> []
   end
 end

--- a/test/loomkin/teams/manager_test.exs
+++ b/test/loomkin/teams/manager_test.exs
@@ -152,6 +152,97 @@ defmodule Loomkin.Teams.ManagerTest do
     end
   end
 
+  describe "list_agents/1 excludes keepers" do
+    test "returns empty list when team has only keepers" do
+      {:ok, team_id} = Manager.create_team(name: "only-keepers")
+
+      # Register a keeper entry (same shape as ContextKeeper.start_link registers)
+      {:ok, _} = Registry.register(
+        Loomkin.Teams.AgentRegistry,
+        {team_id, "keeper:abc-123"},
+        %{type: :keeper, topic: "test topic", tokens: 100, source_agent: "coder"}
+      )
+
+      assert Manager.list_agents(team_id) == []
+    end
+
+    test "returns only agents when team has both agents and keepers" do
+      {:ok, team_id} = Manager.create_team(name: "mixed-team")
+
+      # Register a real agent
+      {:ok, _} = Registry.register(
+        Loomkin.Teams.AgentRegistry,
+        {team_id, "coder-1"},
+        %{role: :coder, status: :idle}
+      )
+
+      # We need a separate process for the keeper registration since Registry
+      # allows only one key per process
+      keeper_task = Task.async(fn ->
+        {:ok, _} = Registry.register(
+          Loomkin.Teams.AgentRegistry,
+          {team_id, "keeper:def-456"},
+          %{type: :keeper, topic: "context", tokens: 50, source_agent: "coder-1"}
+        )
+        Process.sleep(:infinity)
+      end)
+
+      # Give time for registration
+      Process.sleep(10)
+
+      agents = Manager.list_agents(team_id)
+      assert length(agents) == 1
+      assert [%{name: "coder-1", role: :coder, status: :idle}] = agents
+
+      Task.shutdown(keeper_task, :brutal_kill)
+    end
+
+    test "returns all agents when no keepers are present" do
+      {:ok, team_id} = Manager.create_team(name: "agents-only")
+
+      {:ok, _} = Registry.register(
+        Loomkin.Teams.AgentRegistry,
+        {team_id, "researcher-1"},
+        %{role: :researcher, status: :working}
+      )
+
+      agents = Manager.list_agents(team_id)
+      assert length(agents) == 1
+      assert [%{name: "researcher-1", role: :researcher, status: :working}] = agents
+    end
+
+    test "handles multiple keepers without leaking any into agent list" do
+      {:ok, team_id} = Manager.create_team(name: "multi-keeper")
+
+      # Register an agent from the test process
+      {:ok, _} = Registry.register(
+        Loomkin.Teams.AgentRegistry,
+        {team_id, "lead-1"},
+        %{role: :lead, status: :idle}
+      )
+
+      # Register multiple keepers from separate processes
+      keeper_tasks = Enum.map(1..3, fn i ->
+        Task.async(fn ->
+          {:ok, _} = Registry.register(
+            Loomkin.Teams.AgentRegistry,
+            {team_id, "keeper:keeper-#{i}"},
+            %{type: :keeper, topic: "topic-#{i}", tokens: i * 100, source_agent: "lead-1"}
+          )
+          Process.sleep(:infinity)
+        end)
+      end)
+
+      Process.sleep(10)
+
+      agents = Manager.list_agents(team_id)
+      assert length(agents) == 1
+      assert [%{name: "lead-1", role: :lead}] = agents
+
+      Enum.each(keeper_tasks, &Task.shutdown(&1, :brutal_kill))
+    end
+  end
+
   describe "stop_agent/2" do
     test "returns :ok for nonexistent agent" do
       {:ok, team_id} = Manager.create_team(name: "stop-test")

--- a/test/loomkin/tools/team_progress_test.exs
+++ b/test/loomkin/tools/team_progress_test.exs
@@ -1,0 +1,82 @@
+defmodule Loomkin.Tools.TeamProgressTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Teams.Manager
+  alias Loomkin.Tools.TeamProgress
+
+  defp run_progress(team_id) do
+    TeamProgress.run(%{team_id: team_id}, %{})
+  end
+
+  describe "team_progress with keepers" do
+    test "returns ok when team has only keepers registered" do
+      {:ok, team_id} = Manager.create_team(name: "keeper-only-progress")
+
+      # Register a keeper in a separate process
+      keeper_task = Task.async(fn ->
+        {:ok, _} = Registry.register(
+          Loomkin.Teams.AgentRegistry,
+          {team_id, "keeper:abc-123"},
+          %{type: :keeper, topic: "test", tokens: 100, source_agent: "coder"}
+        )
+        Process.sleep(:infinity)
+      end)
+
+      Process.sleep(10)
+
+      assert {:ok, %{result: result}} = run_progress(team_id)
+      assert result =~ "Agents:"
+      assert result =~ "(none)"
+
+      Task.shutdown(keeper_task, :brutal_kill)
+    end
+
+    test "returns ok with zero agents and zero keepers" do
+      {:ok, team_id} = Manager.create_team(name: "empty-progress")
+
+      assert {:ok, %{result: result}} = run_progress(team_id)
+      assert result =~ "Agents:"
+      assert result =~ "(none)"
+    end
+
+    test "lists only real agents when keepers are also present" do
+      {:ok, team_id} = Manager.create_team(name: "mixed-progress")
+
+      # Register a real agent from test process
+      {:ok, _} = Registry.register(
+        Loomkin.Teams.AgentRegistry,
+        {team_id, "researcher-1"},
+        %{role: :researcher, status: :working}
+      )
+
+      # Register a keeper from a separate process
+      keeper_task = Task.async(fn ->
+        {:ok, _} = Registry.register(
+          Loomkin.Teams.AgentRegistry,
+          {team_id, "keeper:xyz-789"},
+          %{type: :keeper, topic: "research notes", tokens: 500, source_agent: "researcher-1"}
+        )
+        Process.sleep(:infinity)
+      end)
+
+      Process.sleep(10)
+
+      assert {:ok, %{result: result}} = run_progress(team_id)
+      assert result =~ "researcher-1 (researcher): working"
+      refute result =~ "keeper"
+
+      Task.shutdown(keeper_task, :brutal_kill)
+    end
+
+    test "output contains all expected sections" do
+      {:ok, team_id} = Manager.create_team(name: "sections-progress")
+
+      assert {:ok, %{result: result}} = run_progress(team_id)
+      assert result =~ "Agents:"
+      assert result =~ "Tasks"
+      assert result =~ "Region Claims:"
+      assert result =~ "Budget:"
+      assert result =~ "Spent: $"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **#89**: `Manager.list_agents/1` now filters out keeper/non-agent registry entries (checks `type: :keeper` and requires `:role` key), preventing `KeyError` crashes in Mission Control
- **#90**: `team_progress` tool uses a `safe_list_agents/1` rescue wrapper + defensive `Map.get` for agent formatting, so architect planning flow never aborts from keeper presence
- **#91**: 8 regression tests covering keepers in both `Manager` and `team_progress`

## Changes

| File | Change |
|------|--------|
| `lib/loomkin/teams/manager.ex` | Filter keepers from `list_agents/1`, defensive `status` fallback |
| `lib/loomkin/tools/team_progress.ex` | `safe_list_agents/1` rescue wrapper, `Map.get` defaults |
| `test/loomkin/teams/manager_test.exs` | 4 tests: only-keepers, mixed, agents-only, multi-keeper |
| `test/loomkin/tools/team_progress_test.exs` | 4 tests: keepers-only, empty, mixed, section format |

## Test plan

- [x] 25/25 tests pass in affected test files
- [x] `list_agents/1` returns `[]` for teams with only keepers
- [x] `list_agents/1` excludes keepers in mixed teams, returns only real agents
- [x] `team_progress` returns `{:ok, %{result: ...}}` with keepers present
- [x] Output sections (Agents, Tasks, Region Claims, Budget) remain intact

Closes #89, closes #90, closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)