### PR TITLE
Fix :unknown_provider error when using OAuth models

### DIFF
--- a/lib/loomkin/llm.ex
+++ b/lib/loomkin/llm.ex
@@ -89,7 +89,7 @@ defmodule Loomkin.LLM do
     oauth_map = ProviderRegistry.oauth_provider_map()
 
     case String.split(model_spec, ":", parts: 2) do
-      [provider, model_id] ->
+      [provider, _model_id] ->
         case Map.get(oauth_map, provider) do
           nil ->
             # No OAuth variant for this provider
@@ -99,8 +99,20 @@ defmodule Loomkin.LLM do
             provider_atom = String.to_existing_atom(provider)
 
             if TokenStore.get_access_token(provider_atom) != nil do
-              Logger.debug("Upgrading #{provider}:#{model_id} to OAuth provider")
-              "#{oauth_provider}:#{model_id}"
+              Logger.debug("Upgrading #{provider} to OAuth provider")
+
+              # Resolve the model via the base provider (LLMDB knows "anthropic:*"
+              # but not "anthropic_oauth:*"), then override .provider so ReqLLM
+              # routes to the registered OAuth adapter module.
+              case ReqLLM.model(model_spec) do
+                {:ok, model} ->
+                  oauth_atom = String.to_existing_atom(oauth_provider)
+                  %{model | provider: oauth_atom}
+
+                {:error, _reason} ->
+                  # Model resolution failed — pass through unchanged
+                  model_spec
+              end
             else
               model_spec
             end


### PR DESCRIPTION
## Summary

- Fixes the `:unknown_provider` error that occurs when actually using an OAuth-connected model (e.g., after connecting Anthropic Max via OAuth)
- LLMDB's spec parser validates providers against its built-in catalog, which only knows stock providers (`anthropic`, `openai`, `google`) — not custom OAuth variants (`anthropic_oauth`, etc.)
- The error occurred *before* ReqLLM ever reached the OAuth adapter's `prepare_request` callback, so the existing `resolve_model` workaround inside the adapter never ran

## Fix

Instead of returning a string like `"anthropic_oauth:claude-sonnet-4-6"` (which LLMDB can't resolve), `maybe_upgrade_to_oauth` now:

1. Resolves the model via the base provider string (`"anthropic:claude-sonnet-4-6"`) which LLMDB recognizes
2. Overrides `.provider` on the resulting model struct to `:anthropic_oauth`
3. Passes the struct to ReqLLM, which routes to the registered OAuth adapter via its provider registry

## Test plan

- [x] All 120 OAuth/provider tests pass
- [x] `mix compile` clean
- [ ] Manual: connect Anthropic OAuth, send a message — should route through OAuth adapter with Bearer auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)