### PR TITLE
Replace activity stream with agent cards + comms feed

### DIFF
--- a/lib/loomkin_web/live/agent_card_component.ex
+++ b/lib/loomkin_web/live/agent_card_component.ex
@@ -1,0 +1,281 @@
+defmodule LoomkinWeb.AgentCardComponent do
+  @moduledoc """
+  Functional component that renders a single agent's workbench card in
+  the mission control UI. Each agent gets one card that updates in-place,
+  showing status, current activity, and action buttons.
+  """
+
+  use Phoenix.Component
+
+  @tool_config %{
+    "file_read" => %{icon: "📄", color: "#818cf8"},
+    "file_write" => %{icon: "✍", color: "#34d399"},
+    "file_edit" => %{icon: "✎", color: "#fbbf24"},
+    "file_search" => %{icon: "🔍", color: "#22d3ee"},
+    "content_search" => %{icon: "🔍", color: "#22d3ee"},
+    "directory_list" => %{icon: "📁", color: "#a78bfa"},
+    "shell" => %{icon: "⚡", color: "#f472b6"},
+    "git" => %{icon: "📈", color: "#fb923c"}
+  }
+  @default_tool_config %{icon: "⚙", color: "#71717a"}
+
+  attr :card, :map, required: true
+  attr :focused, :boolean, default: false
+  attr :team_id, :string, required: true
+
+  def agent_card(assigns) do
+    ~H"""
+    <div
+      id={"agent-card-#{@card.name}"}
+      phx-click="focus_card_agent"
+      phx-value-agent={@card.name}
+      class={[
+        "group relative rounded-xl border p-4 cursor-pointer animate-fade-in min-h-[140px] flex flex-col",
+        if(@focused, do: "card-brand", else: "bg-surface-1 border-subtle hover:bg-surface-2")
+      ]}
+      style="transition: background var(--transition-base), border-color var(--transition-base);"
+    >
+      <%!-- Question overlay --%>
+      <div
+        :if={@card.pending_question}
+        class="absolute inset-0 z-10 rounded-xl bg-gradient-to-br from-violet-900/30 to-purple-900/20 border border-violet-500/30 p-4 flex flex-col"
+      >
+        <div class="flex items-center gap-2 mb-3">
+          <div class="w-6 h-6 rounded-lg bg-violet-500/20 flex items-center justify-center flex-shrink-0">
+            <svg class="w-3.5 h-3.5 text-violet-400" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </div>
+          <p class="text-xs font-semibold text-violet-300 truncate">
+            {@card.pending_question.agent_name} needs your input
+          </p>
+        </div>
+
+        <p class="text-sm text-gray-200 mb-3 leading-relaxed line-clamp-2">
+          {@card.pending_question.question}
+        </p>
+
+        <div class="flex flex-wrap gap-1.5 mt-auto">
+          <button
+            :for={option <- @card.pending_question.options}
+            phx-click="ask_user_answer"
+            phx-value-question-id={@card.pending_question.question_id}
+            phx-value-answer={option}
+            class="px-3 py-1.5 text-xs font-medium text-violet-300 bg-violet-500/10 hover:bg-violet-500/25 border border-violet-500/30 hover:border-violet-400/50 rounded-lg transition-all duration-200 cursor-pointer"
+          >
+            {option}
+          </button>
+          <button
+            phx-click="ask_user_answer"
+            phx-value-question-id={@card.pending_question.question_id}
+            phx-value-answer="__collective__"
+            class="px-3 py-1.5 text-xs font-medium text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 border border-amber-500/30 hover:border-amber-400/50 rounded-lg transition-all duration-200 cursor-pointer"
+          >
+            Let the collective decide
+          </button>
+        </div>
+      </div>
+
+      <%!-- Header: status dot, name, role badge, action buttons --%>
+      <div class="flex items-center gap-2">
+        <span class={["w-2 h-2 rounded-full flex-shrink-0", status_dot_class(@card.status)]}></span>
+        <span
+          class="text-sm font-medium truncate"
+          style={"color: #{LoomkinWeb.AgentColors.agent_color(@card.name)}"}
+        >
+          {@card.name}
+        </span>
+        <span
+          class="text-[10px] px-1.5 py-0.5 rounded font-medium text-muted"
+          style="background: var(--brand-muted);"
+        >
+          {format_role(@card.role)}
+        </span>
+
+        <div class="flex-1"></div>
+
+        <%!-- Action buttons (visible on hover) --%>
+        <div
+          class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100"
+          style="transition: opacity var(--transition-base);"
+        >
+          <%!-- Reply --%>
+          <button
+            phx-click="reply_to_card_agent"
+            phx-value-agent={@card.name}
+            phx-value-team-id={@team_id}
+            title={"Reply to #{@card.name}"}
+            class="text-muted hover:text-brand p-1 rounded-md hover:bg-surface-3 flex-shrink-0"
+            style="transition: color var(--transition-base), background var(--transition-base);"
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fill-rule="evenodd"
+                d="M7.707 3.293a1 1 0 010 1.414L5.414 7H11a7 7 0 017 7v2a1 1 0 11-2 0v-2a5 5 0 00-5-5H5.414l2.293 2.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <%!-- Pause (only when working) --%>
+          <button
+            :if={@card.status == :working}
+            phx-click="pause_card_agent"
+            phx-value-agent={@card.name}
+            phx-value-team-id={@team_id}
+            title={"Pause #{@card.name}"}
+            class="text-muted hover:text-amber-400 p-1 rounded-md hover:bg-surface-3 flex-shrink-0"
+            style="transition: color var(--transition-base), background var(--transition-base);"
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <%!-- Resume (only when paused) --%>
+          <button
+            :if={@card.status == :paused}
+            phx-click="resume_card_agent"
+            phx-value-agent={@card.name}
+            phx-value-team-id={@team_id}
+            title={"Resume #{@card.name}"}
+            class="text-muted hover:text-green-400 p-1 rounded-md hover:bg-surface-3 flex-shrink-0"
+            style="transition: color var(--transition-base), background var(--transition-base);"
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fill-rule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <%!-- Steer (only when paused) --%>
+          <button
+            :if={@card.status == :paused}
+            phx-click="steer_card_agent"
+            phx-value-agent={@card.name}
+            phx-value-team-id={@team_id}
+            title={"Steer #{@card.name}"}
+            class="text-muted hover:text-brand p-1 rounded-md hover:bg-surface-3 flex-shrink-0"
+            style="transition: color var(--transition-base), background var(--transition-base);"
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <%!-- Content area --%>
+      <div class="mt-3 flex-1 min-h-0">
+        <%= case @card.content_type do %>
+          <% :thinking -> %>
+            <p
+              class="text-xs leading-relaxed line-clamp-4 animate-pulse"
+              style="color: var(--text-secondary);"
+            >
+              {format_content(@card.latest_content)}
+            </p>
+          <% :tool_call -> %>
+            <div class="flex items-center gap-1.5">
+              <span class="text-xs" style={"color: #{active_tool_config(@card).color}"}>
+                {active_tool_config(@card).icon}
+              </span>
+              <span
+                class="text-xs font-mono truncate"
+                style={"color: #{active_tool_config(@card).color}"}
+              >
+                {active_tool_name(@card)}
+              </span>
+            </div>
+            <p
+              :if={@card.latest_content}
+              class="text-xs mt-1 line-clamp-3 font-mono truncate"
+              style="color: var(--text-muted);"
+            >
+              {format_content(@card.latest_content)}
+            </p>
+          <% :message -> %>
+            <p class="text-xs leading-relaxed line-clamp-4" style="color: var(--text-secondary);">
+              {format_content(@card.latest_content)}
+            </p>
+          <% _ -> %>
+            <p class="text-xs text-muted italic">idle</p>
+        <% end %>
+
+        <%!-- Last tool (subtle, below content) --%>
+        <div
+          :if={@card.last_tool && @card.content_type != :tool_call}
+          class="mt-1.5 flex items-center gap-1.5"
+        >
+          <span
+            class="text-[10px] opacity-60"
+            style={"color: #{tool_config(@card.last_tool.name).color}"}
+          >
+            {tool_config(@card.last_tool.name).icon}
+          </span>
+          <span class="text-[10px] font-mono truncate text-muted opacity-60">
+            {@card.last_tool.target || @card.last_tool.name}
+          </span>
+        </div>
+      </div>
+
+      <%!-- Footer: current task --%>
+      <div
+        :if={@card.current_task}
+        class="mt-2 pt-2 flex items-center gap-2"
+        style="border-top: 1px solid var(--border-subtle);"
+      >
+        <span class="text-[10px] text-muted uppercase tracking-wide flex-shrink-0">Current</span>
+        <span class="text-xs truncate flex-1 font-mono" style="color: var(--text-secondary);">
+          {@card.current_task}
+        </span>
+      </div>
+    </div>
+    """
+  end
+
+  # --- Status helpers ---
+
+  defp status_dot_class(:working), do: "bg-green-400 agent-dot-working"
+  defp status_dot_class(:idle), do: "bg-zinc-500"
+  defp status_dot_class(:blocked), do: "bg-amber-400 agent-dot-thinking"
+  defp status_dot_class(:paused), do: "bg-blue-400 animate-pulse"
+  defp status_dot_class(:error), do: "bg-red-400 agent-dot-error"
+  defp status_dot_class(:waiting_permission), do: "bg-amber-400 agent-dot-thinking"
+  defp status_dot_class(_), do: "bg-zinc-500"
+
+  # --- Tool lookup helpers ---
+
+  defp tool_config(name) when is_binary(name),
+    do: Map.get(@tool_config, name, @default_tool_config)
+
+  defp tool_config(_), do: @default_tool_config
+
+  defp active_tool_name(%{last_tool: %{name: name}}) when is_binary(name), do: name
+  defp active_tool_name(_), do: "tool"
+
+  defp active_tool_config(card), do: tool_config(active_tool_name(card))
+
+  # --- Formatting helpers ---
+
+  defp format_role(role) when is_atom(role) or is_binary(role) do
+    role |> to_string() |> String.replace("_", " ") |> String.capitalize()
+  end
+
+  defp format_role(_), do: "-"
+
+  defp format_content(nil), do: ""
+
+  defp format_content(content) when is_binary(content),
+    do: content |> String.trim() |> String.slice(0, 500)
+
+  defp format_content(_), do: ""
+end

--- a/lib/loomkin_web/live/agent_comms_component.ex
+++ b/lib/loomkin_web/live/agent_comms_component.ex
@@ -1,0 +1,208 @@
+defmodule LoomkinWeb.AgentCommsComponent do
+  @moduledoc """
+  Functional component that renders the inter-agent communication feed.
+
+  Renders the "social layer" of mission control — messages, discoveries,
+  decisions, task lifecycle, escalations, and other inter-agent comms
+  as compact, color-coded rows.
+  """
+
+  use Phoenix.Component
+
+  alias LoomkinWeb.AgentColors
+
+  @type_config %{
+    message: %{
+      icon: "✉",
+      accent_border: "rgba(52, 211, 153, 0.30)",
+      accent_text: "#6ee7b7",
+      accent_bg: "rgba(52, 211, 153, 0.08)"
+    },
+    discovery: %{
+      icon: "⭐",
+      accent_border: "rgba(251, 191, 36, 0.30)",
+      accent_text: "#fcd34d",
+      accent_bg: "rgba(251, 191, 36, 0.08)"
+    },
+    decision: %{
+      icon: "🧠",
+      accent_border: "rgba(167, 139, 250, 0.35)",
+      accent_text: "#c4b5fd",
+      accent_bg: "rgba(167, 139, 250, 0.10)"
+    },
+    task_created: %{
+      icon: "✚",
+      accent_border: "rgba(34, 211, 238, 0.30)",
+      accent_text: "#67e8f9",
+      accent_bg: "rgba(34, 211, 238, 0.08)"
+    },
+    task_assigned: %{
+      icon: "➤",
+      accent_border: "rgba(96, 165, 250, 0.30)",
+      accent_text: "#93bbfd",
+      accent_bg: "rgba(96, 165, 250, 0.08)"
+    },
+    task_complete: %{
+      icon: "✔",
+      accent_border: "rgba(74, 222, 128, 0.30)",
+      accent_text: "#86efac",
+      accent_bg: "rgba(74, 222, 128, 0.08)"
+    },
+    error: %{
+      icon: "⚠",
+      accent_border: "rgba(248, 113, 113, 0.35)",
+      accent_text: "#fca5a5",
+      accent_bg: "rgba(248, 113, 113, 0.10)"
+    },
+    agent_spawn: %{
+      icon: "✳",
+      accent_border: "rgba(45, 212, 191, 0.25)",
+      accent_text: "#5eead4",
+      accent_bg: "rgba(45, 212, 191, 0.06)"
+    },
+    question: %{
+      icon: "❔",
+      accent_border: "rgba(56, 189, 248, 0.35)",
+      accent_text: "#7dd3fc",
+      accent_bg: "rgba(56, 189, 248, 0.10)"
+    },
+    answer: %{
+      icon: "❕",
+      accent_border: "rgba(56, 189, 248, 0.25)",
+      accent_text: "#7dd3fc",
+      accent_bg: "rgba(56, 189, 248, 0.08)"
+    },
+    tasks_unblocked: %{
+      icon: "🔓",
+      accent_border: "rgba(74, 222, 128, 0.25)",
+      accent_text: "#86efac",
+      accent_bg: "rgba(74, 222, 128, 0.06)"
+    },
+    role_changed: %{
+      icon: "🔄",
+      accent_border: "rgba(129, 140, 248, 0.25)",
+      accent_text: "#a5b4fc",
+      accent_bg: "rgba(129, 140, 248, 0.08)"
+    },
+    escalation: %{
+      icon: "📈",
+      accent_border: "rgba(251, 146, 60, 0.25)",
+      accent_text: "#fdba74",
+      accent_bg: "rgba(251, 146, 60, 0.08)"
+    },
+    collab_event: %{
+      icon: "🤝",
+      accent_border: "rgba(167, 139, 250, 0.25)",
+      accent_text: "#c4b5fd",
+      accent_bg: "rgba(167, 139, 250, 0.08)"
+    },
+    channel_message: %{
+      icon: "💬",
+      accent_border: "rgba(34, 211, 238, 0.25)",
+      accent_text: "#67e8f9",
+      accent_bg: "rgba(34, 211, 238, 0.08)"
+    }
+  }
+
+  @default_config %{
+    icon: "●",
+    accent_border: "rgba(113, 113, 122, 0.20)",
+    accent_text: "#a1a1aa",
+    accent_bg: "rgba(113, 113, 122, 0.06)"
+  }
+
+  @max_visible 100
+
+  attr :events, :list, required: true
+  attr :id, :string, default: "agent-comms"
+
+  def comms_feed(assigns) do
+    visible = Enum.take(assigns.events, -@max_visible)
+    assigns = assign(assigns, :visible_events, visible)
+
+    ~H"""
+    <div id={@id} class="flex flex-col h-full">
+      <%!-- Section header --%>
+      <div class="px-3 py-2 flex items-center gap-2">
+        <span class="text-[10px] font-semibold text-muted uppercase tracking-widest">
+          Team Comms
+        </span>
+        <span class="badge text-[10px] tabular-nums">{length(@events)}</span>
+      </div>
+
+      <%!-- Scrollable feed --%>
+      <div id="comms-feed-scroll" class="flex-1 overflow-y-auto px-2 pb-2 space-y-0.5">
+        <div
+          :if={@visible_events == []}
+          class="flex items-center justify-center py-12 text-muted text-xs"
+        >
+          No inter-agent communication yet
+        </div>
+
+        <.comms_row :for={event <- @visible_events} event={event} />
+      </div>
+    </div>
+    """
+  end
+
+  defp comms_row(assigns) do
+    config = type_config(assigns.event.type)
+    agent_color = AgentColors.agent_color(assigns.event.agent)
+    assigns = assigns |> assign(:config, config) |> assign(:agent_color, agent_color)
+
+    ~H"""
+    <details
+      id={"comms-event-#{@event.id}"}
+      class={[
+        "group flex-col px-2 py-1.5 rounded-md cursor-pointer transition-colors duration-100",
+        "border-l-2"
+      ]}
+      style={"border-left-color: #{@config.accent_border};"}
+    >
+      <summary class="flex items-start gap-2 list-none [&::-webkit-details-marker]:hidden">
+        <%!-- Icon --%>
+        <span
+          class="flex-shrink-0 text-xs leading-5 select-none"
+          style={"color: #{@config.accent_text};"}
+        >
+          {@config.icon}
+        </span>
+
+        <%!-- Body --%>
+        <div class="flex-1 min-w-0 flex items-baseline gap-1.5">
+          <button
+            class="text-xs font-semibold hover:underline flex-shrink-0"
+            style={"color: #{@agent_color};"}
+            phx-click="focus_card_agent"
+            phx-value-agent={@event.agent}
+            type="button"
+          >
+            {@event.agent}
+          </button>
+          <span class="text-xs text-zinc-400 leading-5 truncate">
+            {@event.content}
+          </span>
+        </div>
+
+        <%!-- Timestamp --%>
+        <span class="flex-shrink-0 text-[10px] tabular-nums text-zinc-500 leading-5">
+          {format_timestamp(@event.timestamp)}
+        </span>
+      </summary>
+
+      <%!-- Expanded content --%>
+      <div
+        class="mt-1 ml-5 text-xs text-zinc-300 whitespace-pre-wrap rounded px-2 py-1.5"
+        style={"background: #{@config.accent_bg};"}
+      >
+        {@event.content}
+      </div>
+    </details>
+    """
+  end
+
+  defp type_config(type), do: Map.get(@type_config, type, @default_config)
+
+  defp format_timestamp(%DateTime{} = dt), do: Calendar.strftime(dt, "%H:%M:%S")
+  defp format_timestamp(_), do: ""
+end

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -40,7 +40,9 @@ defmodule LoomkinWeb.WorkspaceLive do
         current_step: nil,
         activity_events: [],
         activity_known_agents: [],
-        # Mission control assigns
+        # Mission control assigns — agent cards + comms
+        agent_cards: %{},
+        comms_events: [],
         roster_version: 0,
         mode: :mission_control,
         focused_agent: nil,
@@ -706,6 +708,33 @@ defmodule LoomkinWeb.WorkspaceLive do
     end
   end
 
+  # --- Agent Card action buttons — forward to existing info handlers to avoid duplication ---
+
+  def handle_event("focus_card_agent", %{"agent" => agent_name}, socket) do
+    send(self(), {:focus_agent, agent_name})
+    {:noreply, socket}
+  end
+
+  def handle_event("reply_to_card_agent", %{"agent" => agent_name, "team-id" => team_id}, socket) do
+    send(self(), {:reply_to_agent, agent_name, team_id})
+    {:noreply, socket}
+  end
+
+  def handle_event("pause_card_agent", %{"agent" => agent_name, "team-id" => team_id}, socket) do
+    send(self(), {:pause_agent, agent_name, team_id})
+    {:noreply, socket}
+  end
+
+  def handle_event("resume_card_agent", %{"agent" => agent_name, "team-id" => team_id}, socket) do
+    send(self(), {:resume_agent, agent_name, team_id})
+    {:noreply, socket}
+  end
+
+  def handle_event("steer_card_agent", %{"agent" => agent_name, "team-id" => team_id}, socket) do
+    send(self(), {:steer_agent, agent_name, team_id})
+    {:noreply, socket}
+  end
+
   # --- Component Info Messages ---
 
   def handle_info({:reply_to_agent, agent_name}, socket) do
@@ -749,7 +778,13 @@ defmodule LoomkinWeb.WorkspaceLive do
           metadata: %{from: agent_name, role: :assistant}
         }
 
-        append_activity_event(socket, event)
+        socket
+        |> append_activity_event(event)
+        |> update_agent_card(agent_name, %{
+          content_type: :message,
+          latest_content: msg.content,
+          updated_at: DateTime.utc_now()
+        })
       else
         socket
       end
@@ -779,6 +814,7 @@ defmodule LoomkinWeb.WorkspaceLive do
     socket =
       socket
       |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
       |> maybe_auto_follow(source, %{tool_name: name, path: target})
       |> assign(current_tool: display, current_tool_name: name)
 
@@ -791,6 +827,7 @@ defmodule LoomkinWeb.WorkspaceLive do
     socket =
       socket
       |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
       |> maybe_auto_follow(source, %{tool_name: name})
       |> assign(current_tool: name, current_tool_name: name)
 
@@ -806,6 +843,7 @@ defmodule LoomkinWeb.WorkspaceLive do
     socket =
       socket
       |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
       |> assign(current_tool: nil)
 
     {:noreply, socket}
@@ -1057,46 +1095,94 @@ defmodule LoomkinWeb.WorkspaceLive do
       socket
       |> update(:roster_version, &((&1 || 0) + 1))
       |> refresh_roster()
+      |> sync_cards_with_roster()
+      |> update_card_status(agent_name, status)
+      |> forward_to_cards_and_comms(event)
 
     {:noreply, forward_to_activity(socket, event)}
   end
 
   def handle_info({:task_created, _task_id, _title} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, socket |> refresh_roster() |> forward_to_activity(event)}
+
+    {:noreply,
+     socket |> refresh_roster() |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
-  def handle_info({:task_assigned, _task_id, _agent_name} = event, socket) do
+  def handle_info({:task_assigned, task_id, agent_name} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, socket |> refresh_roster() |> forward_to_activity(event)}
+
+    # Look up task title from cached_tasks
+    task_title =
+      Enum.find_value(socket.assigns.cached_tasks, "Assigned task", fn t ->
+        if t.id == task_id, do: t.title
+      end)
+
+    socket =
+      socket
+      |> refresh_roster()
+      |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
+      |> update_card_task(agent_name, task_title)
+
+    {:noreply, socket}
   end
 
-  def handle_info({:task_completed, _task_id, _agent_name, _result} = event, socket) do
+  def handle_info({:task_completed, _task_id, agent_name, _result} = event, socket) do
     forward_to_dashboard(socket)
     forward_to_cost(socket)
-    {:noreply, forward_to_activity(socket, event)}
+
+    socket =
+      socket
+      |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
+      |> update_card_task(agent_name, nil)
+
+    {:noreply, socket}
   end
 
-  def handle_info({:task_started, _task_id, _owner} = event, socket) do
+  def handle_info({:task_started, _task_id, owner} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, forward_to_activity(socket, event)}
+
+    socket =
+      socket
+      |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
+      |> update_card_status(owner, :working)
+
+    {:noreply, socket}
   end
 
-  def handle_info({:task_failed, _task_id, _owner, _reason} = event, socket) do
+  def handle_info({:task_failed, _task_id, owner, _reason} = event, socket) do
     forward_to_dashboard(socket)
-    {:noreply, forward_to_activity(socket, event)}
+
+    socket =
+      socket
+      |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
+      |> update_card_status(owner, :error)
+
+    {:noreply, socket}
   end
 
-  def handle_info({:role_changed, _agent_name, _old, _new} = event, socket) do
+  def handle_info({:role_changed, agent_name, _old, new_role} = event, socket) do
     forward_to_dashboard(socket)
-    socket = update(socket, :roster_version, &((&1 || 0) + 1))
-    {:noreply, forward_to_activity(socket, event)}
+
+    socket =
+      socket
+      |> update(:roster_version, &((&1 || 0) + 1))
+      |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
+      |> update_agent_card(agent_name, %{role: new_role})
+
+    {:noreply, socket}
   end
 
   def handle_info({:agent_escalation, _agent_name, _old, _new} = event, socket) do
     forward_to_dashboard(socket)
     forward_to_cost(socket)
-    {:noreply, forward_to_activity(socket, event)}
+
+    {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
   def handle_info({:usage, _agent_name, _payload}, socket) do
@@ -1105,14 +1191,28 @@ defmodule LoomkinWeb.WorkspaceLive do
   end
 
   # Agent error events (max iterations exceeded, tool failures, etc.)
-  def handle_info({:agent_error, _agent_name, _payload} = event, socket) do
-    {:noreply, forward_to_activity(socket, event)}
+  def handle_info({:agent_error, agent_name, _payload} = event, socket) do
+    socket =
+      socket
+      |> forward_to_activity(event)
+      |> forward_to_cards_and_comms(event)
+      |> update_card_status(agent_name, :error)
+
+    {:noreply, socket}
   end
 
-  # Agent streaming events — show thoughts live in activity feed
+  # Agent streaming events — show thoughts live in activity feed + agent cards
   def handle_info({:agent_stream_start, agent_name, _payload}, socket) do
-    # Start accumulating this agent's thoughts
-    {:noreply, assign(socket, streaming_agent: agent_name, streaming_thoughts: "")}
+    socket =
+      socket
+      |> assign(streaming_agent: agent_name, streaming_thoughts: "")
+      |> update_agent_card(agent_name, %{
+        content_type: :thinking,
+        latest_content: "",
+        updated_at: DateTime.utc_now()
+      })
+
+    {:noreply, socket}
   end
 
   def handle_info({:agent_stream_delta, agent_name, payload}, socket) do
@@ -1154,7 +1254,17 @@ defmodule LoomkinWeb.WorkspaceLive do
           ]
       end
 
-    {:noreply, assign(socket, activity_events: events, streaming_thoughts: updated)}
+    # Also update the agent card with streaming content
+    socket =
+      socket
+      |> assign(activity_events: events, streaming_thoughts: updated)
+      |> update_agent_card(agent_name, %{
+        latest_content: updated,
+        content_type: :thinking,
+        updated_at: DateTime.utc_now()
+      })
+
+    {:noreply, socket}
   end
 
   def handle_info({:agent_stream_end, agent_name, _payload}, socket) do
@@ -1163,8 +1273,15 @@ defmodule LoomkinWeb.WorkspaceLive do
     thinking_id = "thinking-#{agent_name}"
     events = Enum.reject(socket.assigns.activity_events, &(&1.id == thinking_id))
 
-    {:noreply,
-     assign(socket, activity_events: events, streaming_agent: nil, streaming_thoughts: "")}
+    socket =
+      socket
+      |> assign(activity_events: events, streaming_agent: nil, streaming_thoughts: "")
+      |> update_agent_card(agent_name, %{
+        content_type: :idle,
+        updated_at: DateTime.utc_now()
+      })
+
+    {:noreply, socket}
   end
 
   def handle_info({:child_team_created, child_team_id}, socket) do
@@ -1295,17 +1412,17 @@ defmodule LoomkinWeb.WorkspaceLive do
     end
   end
 
-  # Team decision and context events — buffer for activity feed
+  # Team decision and context events — buffer for activity feed + comms
   def handle_info({:decision_logged, _node_id, _agent_name} = event, socket) do
-    {:noreply, forward_to_activity(socket, event)}
+    {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
   def handle_info({:context_update, _from_agent, _payload} = event, socket) do
-    {:noreply, forward_to_activity(socket, event)}
+    {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
   def handle_info({:context_offloaded, _agent_name, _payload} = event, socket) do
-    {:noreply, forward_to_activity(socket, event)}
+    {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
   # Messages from AgentRosterComponent
@@ -1379,11 +1496,11 @@ defmodule LoomkinWeb.WorkspaceLive do
 
   # New event types for activity feed
   def handle_info({:keeper_created, _payload} = event, socket) do
-    {:noreply, forward_to_activity(socket, event)}
+    {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
   def handle_info({:tasks_unblocked, _task_ids} = event, socket) do
-    {:noreply, forward_to_activity(socket, event)}
+    {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
   # --- Ask User questions from agents ---
@@ -1405,12 +1522,33 @@ defmodule LoomkinWeb.WorkspaceLive do
       socket
       |> assign(pending_questions: questions)
       |> append_activity_event(event)
+      |> update_agent_card(question.agent_name, %{
+        pending_question: %{
+          question_id: question.question_id,
+          question: question.question,
+          options: question.options,
+          agent_name: question.agent_name
+        }
+      })
 
     {:noreply, socket}
   end
 
   def handle_info({:ask_user_answered, question_id, answer}, socket) do
     remaining = Enum.reject(socket.assigns.pending_questions, &(&1.question_id == question_id))
+
+    # Clear pending_question from the agent's card
+    agent_name =
+      Enum.find_value(socket.assigns.pending_questions, fn q ->
+        if q.question_id == question_id, do: q.agent_name
+      end)
+
+    socket =
+      if agent_name do
+        update_agent_card(socket, agent_name, %{pending_question: nil})
+      else
+        socket
+      end
 
     event = %{
       id: Ecto.UUID.generate(),
@@ -1471,7 +1609,9 @@ defmodule LoomkinWeb.WorkspaceLive do
         socket
       end
 
-    {:noreply, forward_to_activity(socket, {:collab_event, payload})}
+    event = {:collab_event, payload}
+
+    {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
   # OAuth auth status changed — refresh model selector to reflect new provider availability
@@ -1763,58 +1903,44 @@ defmodule LoomkinWeb.WorkspaceLive do
   # --- Mission Control Mode (three-panel layout) ---
 
   defp render_mode(:mission_control, assigns) do
-    ~H"""
-    <%!-- Left: Agent Roster (xl:w-64) --%>
-    <.live_component
-      module={LoomkinWeb.AgentRosterComponent}
-      id="agent-roster"
-      team_id={@active_team_id}
-      agents={@cached_agents}
-      tasks={@cached_tasks}
-      budget={@cached_budget}
-      focused_agent={@focused_agent}
-      roster_version={@roster_version}
-      channel_bindings={@channel_bindings}
-    />
+    sorted_cards =
+      assigns.agent_cards
+      |> Enum.sort_by(fn {_, c} -> c.updated_at end, DateTime)
+      |> Enum.map(fn {_name, card} -> card end)
 
-    <%!-- Center: Activity Feed (flex-1) + Composer --%>
+    assigns = assign(assigns, :sorted_cards, sorted_cards)
+
+    ~H"""
+    <%!-- Left: Agent Cards + Comms + Composer (flex-1) --%>
     <div
       class="flex-1 flex flex-col min-w-0 min-h-0 bg-surface-0"
-      style="border-left: 1px solid var(--border-subtle); border-right: 1px solid var(--border-subtle);"
+      style="border-right: 1px solid var(--border-subtle);"
     >
-      <%!-- Scrollable feed area --%>
-      <div class="flex-1 overflow-auto min-h-0">
-        <.live_component
-          module={LoomkinWeb.TeamActivityComponent}
-          id="activity-feed"
-          team_id={@active_team_id}
-          events={filter_high_signal_events(@activity_events)}
-          known_agents={@activity_known_agents}
-          focused_agent={@focused_agent}
-        />
+      <%!-- Agent Cards Grid --%>
+      <div class="flex-shrink-0 p-3 pb-0">
+        <div :if={@sorted_cards == []} class="text-center py-8">
+          <div class="text-muted text-xs">Waiting for agents to spawn...</div>
+        </div>
+        <div class={["grid gap-3", card_grid_cols(length(@sorted_cards))]}>
+          <LoomkinWeb.AgentCardComponent.agent_card
+            :for={card <- @sorted_cards}
+            card={card}
+            focused={@focused_agent == card.name}
+            team_id={@active_team_id}
+          />
+        </div>
       </div>
 
-      <%!-- Pending ask_user questions --%>
+      <%!-- Comms Feed (scrollable, takes remaining space) --%>
       <div
-        :if={@pending_questions != []}
-        class="flex-shrink-0 px-3 py-2"
-        style="border-top: 1px solid var(--border-brand); background: var(--surface-1);"
+        class="flex-1 overflow-auto min-h-0"
+        style="border-top: 1px solid var(--border-subtle);"
       >
-        <.live_component
-          module={LoomkinWeb.AskUserComponent}
-          id="ask-user-questions"
-          questions={@pending_questions}
-        />
+        <LoomkinWeb.AgentCommsComponent.comms_feed events={@comms_events} id="agent-comms" />
       </div>
 
-      <%!-- Collapsible tool calls feed --%>
-      <div class="flex-shrink-0">
-        <.live_component
-          module={LoomkinWeb.ToolCallsComponent}
-          id="tool-calls-feed"
-          events={@activity_events}
-        />
-      </div>
+      <%!-- Budget bar --%>
+      {render_budget_bar(assigns)}
 
       <%!-- Sticky composer --%>
       {render_input_bar(assigns)}
@@ -1846,6 +1972,61 @@ defmodule LoomkinWeb.WorkspaceLive do
     />
     """
   end
+
+  defp card_grid_cols(n) when n <= 1, do: "grid-cols-1"
+  defp card_grid_cols(n) when n <= 4, do: "grid-cols-2"
+  defp card_grid_cols(_), do: "grid-cols-3"
+
+  defp render_budget_bar(assigns) do
+    budget = assigns[:cached_budget] || %{spent: 0.0, limit: 5.0}
+    assigns = assign(assigns, :budget, budget)
+
+    ~H"""
+    <div
+      class="flex-shrink-0 px-4 py-2 flex items-center gap-3"
+      style="border-top: 1px solid var(--border-subtle); background: var(--surface-1);"
+    >
+      <span class="text-[10px] font-semibold text-muted uppercase tracking-widest flex-shrink-0">
+        Budget
+      </span>
+      <div class="flex-1 rounded-full h-1.5 overflow-hidden" style="background: var(--surface-3);">
+        <div
+          class={["h-full rounded-full", budget_bar_color(@budget)]}
+          style={"width: #{min(budget_pct(@budget), 100)}%; transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);"}
+        >
+        </div>
+      </div>
+      <span
+        class="text-[11px] font-mono tabular-nums flex-shrink-0"
+        style="color: var(--text-secondary);"
+      >
+        ${format_decimal_cost(@budget.spent)}
+        <span class="text-muted">/ ${format_decimal_cost(@budget.limit)}</span>
+      </span>
+    </div>
+    """
+  end
+
+  defp budget_pct(%{spent: spent, limit: limit}) when limit > 0,
+    do: round(spent / limit * 100)
+
+  defp budget_pct(_), do: 0
+
+  defp budget_bar_color(%{spent: spent, limit: limit}) when limit > 0 do
+    pct = spent / limit * 100
+
+    cond do
+      pct >= 90 -> "bg-red-500"
+      pct >= 70 -> "bg-amber-500"
+      true -> "bg-emerald-500"
+    end
+  end
+
+  defp budget_bar_color(_), do: "bg-emerald-500"
+
+  defp format_decimal_cost(n) when is_float(n), do: :erlang.float_to_binary(n, decimals: 2)
+  defp format_decimal_cost(n) when is_integer(n), do: "#{n}.00"
+  defp format_decimal_cost(_), do: "0.00"
 
   # --- Shared input bar (used by both modes) ---
 
@@ -2853,12 +3034,170 @@ defmodule LoomkinWeb.WorkspaceLive do
 
   defp activity_event_from(_), do: nil
 
-  # Filter out low-signal events from the primary activity feed.
-  # Tool calls and context offloads go to the collapsible ToolCallsComponent instead.
-  @low_signal_event_types [:tool_call, :context_offload, :status]
+  # --- Agent Cards + Comms routing (mission control v2) ---
 
-  defp filter_high_signal_events(events) do
-    Enum.reject(events, fn event -> event.type in @low_signal_event_types end)
+  # Event types that belong in the inter-agent comms feed
+  @comms_event_types [
+    :message,
+    :discovery,
+    :decision,
+    :agent_spawn,
+    :question,
+    :answer,
+    :tasks_unblocked,
+    :role_changed,
+    :escalation,
+    :channel_message,
+    :task_created,
+    :task_assigned,
+    :task_complete,
+    :error
+  ]
+
+  @max_comms_events 200
+
+  defp forward_to_cards_and_comms(socket, pubsub_event) do
+    case activity_event_from(pubsub_event) do
+      nil -> socket
+      :merge_tool_result -> update_card_tool_result(socket, pubsub_event)
+      :maybe_agent_spawn -> maybe_spawn_card(socket, pubsub_event)
+      event -> route_event_to_cards_or_comms(socket, event)
+    end
+  end
+
+  defp route_event_to_cards_or_comms(socket, event) do
+    socket =
+      if event.type in @comms_event_types do
+        comms = socket.assigns.comms_events ++ [event]
+        comms = if length(comms) > @max_comms_events, do: tl(comms), else: comms
+        assign(socket, comms_events: comms)
+      else
+        socket
+      end
+
+    # Tool calls and status updates go to agent cards
+    case event.type do
+      :tool_call ->
+        update_agent_card(socket, event.agent, %{
+          content_type: :tool_call,
+          last_tool: %{
+            name: (event.metadata || %{})[:tool_name] || "tool",
+            target: (event.metadata || %{})[:file_path]
+          },
+          latest_content: event.content,
+          updated_at: event.timestamp
+        })
+
+      _ ->
+        socket
+    end
+  end
+
+  defp maybe_spawn_card(socket, {:agent_status, agent, :idle}) do
+    cards = socket.assigns.agent_cards
+
+    if Map.has_key?(cards, agent) do
+      socket
+    else
+      card = default_agent_card(agent, socket)
+
+      comms_event = %{
+        id: Ecto.UUID.generate(),
+        type: :agent_spawn,
+        agent: agent,
+        content: "#{agent} joined",
+        timestamp: DateTime.utc_now(),
+        expanded: false,
+        metadata: %{}
+      }
+
+      comms = socket.assigns.comms_events ++ [comms_event]
+
+      assign(socket, agent_cards: Map.put(cards, agent, card), comms_events: comms)
+    end
+  end
+
+  defp update_card_tool_result(socket, {:tool_complete, agent, %{result: result} = payload}) do
+    result_str = String.slice(to_string(result), 0, 200)
+    tool_name = payload[:tool_name]
+
+    update_agent_card(socket, agent, %{
+      last_tool: %{name: tool_name || "tool", target: nil, result: result_str},
+      updated_at: DateTime.utc_now()
+    })
+  end
+
+  defp update_card_tool_result(socket, _), do: socket
+
+  defp update_agent_card(socket, agent_name, updates) when is_binary(agent_name) do
+    cards = socket.assigns.agent_cards
+    card = Map.get(cards, agent_name, default_agent_card(agent_name, socket))
+    card = Map.merge(card, updates)
+    assign(socket, agent_cards: Map.put(cards, agent_name, card))
+  end
+
+  defp update_agent_card(socket, _, _), do: socket
+
+  defp update_card_status(socket, agent_name, status) do
+    update_agent_card(socket, agent_name, %{
+      status: status,
+      updated_at: DateTime.utc_now()
+    })
+  end
+
+  defp update_card_task(socket, agent_name, task_desc) do
+    update_agent_card(socket, agent_name, %{
+      current_task: task_desc,
+      updated_at: DateTime.utc_now()
+    })
+  end
+
+  defp default_agent_card(agent_name, socket) do
+    # Try to find role from cached_agents
+    role =
+      Enum.find_value(socket.assigns.cached_agents, :agent, fn a ->
+        if a.name == agent_name, do: a.role
+      end)
+
+    team_id =
+      Enum.find_value(socket.assigns.cached_agents, socket.assigns[:active_team_id], fn a ->
+        if a.name == agent_name, do: a.team_id
+      end)
+
+    %{
+      name: agent_name,
+      role: role,
+      team_id: team_id,
+      status: :idle,
+      current_task: nil,
+      latest_content: nil,
+      content_type: :idle,
+      last_tool: nil,
+      pending_question: nil,
+      updated_at: DateTime.utc_now()
+    }
+  end
+
+  # Sync agent cards with roster data (status, role, task, team_id)
+  defp sync_cards_with_roster(socket) do
+    agents = socket.assigns.cached_agents
+    cards = socket.assigns.agent_cards
+
+    updated_cards =
+      Enum.reduce(agents, cards, fn agent, acc ->
+        card = Map.get(acc, agent.name, default_agent_card(agent.name, socket))
+
+        card =
+          card
+          |> Map.put(:status, agent.status)
+          |> Map.put(:role, agent.role)
+          |> Map.put(:team_id, agent.team_id)
+          |> Map.put(:current_task, Map.get(agent, :current_task) || card.current_task)
+
+        Map.put(acc, agent.name, card)
+      end)
+
+    assign(socket, agent_cards: updated_cards)
   end
 
   # --- Human-readable tool descriptions ---


### PR DESCRIPTION
## Summary

- **Agent Cards**: One fixed card per agent that updates in-place showing current thinking, tool calls, status, action buttons (pause/resume/steer/reply), and pending `ask_user` questions inline
- **Comms Feed**: Dedicated inter-agent communication feed (messages, discoveries, decisions, task lifecycle, alerts) with expand-on-click via native `<details>` elements
- **Removed from mission control**: Left sidebar (AgentRosterComponent), top filter controls, separate ToolCallsComponent and AskUserComponent — all folded into the new layout
- Budget bar moved inline between comms feed and composer; context inspector (right panel) preserved

### New files
- `agent_card_component.ex` — functional component, responsive grid (1/2/3 cols based on agent count)
- `agent_comms_component.ex` — functional component with 15 typed event categories

### Data flow
- New assigns: `agent_cards` (per-agent state map) + `comms_events` (inter-agent messages list)
- `forward_to_cards_and_comms/2` routes PubSub events alongside existing `forward_to_activity`
- Streaming thoughts write to per-agent card `latest_content` (supports multi-agent streaming)
- Card action buttons forward to existing info handlers (zero duplication)

## Test plan
- [x] `mix compile` — clean, zero warnings
- [x] `mix test test/loomkin_web/` — 70 tests, 0 failures
- [ ] Manual: verify agent cards render and update in real-time
- [ ] Manual: verify comms feed shows inter-agent messages
- [ ] Manual: verify card action buttons (pause/resume/steer/reply) work
- [ ] Manual: verify ask_user questions appear inline on agent cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)