### PR TITLE
Fix bootstrap agent race conditions and activity feed UX

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -364,6 +364,7 @@ Hooks.AutoResizeTextarea = {
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {
+  longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
   hooks: Hooks
 })

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -1940,7 +1940,10 @@ defmodule LoomkinWeb.WorkspaceLive do
   # Used on mount to recover feed state after reconnections.
   defp messages_to_activity_events(messages) do
     messages
-    |> Enum.filter(fn msg -> msg.role in [:user, :assistant] end)
+    |> Enum.filter(fn msg ->
+      role = Map.get(msg, :role)
+      role in [:user, :assistant]
+    end)
     |> Enum.map(fn msg ->
       {agent, from, to} =
         case msg.role do
@@ -1952,7 +1955,7 @@ defmodule LoomkinWeb.WorkspaceLive do
         id: "history-#{Ecto.UUID.generate()}",
         type: :message,
         agent: agent,
-        content: msg.content || "",
+        content: Map.get(msg, :content) || "",
         timestamp: Map.get(msg, :inserted_at, DateTime.utc_now()),
         expanded: false,
         metadata: %{from: from, to: to}


### PR DESCRIPTION
## Summary
- **Race condition fix**: Agents spawn before workspace subscribes to team PubSub — now synthesizes "joined" events from existing agents when subscribing
- **"Has joined" dedup**: Track known agents per session, only show join event once (prevents late "concierge joined" after it already spoke)
- **Thinking card expand**: Add show more/show less toggle to thinking/streaming cards (was truncated with no way to read full content)
- **Cancel button**: Handle `:cancelled` silently and `:busy` with gentle info flash instead of error
- **Activity feed cleanup**: Remove finalized thinking cards on stream end, filter `:status` events from main feed

## Test plan
- [ ] Start a new session — concierge and orienter should appear in sidebar immediately
- [ ] Concierge greeting should appear without a late "has joined" after
- [ ] Orienter should show as working (not perpetually idle)
- [ ] Long thinking content should have "show more" toggle
- [ ] Click cancel while agent is thinking — no error flash
- [ ] Send message while agent is busy — info flash, not error
- [ ] Activity feed should show communications, not pile up thinking cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)