### PR TITLE
Fix UI not updating after OAuth token refresh

### DIFF
--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -1277,7 +1277,7 @@ defmodule LoomkinWeb.WorkspaceLive do
   end
 
   def handle_info({:auth_refreshed, _provider}, socket) do
-    {:noreply, socket}
+    {:noreply, send_update_to_model_selector(socket)}
   end
 
   def handle_info({:auth_refresh_failed, _provider, _reason}, socket) do


### PR DESCRIPTION
## Summary

- The `{:auth_refreshed, provider}` handler in WorkspaceLive was a no-op (`{:noreply, socket}`)
- When TokenStore successfully refreshes an expired token on startup (1s after boot), the model selector never re-checked provider status
- Result: users see "Connect your subscription" on every restart, even though the refresh succeeds moments later

## Fix

Call `send_update_to_model_selector(socket)` in the `auth_refreshed` handler, matching the behavior of `auth_connected` and `auth_disconnected`.

## Test plan

- [ ] Start server with previously-connected OAuth provider
- [ ] Model selector should briefly show "Connect", then switch to "Connected" after token refresh (~1s)
- [ ] Verify no regressions with connect/disconnect flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)