### PR TITLE
Fix KeyError crash in model selector OAuth warning banner

### DIFF
--- a/lib/loomkin_web/live/model_selector_component.ex
+++ b/lib/loomkin_web/live/model_selector_component.ex
@@ -154,7 +154,7 @@ defmodule LoomkinWeb.ModelSelectorComponent do
         </div>
 
         <%!-- Key warning --%>
-        <.key_warning_banner model={@model} all_providers={@all_providers} />
+        <.key_warning_banner model={@model} all_providers={@all_providers} myself={@myself} />
 
         <%!-- Unconfigured providers --%>
         <div :if={@unconfigured_providers != [] and @search == ""} style="border-top: 1px solid var(--border-subtle);">


### PR DESCRIPTION
## Summary
- `key_warning_banner/1` is a function component that renders a `phx-target={@myself}` button for OAuth connect, but `@myself` was never passed through from the parent `render/1`
- Opening the model selector with an OAuth-disconnected provider as the current model crashes the LiveView with `KeyError: key :myself not found`
- One-line fix: pass `myself={@myself}` to the function component call

## Test plan
- [ ] Start app with no `ANTHROPIC_API_KEY` set and model set to `anthropic:claude-sonnet-4-6`
- [ ] Open the model selector dropdown — should render the OAuth warning banner without crashing
- [ ] Click "Connect with OAuth" in the banner — should start the paste-back flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)