### PR TITLE
Fix ask_user tool crash: read team_id from context

### DIFF
--- a/lib/loomkin/tools/ask_user.ex
+++ b/lib/loomkin/tools/ask_user.ex
@@ -11,7 +11,6 @@ defmodule Loomkin.Tools.AskUser do
         "The question appears in the mission control UI and the agent blocks until " <>
         "the user selects an answer. Use this when you need human input to proceed.",
     schema: [
-      team_id: [type: :string, required: true, doc: "Team ID"],
       question: [type: :string, required: true, doc: "The question to ask the user"],
       options: [type: {:list, :string}, required: true, doc: "List of answer options to present"]
     ]
@@ -23,7 +22,7 @@ defmodule Loomkin.Tools.AskUser do
   @doc false
   @impl true
   def run(params, context) do
-    team_id = param!(params, :team_id)
+    team_id = param!(context, :team_id)
     question = param!(params, :question)
     options = param!(params, :options)
     agent_name = param!(context, :agent_name)


### PR DESCRIPTION
## Summary
- The `ask_user` tool was crashing with `KeyError: key "team_id" not found` whenever an agent tried to ask the user a question
- **Root cause**: `team_id` was declared as a required schema parameter the LLM must provide, but agents have no way to know their team ID
- **Fix**: Read `team_id` from the execution context (already populated by `agent_loop.ex` at tool call time) instead of from LLM params — consistent with how `team_spawn` and other tools handle team identity

## Test plan
- [ ] Start a team and trigger an agent that calls `ask_user` — should no longer crash
- [ ] Verify the question appears in the mission control UI with correct team routing
- [ ] Confirm the answer is routed back to the blocking agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)