### PR TITLE
Narrow safe_list_agents rescue and harden test sync

### DIFF
--- a/lib/loomkin/tools/team_progress.ex
+++ b/lib/loomkin/tools/team_progress.ex
@@ -10,6 +10,8 @@ defmodule Loomkin.Tools.TeamProgress do
       team_id: [type: :string, required: true, doc: "Team ID"]
     ]
 
+  require Logger
+
   import Loomkin.Tool, only: [param!: 2]
 
   alias Loomkin.Teams.{Context, Manager, RateLimiter, Tasks}
@@ -24,12 +26,17 @@ defmodule Loomkin.Tools.TeamProgress do
     budget = RateLimiter.get_budget(team_id)
 
     agents_section =
-      if agents == [] do
-        "  (none)"
-      else
-        Enum.map_join(agents, "\n", fn a ->
-          "  - #{Map.get(a, :name, "?")} (#{Map.get(a, :role, "?")}): #{Map.get(a, :status, "?")}"
-        end)
+      case agents do
+        :error ->
+          "  (unavailable — check logs)"
+
+        [] ->
+          "  (none)"
+
+        agents ->
+          Enum.map_join(agents, "\n", fn a ->
+            "  - #{Map.get(a, :name, "?")} (#{Map.get(a, :role, "?")}): #{Map.get(a, :status, "?")}"
+          end)
       end
 
     tasks_section =
@@ -76,6 +83,8 @@ defmodule Loomkin.Tools.TeamProgress do
   defp safe_list_agents(team_id) do
     Manager.list_agents(team_id)
   rescue
-    _ -> []
+    e ->
+      Logger.warning("list_agents failed for team #{team_id}: #{Exception.message(e)}")
+      :error
   end
 end

--- a/test/loomkin/teams/manager_test.exs
+++ b/test/loomkin/teams/manager_test.exs
@@ -176,25 +176,25 @@ defmodule Loomkin.Teams.ManagerTest do
         %{role: :coder, status: :idle}
       )
 
-      # We need a separate process for the keeper registration since Registry
-      # allows only one key per process
-      keeper_task = Task.async(fn ->
+      # Spawn keeper in a separate process with explicit handshake
+      parent = self()
+
+      keeper_pid = spawn_link(fn ->
         {:ok, _} = Registry.register(
           Loomkin.Teams.AgentRegistry,
           {team_id, "keeper:def-456"},
           %{type: :keeper, topic: "context", tokens: 50, source_agent: "coder-1"}
         )
+        send(parent, :keeper_registered)
         Process.sleep(:infinity)
       end)
 
-      # Give time for registration
-      Process.sleep(10)
+      assert_receive :keeper_registered
+      on_exit(fn -> Process.exit(keeper_pid, :kill) end)
 
       agents = Manager.list_agents(team_id)
       assert length(agents) == 1
       assert [%{name: "coder-1", role: :coder, status: :idle}] = agents
-
-      Task.shutdown(keeper_task, :brutal_kill)
     end
 
     test "returns all agents when no keepers are present" do
@@ -221,25 +221,27 @@ defmodule Loomkin.Teams.ManagerTest do
         %{role: :lead, status: :idle}
       )
 
-      # Register multiple keepers from separate processes
-      keeper_tasks = Enum.map(1..3, fn i ->
-        Task.async(fn ->
+      # Register multiple keepers with explicit handshake
+      parent = self()
+
+      keeper_pids = Enum.map(1..3, fn i ->
+        spawn_link(fn ->
           {:ok, _} = Registry.register(
             Loomkin.Teams.AgentRegistry,
             {team_id, "keeper:keeper-#{i}"},
             %{type: :keeper, topic: "topic-#{i}", tokens: i * 100, source_agent: "lead-1"}
           )
+          send(parent, {:keeper_registered, i})
           Process.sleep(:infinity)
         end)
       end)
 
-      Process.sleep(10)
+      for i <- 1..3, do: assert_receive({:keeper_registered, ^i})
+      on_exit(fn -> Enum.each(keeper_pids, &Process.exit(&1, :kill)) end)
 
       agents = Manager.list_agents(team_id)
       assert length(agents) == 1
       assert [%{name: "lead-1", role: :lead}] = agents
-
-      Enum.each(keeper_tasks, &Task.shutdown(&1, :brutal_kill))
     end
   end
 

--- a/test/loomkin/tools/team_progress_test.exs
+++ b/test/loomkin/tools/team_progress_test.exs
@@ -12,23 +12,24 @@ defmodule Loomkin.Tools.TeamProgressTest do
     test "returns ok when team has only keepers registered" do
       {:ok, team_id} = Manager.create_team(name: "keeper-only-progress")
 
-      # Register a keeper in a separate process
-      keeper_task = Task.async(fn ->
+      parent = self()
+
+      keeper_pid = spawn_link(fn ->
         {:ok, _} = Registry.register(
           Loomkin.Teams.AgentRegistry,
           {team_id, "keeper:abc-123"},
           %{type: :keeper, topic: "test", tokens: 100, source_agent: "coder"}
         )
+        send(parent, :keeper_registered)
         Process.sleep(:infinity)
       end)
 
-      Process.sleep(10)
+      assert_receive :keeper_registered
+      on_exit(fn -> Process.exit(keeper_pid, :kill) end)
 
       assert {:ok, %{result: result}} = run_progress(team_id)
       assert result =~ "Agents:"
       assert result =~ "(none)"
-
-      Task.shutdown(keeper_task, :brutal_kill)
     end
 
     test "returns ok with zero agents and zero keepers" do
@@ -49,23 +50,24 @@ defmodule Loomkin.Tools.TeamProgressTest do
         %{role: :researcher, status: :working}
       )
 
-      # Register a keeper from a separate process
-      keeper_task = Task.async(fn ->
+      parent = self()
+
+      keeper_pid = spawn_link(fn ->
         {:ok, _} = Registry.register(
           Loomkin.Teams.AgentRegistry,
           {team_id, "keeper:xyz-789"},
           %{type: :keeper, topic: "research notes", tokens: 500, source_agent: "researcher-1"}
         )
+        send(parent, :keeper_registered)
         Process.sleep(:infinity)
       end)
 
-      Process.sleep(10)
+      assert_receive :keeper_registered
+      on_exit(fn -> Process.exit(keeper_pid, :kill) end)
 
       assert {:ok, %{result: result}} = run_progress(team_id)
       assert result =~ "researcher-1 (researcher): working"
       refute result =~ "keeper"
-
-      Task.shutdown(keeper_task, :brutal_kill)
     end
 
     test "output contains all expected sections" do


### PR DESCRIPTION
## Summary

Followup to #122 addressing code review findings:

- **[P2] Silent failure in team_progress**: `safe_list_agents/1` was rescuing all exceptions and returning `[]`, making real failures look like "no agents." Now returns `:error` on failure, logs the exception via `Logger.warning`, and the summary shows `(unavailable — check logs)` instead of `(none)`
- **[P3] Flaky test synchronization**: Replaced `Process.sleep(10)` with explicit `send`/`assert_receive` handshake for keeper registration. Added `on_exit` cleanup so keeper processes are killed even on assertion failure

## Test plan

- [x] 25/25 tests pass in affected files
- [x] `team_progress` shows "unavailable" when list_agents raises (not silent empty)
- [x] No `Process.sleep` remaining in keeper tests
- [x] Keeper processes cleaned up via `on_exit` callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)