### PR TITLE
Add 6 decision graph upgrades: health, pivots, writeup, git linking, merge, sync

### DIFF
--- a/lib/loomkin/decisions/diff.ex
+++ b/lib/loomkin/decisions/diff.ex
@@ -1,0 +1,243 @@
+defmodule Loomkin.Decisions.Diff do
+  @moduledoc "Export and apply decision graph patches using change_id for idempotent merging."
+
+  import Ecto.Query
+
+  alias Loomkin.Repo
+  alias Loomkin.Schemas.DecisionEdge
+  alias Loomkin.Schemas.DecisionNode
+
+  @patch_version "1.0"
+
+  @doc """
+  Export a subset of the decision graph as a JSON-serializable patch.
+
+  Options:
+    * `:team_id` - filter nodes by team_id in metadata
+    * `:session_id` - filter nodes by session_id
+    * `:node_ids` - explicit list of node IDs to export
+    * `:author` - author name for the patch
+    * `:branch` - branch label for the patch
+  """
+  def export_patch(opts \\ []) do
+    nodes = query_nodes(opts)
+    node_ids = MapSet.new(nodes, & &1.id)
+
+    edges =
+      query_edges_for_nodes(node_ids)
+      |> Enum.filter(fn edge ->
+        MapSet.member?(node_ids, edge.from_node_id) and
+          MapSet.member?(node_ids, edge.to_node_id)
+      end)
+
+    # Build change_id lookup for edges
+    change_id_by_id = Map.new(nodes, fn n -> {n.id, n.change_id} end)
+
+    patch = %{
+      "version" => @patch_version,
+      "author" => Keyword.get(opts, :author),
+      "branch" => Keyword.get(opts, :branch),
+      "created_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "nodes" => Enum.map(nodes, &serialize_node/1),
+      "edges" =>
+        Enum.map(edges, fn edge ->
+          serialize_edge(edge, change_id_by_id)
+        end)
+    }
+
+    {:ok, patch}
+  end
+
+  @doc """
+  Apply a patch idempotently. Nodes with existing change_ids are skipped.
+
+  Options:
+    * `:dry_run` - if true, report counts without inserting (default: false)
+  """
+  def apply_patch(patch, opts \\ []) do
+    case validate_patch(patch) do
+      :ok -> do_apply(patch, opts)
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  Validate patch structure. Checks that all edge references point to nodes in the patch.
+  """
+  def validate_patch(%{"version" => "1.0", "nodes" => nodes, "edges" => edges})
+      when is_list(nodes) and is_list(edges) do
+    node_change_ids = MapSet.new(nodes, fn n -> n["change_id"] end)
+
+    missing =
+      Enum.flat_map(edges, fn edge ->
+        from = edge["from_change_id"]
+        to = edge["to_change_id"]
+
+        missing_from = if MapSet.member?(node_change_ids, from), do: [], else: [from]
+        missing_to = if MapSet.member?(node_change_ids, to), do: [], else: [to]
+        missing_from ++ missing_to
+      end)
+      |> Enum.uniq()
+
+    if missing == [] do
+      :ok
+    else
+      {:error, {:dangling_edge_references, missing}}
+    end
+  end
+
+  def validate_patch(_), do: {:error, :invalid_patch_format}
+
+  # --- Private ---
+
+  defp query_nodes(opts) do
+    query = from(n in DecisionNode)
+
+    query =
+      case Keyword.get(opts, :node_ids) do
+        nil -> query
+        ids -> where(query, [n], n.id in ^ids)
+      end
+
+    query =
+      case Keyword.get(opts, :session_id) do
+        nil -> query
+        sid -> where(query, [n], n.session_id == ^sid)
+      end
+
+    query =
+      case Keyword.get(opts, :team_id) do
+        nil -> query
+        tid -> where(query, [n], fragment("? ->> 'team_id' = ?", n.metadata, ^tid))
+      end
+
+    Repo.all(query)
+  end
+
+  defp query_edges_for_nodes(node_ids) do
+    ids = MapSet.to_list(node_ids)
+
+    from(e in DecisionEdge, where: e.from_node_id in ^ids or e.to_node_id in ^ids)
+    |> Repo.all()
+  end
+
+  defp serialize_node(node) do
+    %{
+      "change_id" => node.change_id,
+      "node_type" => to_string(node.node_type),
+      "title" => node.title,
+      "description" => node.description,
+      "status" => to_string(node.status),
+      "confidence" => node.confidence,
+      "metadata" => node.metadata,
+      "agent_name" => node.agent_name,
+      "created_at" => node.inserted_at && DateTime.to_iso8601(node.inserted_at)
+    }
+  end
+
+  defp serialize_edge(edge, change_id_by_id) do
+    %{
+      "from_change_id" => Map.fetch!(change_id_by_id, edge.from_node_id),
+      "to_change_id" => Map.fetch!(change_id_by_id, edge.to_node_id),
+      "edge_type" => to_string(edge.edge_type),
+      "rationale" => edge.rationale
+    }
+  end
+
+  defp do_apply(patch, opts) do
+    dry_run = Keyword.get(opts, :dry_run, false)
+
+    Repo.transaction(fn ->
+      # Process nodes
+      {nodes_added, nodes_skipped, change_id_to_db_id} =
+        Enum.reduce(patch["nodes"], {0, 0, %{}}, fn node_data, {added, skipped, mapping} ->
+          change_id = node_data["change_id"]
+
+          case find_node_by_change_id(change_id) do
+            nil ->
+              if dry_run do
+                {added + 1, skipped, Map.put(mapping, change_id, :dry_run)}
+              else
+                case insert_node_from_patch(node_data) do
+                  {:ok, node} ->
+                    {added + 1, skipped, Map.put(mapping, change_id, node.id)}
+
+                  {:error, reason} ->
+                    Repo.rollback(reason)
+                end
+              end
+
+            existing ->
+              {added, skipped + 1, Map.put(mapping, change_id, existing.id)}
+          end
+        end)
+
+      # Process edges
+      {edges_added, edges_skipped} =
+        Enum.reduce(patch["edges"], {0, 0}, fn edge_data, {added, skipped} ->
+          from_id = Map.get(change_id_to_db_id, edge_data["from_change_id"])
+          to_id = Map.get(change_id_to_db_id, edge_data["to_change_id"])
+          edge_type = String.to_existing_atom(edge_data["edge_type"])
+
+          cond do
+            is_nil(from_id) or is_nil(to_id) ->
+              {added, skipped + 1}
+
+            dry_run ->
+              {added + 1, skipped}
+
+            edge_exists?(from_id, to_id, edge_type) ->
+              {added, skipped + 1}
+
+            true ->
+              case Loomkin.Decisions.Graph.add_edge(from_id, to_id, edge_type,
+                     rationale: edge_data["rationale"]
+                   ) do
+                {:ok, _} -> {added + 1, skipped}
+                {:error, reason} -> Repo.rollback(reason)
+              end
+          end
+        end)
+
+      %{
+        nodes_added: nodes_added,
+        nodes_skipped: nodes_skipped,
+        edges_added: edges_added,
+        edges_skipped: edges_skipped
+      }
+    end)
+  end
+
+  defp find_node_by_change_id(change_id) do
+    from(n in DecisionNode, where: n.change_id == ^change_id, limit: 1)
+    |> Repo.one()
+  end
+
+  defp insert_node_from_patch(data) do
+    attrs = %{
+      change_id: data["change_id"],
+      node_type: String.to_existing_atom(data["node_type"]),
+      title: data["title"],
+      description: data["description"],
+      status: String.to_existing_atom(data["status"] || "active"),
+      confidence: data["confidence"],
+      metadata: data["metadata"] || %{},
+      agent_name: data["agent_name"]
+    }
+
+    %DecisionNode{}
+    |> DecisionNode.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  defp edge_exists?(from_id, to_id, edge_type) do
+    from(e in DecisionEdge,
+      where:
+        e.from_node_id == ^from_id and
+          e.to_node_id == ^to_id and
+          e.edge_type == ^edge_type,
+      limit: 1
+    )
+    |> Repo.exists?()
+  end
+end

--- a/lib/loomkin/decisions/git_linker.ex
+++ b/lib/loomkin/decisions/git_linker.ex
@@ -1,0 +1,173 @@
+defmodule Loomkin.Decisions.GitLinker do
+  @moduledoc "Links decision graph nodes to git commits."
+
+  import Ecto.Query
+  alias Loomkin.Repo
+  alias Loomkin.Decisions.Graph
+  alias Loomkin.Schemas.DecisionNode
+
+  @all_edge_types [
+    :leads_to,
+    :chosen,
+    :rejected,
+    :requires,
+    :blocks,
+    :enables,
+    :supersedes,
+    :supports,
+    :revises,
+    :summarizes
+  ]
+
+  @doc "Find nodes with metadata.commit matching the given hash."
+  def nodes_for_commit(commit_hash) when is_binary(commit_hash) do
+    DecisionNode
+    |> where([n], fragment("? ->> 'commit' = ?", n.metadata, ^commit_hash))
+    |> Repo.all()
+  end
+
+  @doc "Walk downstream from a node, collecting commit hashes from metadata."
+  def commits_for_node(node_id) when is_binary(node_id) do
+    root = Graph.get_node(node_id)
+    downstream = Graph.walk_downstream(node_id, @all_edge_types, max_depth: 10)
+    downstream_nodes = Enum.map(downstream, fn {node, _depth, _type} -> node end)
+
+    all_nodes = if root, do: [root | downstream_nodes], else: downstream_nodes
+
+    all_nodes
+    |> Enum.map(fn node -> get_in(node.metadata, ["commit"]) end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Export all commits referenced in the graph with linked node IDs.
+
+  Options:
+    - :project_path - path to git repo (required for git log enrichment)
+  """
+  def export_history(opts \\ []) do
+    project_path = Keyword.get(opts, :project_path)
+
+    nodes_with_commits =
+      DecisionNode
+      |> where([n], fragment("? ->> 'commit' IS NOT NULL", n.metadata))
+      |> Repo.all()
+
+    commits_to_nodes =
+      nodes_with_commits
+      |> Enum.group_by(fn n -> n.metadata["commit"] end)
+      |> Enum.map(fn {commit_hash, nodes} ->
+        node_ids = Enum.map(nodes, & &1.id)
+        git_info = if project_path, do: git_log_info(commit_hash, project_path), else: %{}
+        Map.merge(%{commit: commit_hash, node_ids: node_ids}, git_info)
+      end)
+
+    {:ok, commits_to_nodes}
+  end
+
+  @doc """
+  Auto-link unlinked action/outcome nodes to recent commits by keyword overlap.
+
+  Options:
+    - :project_path - path to git repo (required)
+    - :limit - number of recent commits to check (default 50)
+    - :min_overlap - minimum matching words (default 3)
+  """
+  def auto_link(opts \\ []) do
+    project_path = Keyword.fetch!(opts, :project_path)
+    limit = Keyword.get(opts, :limit, 50)
+    min_overlap = Keyword.get(opts, :min_overlap, 3)
+
+    unlinked_nodes =
+      DecisionNode
+      |> where([n], n.node_type in [:action, :outcome])
+      |> where([n], n.status == :active)
+      |> where([n], fragment("? ->> 'commit' IS NULL", n.metadata))
+      |> Repo.all()
+
+    recent_commits = recent_git_log(project_path, limit)
+
+    linked =
+      Enum.reduce(unlinked_nodes, [], fn node, acc ->
+        case best_commit_match(node, recent_commits, min_overlap) do
+          nil ->
+            acc
+
+          {commit_hash, _score} ->
+            metadata = Map.put(node.metadata, "commit", commit_hash)
+            {:ok, _updated} = Graph.update_node(node, %{metadata: metadata})
+            [{node.id, commit_hash} | acc]
+        end
+      end)
+
+    {:ok, Enum.reverse(linked)}
+  end
+
+  defp git_log_info(commit_hash, project_path) do
+    format = "%an%n%aI%n%s"
+
+    case System.cmd("git", ["log", "-1", "--format=#{format}", commit_hash],
+           cd: project_path,
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        lines = String.split(output, "\n", trim: true)
+
+        case lines do
+          [author, date, message | _] ->
+            %{author: author, date: date, message: message}
+
+          _ ->
+            %{}
+        end
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp recent_git_log(project_path, limit) do
+    format = "%H%n%s"
+
+    case System.cmd("git", ["log", "-#{limit}", "--format=#{format}"],
+           cd: project_path,
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        output
+        |> String.split("\n", trim: true)
+        |> Enum.chunk_every(2)
+        |> Enum.flat_map(fn
+          [hash, message] -> [%{hash: hash, message: message}]
+          _ -> []
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  defp best_commit_match(node, commits, min_overlap) do
+    node_words = extract_words(node.title)
+
+    commits
+    |> Enum.map(fn %{hash: hash, message: message} ->
+      commit_words = extract_words(message)
+      overlap = MapSet.intersection(node_words, commit_words) |> MapSet.size()
+      {hash, overlap}
+    end)
+    |> Enum.filter(fn {_hash, overlap} -> overlap >= min_overlap end)
+    |> Enum.max_by(fn {_hash, overlap} -> overlap end, fn -> nil end)
+  end
+
+  defp extract_words(text) when is_binary(text) do
+    text
+    |> String.downcase()
+    |> String.split(~r/[^a-z0-9]+/, trim: true)
+    |> Enum.reject(&(String.length(&1) < 3))
+    |> MapSet.new()
+  end
+
+  defp extract_words(_), do: MapSet.new()
+end

--- a/lib/loomkin/decisions/graph.ex
+++ b/lib/loomkin/decisions/graph.ex
@@ -79,6 +79,12 @@ defmodule Loomkin.Decisions.Graph do
     |> apply_node_filters(rest)
   end
 
+  defp apply_node_filters(query, [{:branch, branch} | rest]) do
+    query
+    |> where([n], fragment("? ->> 'branch' = ?", n.metadata, ^branch))
+    |> apply_node_filters(rest)
+  end
+
   defp apply_node_filters(query, [{:cross_session, true} | rest]) do
     apply_node_filters(query, rest)
   end
@@ -168,6 +174,195 @@ defmodule Loomkin.Decisions.Graph do
         {:error, reason} ->
           Repo.rollback(reason)
       end
+    end)
+  end
+
+  # --- Pivot Chains ---
+
+  @doc """
+  Creates an atomic pivot chain: old_node -> observation -> revisit -> new_decision.
+  Supersedes the old node and broadcasts {:pivot_created, ...}.
+  """
+  def create_pivot_chain(old_node_id, observation_title, new_approach_title, opts \\ []) do
+    Repo.transaction(fn ->
+      old_node = get_node(old_node_id)
+
+      if is_nil(old_node), do: Repo.rollback(:old_node_not_found)
+      if old_node.status != :active, do: Repo.rollback(:old_node_not_active)
+
+      base_metadata =
+        Map.take(old_node.metadata || %{}, ["team_id", "keeper_id"])
+        |> Map.put("agent_name", old_node.agent_name || Keyword.get(opts, :agent_name))
+        |> Map.merge(Keyword.get(opts, :metadata, %{}))
+
+      base_attrs = %{
+        status: :active,
+        session_id: old_node.session_id,
+        agent_name: Keyword.get(opts, :agent_name, old_node.agent_name),
+        metadata: base_metadata
+      }
+
+      {:ok, observation} =
+        base_attrs
+        |> Map.merge(%{node_type: :observation, title: observation_title})
+        |> add_node()
+        |> rollback_on_error()
+
+      {:ok, revisit} =
+        base_attrs
+        |> Map.merge(%{node_type: :revisit, title: "Reconsidering: #{old_node.title}"})
+        |> add_node()
+        |> rollback_on_error()
+
+      {:ok, decision} =
+        base_attrs
+        |> Map.merge(%{
+          node_type: :decision,
+          title: new_approach_title,
+          confidence: Keyword.get(opts, :confidence)
+        })
+        |> add_node()
+        |> rollback_on_error()
+
+      add_edge(old_node_id, observation.id, :leads_to) |> rollback_on_error()
+      add_edge(observation.id, revisit.id, :leads_to) |> rollback_on_error()
+      add_edge(revisit.id, decision.id, :leads_to) |> rollback_on_error()
+
+      add_edge(old_node_id, decision.id, :supersedes,
+        rationale: "Pivoted via: #{observation_title}"
+      )
+      |> rollback_on_error()
+
+      update_node(old_node, %{status: :superseded}) |> rollback_on_error()
+
+      result = %{
+        old_node: old_node,
+        observation: observation,
+        revisit: revisit,
+        decision: decision
+      }
+
+      Phoenix.PubSub.broadcast(Loomkin.PubSub, "decision_graph", {:pivot_created, result})
+
+      result
+    end)
+  end
+
+  defp rollback_on_error({:ok, _} = ok), do: ok
+  defp rollback_on_error({:error, reason}), do: Repo.rollback(reason)
+
+  # --- Subtree Merging ---
+
+  @all_edge_types ~w(leads_to chosen rejected requires blocks enables supersedes supports revises summarizes)a
+
+  @doc """
+  Merge (copy) a subtree rooted at `source_root_id` under `target_parent_id`.
+
+  Options:
+    * `:supersede_source` - mark source nodes as superseded (default: false)
+    * `:edge_type` - edge type from target parent to copied root (default: :leads_to)
+    * `:prefix_titles` - string prefix for copied node titles (default: nil)
+    * `:metadata_merge` - map to merge into all copied node metadata (default: %{})
+
+  Returns `{:ok, %{merged_count: N, root_id: new_root_id, id_mapping: %{old => new}}}`.
+  """
+  def merge_subtree(source_root_id, target_parent_id, opts \\ []) do
+    edge_type = Keyword.get(opts, :edge_type, :leads_to)
+    supersede_source = Keyword.get(opts, :supersede_source, false)
+    prefix = Keyword.get(opts, :prefix_titles)
+    metadata_merge = Keyword.get(opts, :metadata_merge, %{})
+
+    Repo.transaction(fn ->
+      source_root = get_node(source_root_id)
+
+      if is_nil(source_root), do: Repo.rollback(:source_not_found)
+      if is_nil(get_node(target_parent_id)), do: Repo.rollback(:target_not_found)
+
+      # Collect all downstream nodes (source root + descendants)
+      downstream = walk_downstream(source_root_id, @all_edge_types, max_depth: 100)
+      all_nodes = [source_root | Enum.map(downstream, fn {node, _d, _e} -> node end)]
+      node_ids = MapSet.new(all_nodes, & &1.id)
+
+      # Build ID mapping: old_id -> new_id
+      id_mapping =
+        Map.new(all_nodes, fn node -> {node.id, Ecto.UUID.generate()} end)
+
+      # Copy nodes
+      for node <- all_nodes do
+        new_id = Map.fetch!(id_mapping, node.id)
+        title = if prefix, do: "#{prefix}#{node.title}", else: node.title
+        merged_meta = Map.merge(node.metadata || %{}, metadata_merge)
+
+        attrs = %{
+          node_type: node.node_type,
+          title: title,
+          description: node.description,
+          status: node.status,
+          confidence: node.confidence,
+          metadata: merged_meta,
+          agent_name: node.agent_name,
+          session_id: node.session_id,
+          change_id: Ecto.UUID.generate()
+        }
+
+        case %DecisionNode{id: new_id}
+             |> DecisionNode.changeset(attrs)
+             |> Repo.insert() do
+          {:ok, _} -> :ok
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end
+
+      # Collect edges where both endpoints are in the subtree
+      all_edges =
+        Enum.flat_map(all_nodes, fn node ->
+          list_edges(from_node_id: node.id)
+        end)
+
+      internal_edges =
+        Enum.filter(all_edges, fn edge ->
+          MapSet.member?(node_ids, edge.from_node_id) and
+            MapSet.member?(node_ids, edge.to_node_id)
+        end)
+        |> Enum.uniq_by(& &1.id)
+
+      # Recreate internal edges with mapped IDs
+      for edge <- internal_edges do
+        new_from = Map.fetch!(id_mapping, edge.from_node_id)
+        new_to = Map.fetch!(id_mapping, edge.to_node_id)
+
+        case add_edge(new_from, new_to, edge.edge_type,
+               rationale: edge.rationale,
+               weight: edge.weight
+             ) do
+          {:ok, _} -> :ok
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end
+
+      # Link target parent to copied root
+      new_root_id = Map.fetch!(id_mapping, source_root_id)
+
+      case add_edge(target_parent_id, new_root_id, edge_type) do
+        {:ok, _} -> :ok
+        {:error, reason} -> Repo.rollback(reason)
+      end
+
+      # Optionally supersede source nodes
+      if supersede_source do
+        for node <- all_nodes do
+          case update_node(node, %{status: :superseded}) do
+            {:ok, _} -> :ok
+            {:error, reason} -> Repo.rollback(reason)
+          end
+        end
+      end
+
+      %{
+        merged_count: length(all_nodes),
+        root_id: new_root_id,
+        id_mapping: id_mapping
+      }
     end)
   end
 

--- a/lib/loomkin/decisions/pulse.ex
+++ b/lib/loomkin/decisions/pulse.ex
@@ -19,6 +19,7 @@ defmodule Loomkin.Decisions.Pulse do
     coverage_gaps = find_coverage_gaps(active_goals)
     low_confidence = find_low_confidence(confidence_threshold)
     stale_nodes = find_stale_nodes(stale_days)
+    health_score = compute_health(opts)
 
     %{
       active_goals: active_goals,
@@ -26,9 +27,85 @@ defmodule Loomkin.Decisions.Pulse do
       coverage_gaps: coverage_gaps,
       low_confidence: low_confidence,
       stale_nodes: stale_nodes,
+      health_score: health_score,
       summary:
         build_summary(active_goals, recent_decisions, coverage_gaps, low_confidence, stale_nodes)
     }
+  end
+
+  @doc "Computes a 0-100 health score for the decision graph."
+  def compute_health(opts \\ []) do
+    team_id = Keyword.get(opts, :team_id)
+
+    active_nodes = list_active_nodes(team_id)
+    all_edges = list_all_edges(team_id, active_nodes)
+
+    gap_count = count_coverage_gaps(active_nodes, all_edges)
+    orphan_count = count_orphans(active_nodes, all_edges)
+    low_confidence_count = count_low_confidence(active_nodes)
+
+    100 - min(gap_count * 10, 50) - min(orphan_count * 5, 30) - min(low_confidence_count * 3, 20)
+  end
+
+  defp list_active_nodes(nil) do
+    DecisionNode
+    |> where([n], n.status == :active)
+    |> Repo.all()
+  end
+
+  defp list_active_nodes(team_id) do
+    DecisionNode
+    |> where([n], n.status == :active)
+    |> where([n], fragment("? ->> 'team_id' = ?", n.metadata, ^team_id))
+    |> Repo.all()
+  end
+
+  defp list_all_edges(nil, _nodes), do: Repo.all(DecisionEdge)
+
+  defp list_all_edges(_team_id, active_nodes) do
+    node_ids = Enum.map(active_nodes, & &1.id)
+
+    DecisionEdge
+    |> where([e], e.from_node_id in ^node_ids or e.to_node_id in ^node_ids)
+    |> Repo.all()
+  end
+
+  defp count_coverage_gaps(active_nodes, all_edges) do
+    gap_types = [:goal, :decision]
+
+    active_nodes
+    |> Enum.filter(&(&1.node_type in gap_types))
+    |> Enum.count(fn node ->
+      outgoing_target_ids =
+        all_edges
+        |> Enum.filter(&(&1.from_node_id == node.id))
+        |> Enum.map(& &1.to_node_id)
+        |> MapSet.new()
+
+      connected_types =
+        active_nodes
+        |> Enum.filter(&MapSet.member?(outgoing_target_ids, &1.id))
+        |> Enum.map(& &1.node_type)
+
+      not Enum.any?(connected_types, &(&1 in [:action, :outcome]))
+    end)
+  end
+
+  defp count_orphans(active_nodes, all_edges) do
+    edge_node_ids =
+      all_edges
+      |> Enum.flat_map(&[&1.from_node_id, &1.to_node_id])
+      |> MapSet.new()
+
+    active_nodes
+    |> Enum.reject(&(&1.node_type == :goal))
+    |> Enum.count(&(not MapSet.member?(edge_node_ids, &1.id)))
+  end
+
+  defp count_low_confidence(active_nodes) do
+    Enum.count(active_nodes, fn node ->
+      node.confidence != nil and node.confidence < @default_confidence_threshold
+    end)
   end
 
   defp find_coverage_gaps(goals) do

--- a/lib/loomkin/decisions/writeup.ex
+++ b/lib/loomkin/decisions/writeup.ex
@@ -1,0 +1,232 @@
+defmodule Loomkin.Decisions.Writeup do
+  @moduledoc "Generates PR writeup Markdown from the decision graph."
+
+  alias Loomkin.Decisions.Graph
+
+  @all_edge_types [
+    :leads_to,
+    :chosen,
+    :rejected,
+    :requires,
+    :blocks,
+    :enables,
+    :supersedes,
+    :supports,
+    :revises,
+    :summarizes
+  ]
+
+  @doc """
+  Generate a PR writeup from the decision graph.
+
+  Options:
+    - :title - PR title (default "Pull Request")
+    - :team_id - scope to a team
+    - :session_id - scope to a session
+    - :root_ids - BFS from specific root nodes
+    - :include_test_plan - include test plan section (default true)
+  """
+  def generate(opts \\ []) do
+    title = Keyword.get(opts, :title, "Pull Request")
+    include_test_plan = Keyword.get(opts, :include_test_plan, true)
+
+    nodes = collect_nodes(opts)
+    edges = collect_edges(nodes)
+    grouped = Enum.group_by(nodes, & &1.node_type)
+
+    sections =
+      [
+        "# #{title}\n",
+        summary_section(grouped),
+        decisions_section(grouped, edges),
+        implementation_section(grouped),
+        results_section(grouped),
+        prior_attempts_section(nodes),
+        if(include_test_plan, do: test_plan_section(), else: nil)
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("\n")
+
+    {:ok, sections}
+  end
+
+  defp collect_nodes(opts) do
+    root_ids = Keyword.get(opts, :root_ids)
+    team_id = Keyword.get(opts, :team_id)
+    session_id = Keyword.get(opts, :session_id)
+
+    cond do
+      root_ids && root_ids != [] ->
+        root_ids
+        |> Enum.flat_map(fn root_id ->
+          root_node = Graph.get_node(root_id)
+          downstream = Graph.walk_downstream(root_id, @all_edge_types, max_depth: 10)
+          downstream_nodes = Enum.map(downstream, fn {node, _depth, _type} -> node end)
+          if root_node, do: [root_node | downstream_nodes], else: downstream_nodes
+        end)
+        |> Enum.uniq_by(& &1.id)
+
+      team_id ->
+        Graph.list_nodes(team_id: team_id)
+
+      session_id ->
+        Graph.list_nodes(session_id: session_id)
+
+      true ->
+        Graph.list_nodes(status: :active)
+    end
+  end
+
+  defp collect_edges(nodes) do
+    node_ids = MapSet.new(nodes, & &1.id)
+
+    nodes
+    |> Enum.flat_map(fn node ->
+      Graph.list_edges(from_node_id: node.id)
+    end)
+    |> Enum.filter(fn edge ->
+      MapSet.member?(node_ids, edge.from_node_id) and
+        MapSet.member?(node_ids, edge.to_node_id)
+    end)
+    |> Enum.uniq_by(& &1.id)
+  end
+
+  defp summary_section(grouped) do
+    goals = Map.get(grouped, :goal, [])
+    observations = Map.get(grouped, :observation, [])
+
+    if goals == [] and observations == [] do
+      nil
+    else
+      lines = ["## Summary\n"]
+
+      lines =
+        if goals != [] do
+          goal_lines =
+            Enum.map(goals, fn g ->
+              if g.description, do: "- **#{g.title}**: #{g.description}", else: "- **#{g.title}**"
+            end)
+
+          lines ++ goal_lines
+        else
+          lines
+        end
+
+      lines =
+        if observations != [] do
+          obs_lines =
+            Enum.map(observations, fn o ->
+              if o.description, do: "- #{o.title}: #{o.description}", else: "- #{o.title}"
+            end)
+
+          lines ++ ["\n### Observations\n"] ++ obs_lines
+        else
+          lines
+        end
+
+      Enum.join(lines, "\n") <> "\n"
+    end
+  end
+
+  defp decisions_section(grouped, edges) do
+    decisions = Map.get(grouped, :decision, [])
+
+    if decisions == [] do
+      nil
+    else
+      edges_by_from = Enum.group_by(edges, & &1.from_node_id)
+      all_nodes_by_id = build_node_index(grouped)
+
+      decision_blocks =
+        Enum.map(decisions, fn decision ->
+          outgoing = Map.get(edges_by_from, decision.id, [])
+
+          option_lines =
+            outgoing
+            |> Enum.filter(fn e -> e.edge_type in [:chosen, :rejected, :leads_to] end)
+            |> Enum.map(fn edge ->
+              option_node = Map.get(all_nodes_by_id, edge.to_node_id)
+              option_title = if option_node, do: option_node.title, else: edge.to_node_id
+
+              case edge.edge_type do
+                :chosen -> "  - [x] #{option_title}"
+                :rejected -> "  - [ ] #{option_title}"
+                :leads_to -> "  - #{option_title}"
+              end
+            end)
+
+          header = "### #{decision.title}"
+          desc = if decision.description, do: "\n#{decision.description}\n", else: ""
+          options = if option_lines != [], do: "\n" <> Enum.join(option_lines, "\n"), else: ""
+          header <> desc <> options
+        end)
+
+      "## Key Decisions\n\n" <> Enum.join(decision_blocks, "\n\n") <> "\n"
+    end
+  end
+
+  defp implementation_section(grouped) do
+    actions = Map.get(grouped, :action, [])
+
+    if actions == [] do
+      nil
+    else
+      lines =
+        Enum.map(actions, fn a ->
+          if a.description, do: "- **#{a.title}**: #{a.description}", else: "- #{a.title}"
+        end)
+
+      "## Implementation\n\n" <> Enum.join(lines, "\n") <> "\n"
+    end
+  end
+
+  defp results_section(grouped) do
+    outcomes = Map.get(grouped, :outcome, [])
+
+    if outcomes == [] do
+      nil
+    else
+      lines =
+        Enum.map(outcomes, fn o ->
+          if o.description, do: "- **#{o.title}**: #{o.description}", else: "- #{o.title}"
+        end)
+
+      "## Results\n\n" <> Enum.join(lines, "\n") <> "\n"
+    end
+  end
+
+  defp prior_attempts_section(nodes) do
+    prior =
+      Enum.filter(nodes, fn n -> n.status in [:superseded, :abandoned] end)
+
+    if prior == [] do
+      nil
+    else
+      lines =
+        Enum.map(prior, fn n ->
+          status_label = if n.status == :superseded, do: "superseded", else: "abandoned"
+          "- ~~#{n.title}~~ (#{status_label})"
+        end)
+
+      "## Prior Attempts\n\n" <> Enum.join(lines, "\n") <> "\n"
+    end
+  end
+
+  defp test_plan_section do
+    """
+    ## Test Plan
+
+    - [ ] Unit tests pass
+    - [ ] Integration tests pass
+    - [ ] Manual verification complete
+    - [ ] Edge cases covered
+    """
+  end
+
+  defp build_node_index(grouped) do
+    grouped
+    |> Map.values()
+    |> List.flatten()
+    |> Map.new(fn n -> {n.id, n} end)
+  end
+end

--- a/lib/loomkin/tools/decision_query.ex
+++ b/lib/loomkin/tools/decision_query.ex
@@ -36,7 +36,7 @@ defmodule Loomkin.Tools.DecisionQuery do
 
       "pulse" ->
         report = Pulse.generate()
-        {:ok, %{result: report.summary}}
+        {:ok, %{result: "#{report.summary} Health: #{report.health_score}/100."}}
 
       "search" ->
         search_term = param(params, :search_term, "")

--- a/lib/loomkin/tools/generate_writeup.ex
+++ b/lib/loomkin/tools/generate_writeup.ex
@@ -1,0 +1,48 @@
+defmodule Loomkin.Tools.GenerateWriteup do
+  @moduledoc "Agent tool to generate a PR writeup from the decision graph."
+
+  use Jido.Action,
+    name: "generate_writeup",
+    description:
+      "Generate a PR writeup from the decision graph. Returns Markdown text summarizing goals, decisions, implementation, and results.",
+    schema: [
+      title: [type: :string, doc: "PR title"],
+      root_id: [type: :string, doc: "Root node ID to generate from (traverses children)"]
+    ]
+
+  import Loomkin.Tool, only: [param: 2]
+
+  alias Loomkin.Decisions.Writeup
+
+  @impl true
+  def run(params, context) do
+    opts = []
+
+    opts =
+      case param(params, :title) do
+        nil -> opts
+        title -> Keyword.put(opts, :title, title)
+      end
+
+    opts =
+      case param(params, :root_id) do
+        nil -> opts
+        root_id -> Keyword.put(opts, :root_ids, [root_id])
+      end
+
+    opts =
+      case param(context, :team_id) do
+        nil -> opts
+        team_id -> Keyword.put(opts, :team_id, team_id)
+      end
+
+    opts =
+      case param(context, :session_id) do
+        nil -> opts
+        session_id -> Keyword.put(opts, :session_id, session_id)
+      end
+
+    {:ok, markdown} = Writeup.generate(opts)
+    {:ok, %{result: markdown}}
+  end
+end

--- a/lib/loomkin/tools/merge_graph.ex
+++ b/lib/loomkin/tools/merge_graph.ex
@@ -1,0 +1,45 @@
+defmodule Loomkin.Tools.MergeGraph do
+  @moduledoc "Tool for merging a decision subtree into another part of the graph."
+
+  use Jido.Action,
+    name: "merge_graph",
+    description:
+      "Merge a decision subtree into another part of the graph. Use after speculative work succeeds to consolidate results.",
+    schema: [
+      source_root_id: [type: :string, required: true, doc: "Root of the subtree to merge"],
+      target_parent_id: [type: :string, required: true, doc: "Node to merge under"],
+      supersede_source: [
+        type: :boolean,
+        doc: "Mark source nodes as superseded (default: false)"
+      ]
+    ]
+
+  import Loomkin.Tool, only: [param!: 2, param: 3]
+
+  alias Loomkin.Decisions.Graph
+
+  @impl true
+  def run(params, _context) do
+    source_root_id = param!(params, :source_root_id)
+    target_parent_id = param!(params, :target_parent_id)
+    supersede_source = param(params, :supersede_source, false)
+
+    case Graph.merge_subtree(source_root_id, target_parent_id, supersede_source: supersede_source) do
+      {:ok, result} ->
+        {:ok,
+         %{
+           result:
+             "Merged #{result.merged_count} nodes under #{target_parent_id}. New root: #{result.root_id}"
+         }}
+
+      {:error, :source_not_found} ->
+        {:error, "Source root node not found: #{source_root_id}"}
+
+      {:error, :target_not_found} ->
+        {:error, "Target parent node not found: #{target_parent_id}"}
+
+      {:error, reason} ->
+        {:error, "Merge failed: #{inspect(reason)}"}
+    end
+  end
+end

--- a/lib/loomkin/tools/pivot_decision.ex
+++ b/lib/loomkin/tools/pivot_decision.ex
@@ -1,0 +1,70 @@
+defmodule Loomkin.Tools.PivotDecision do
+  @moduledoc "Tool for creating a pivot chain in the decision graph."
+
+  use Jido.Action,
+    name: "pivot_decision",
+    description:
+      "Pivot away from an existing decision/goal by creating an observation, revisit, and new approach. " <>
+        "Supersedes the old node atomically.",
+    schema: [
+      old_node_id: [
+        type: :string,
+        required: true,
+        doc: "ID of the active node to pivot away from"
+      ],
+      observation: [
+        type: :string,
+        required: true,
+        doc: "What was observed that triggered the pivot"
+      ],
+      new_approach: [
+        type: :string,
+        required: true,
+        doc: "Title of the new approach/decision"
+      ],
+      confidence: [type: :integer, doc: "Confidence level 0-100 for the new decision"]
+    ]
+
+  import Loomkin.Tool, only: [param!: 2, param: 2]
+
+  alias Loomkin.Decisions.Graph
+
+  @impl true
+  def run(params, context) do
+    old_node_id = param!(params, :old_node_id)
+    observation = param!(params, :observation)
+    new_approach = param!(params, :new_approach)
+
+    opts =
+      [
+        agent_name: param(context, :agent_name),
+        confidence: param(params, :confidence),
+        metadata:
+          %{}
+          |> maybe_put("team_id", param(context, :team_id))
+          |> maybe_put("keeper_id", param(context, :keeper_id))
+      ]
+
+    case Graph.create_pivot_chain(old_node_id, observation, new_approach, opts) do
+      {:ok, result} ->
+        {:ok,
+         %{
+           result:
+             "Pivot created: #{result.old_node.title} -> #{result.observation.title} -> " <>
+               "#{result.revisit.title} -> #{result.decision.title} (id: #{result.decision.id})"
+         }}
+
+      {:error, :old_node_not_found} ->
+        {:error, "Node #{old_node_id} not found"}
+
+      {:error, :old_node_not_active} ->
+        {:error, "Node #{old_node_id} is not active (already superseded or abandoned)"}
+
+      {:error, reason} ->
+        {:error, "Pivot failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/test/loomkin/decisions/diff_test.exs
+++ b/test/loomkin/decisions/diff_test.exs
@@ -1,0 +1,151 @@
+defmodule Loomkin.Decisions.DiffTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.Diff
+  alias Loomkin.Decisions.Graph
+
+  defp node_attrs(overrides \\ %{}) do
+    Map.merge(%{node_type: :goal, title: "Test node"}, overrides)
+  end
+
+  defp build_small_graph do
+    {:ok, root} = Graph.add_node(node_attrs(%{title: "Root", metadata: %{"team_id" => "t1"}}))
+
+    {:ok, child} =
+      Graph.add_node(
+        node_attrs(%{title: "Child", node_type: :decision, metadata: %{"team_id" => "t1"}})
+      )
+
+    {:ok, _edge} = Graph.add_edge(root.id, child.id, :leads_to, rationale: "because")
+    {root, child}
+  end
+
+  describe "export_patch/1" do
+    test "exports nodes and edges as a patch" do
+      {root, child} = build_small_graph()
+
+      assert {:ok, patch} = Diff.export_patch(node_ids: [root.id, child.id])
+
+      assert patch["version"] == "1.0"
+      assert length(patch["nodes"]) == 2
+      assert length(patch["edges"]) == 1
+
+      edge = hd(patch["edges"])
+      node_change_ids = Enum.map(patch["nodes"], & &1["change_id"])
+      assert edge["from_change_id"] in node_change_ids
+      assert edge["to_change_id"] in node_change_ids
+      assert edge["edge_type"] == "leads_to"
+      assert edge["rationale"] == "because"
+    end
+
+    test "exports with team_id filter" do
+      build_small_graph()
+
+      {:ok, _other} =
+        Graph.add_node(node_attrs(%{title: "Other team", metadata: %{"team_id" => "t2"}}))
+
+      assert {:ok, patch} = Diff.export_patch(team_id: "t1")
+      assert length(patch["nodes"]) == 2
+    end
+
+    test "includes author and branch" do
+      assert {:ok, patch} = Diff.export_patch(author: "agent-1", branch: "feature/x")
+      assert patch["author"] == "agent-1"
+      assert patch["branch"] == "feature/x"
+    end
+  end
+
+  describe "validate_patch/1" do
+    test "valid patch passes" do
+      patch = %{
+        "version" => "1.0",
+        "nodes" => [%{"change_id" => "abc"}],
+        "edges" => [%{"from_change_id" => "abc", "to_change_id" => "abc"}]
+      }
+
+      assert :ok = Diff.validate_patch(patch)
+    end
+
+    test "detects dangling edge references" do
+      patch = %{
+        "version" => "1.0",
+        "nodes" => [%{"change_id" => "abc"}],
+        "edges" => [%{"from_change_id" => "abc", "to_change_id" => "missing"}]
+      }
+
+      assert {:error, {:dangling_edge_references, ["missing"]}} = Diff.validate_patch(patch)
+    end
+
+    test "rejects invalid format" do
+      assert {:error, :invalid_patch_format} = Diff.validate_patch(%{})
+      assert {:error, :invalid_patch_format} = Diff.validate_patch("bad")
+    end
+  end
+
+  describe "apply_patch/2" do
+    test "inserts new nodes and edges" do
+      {root, child} = build_small_graph()
+      {:ok, patch} = Diff.export_patch(node_ids: [root.id, child.id])
+
+      # Delete originals so patch creates fresh copies
+      Loomkin.Repo.delete_all(Loomkin.Schemas.DecisionEdge)
+      Loomkin.Repo.delete_all(Loomkin.Schemas.DecisionNode)
+
+      assert {:ok, result} = Diff.apply_patch(patch)
+      assert result.nodes_added == 2
+      assert result.nodes_skipped == 0
+      assert result.edges_added == 1
+      assert result.edges_skipped == 0
+    end
+
+    test "skips existing nodes by change_id (idempotent)" do
+      {root, child} = build_small_graph()
+      {:ok, patch} = Diff.export_patch(node_ids: [root.id, child.id])
+
+      # Apply again without deleting — should skip everything
+      assert {:ok, result} = Diff.apply_patch(patch)
+      assert result.nodes_added == 0
+      assert result.nodes_skipped == 2
+      assert result.edges_added == 0
+      assert result.edges_skipped == 1
+    end
+
+    test "dry_run reports counts without inserting" do
+      {root, child} = build_small_graph()
+      {:ok, patch} = Diff.export_patch(node_ids: [root.id, child.id])
+
+      Loomkin.Repo.delete_all(Loomkin.Schemas.DecisionEdge)
+      Loomkin.Repo.delete_all(Loomkin.Schemas.DecisionNode)
+
+      assert {:ok, result} = Diff.apply_patch(patch, dry_run: true)
+      assert result.nodes_added == 2
+      assert result.edges_added == 1
+
+      # Nothing actually inserted
+      assert Loomkin.Repo.aggregate(Loomkin.Schemas.DecisionNode, :count) == 0
+    end
+
+    test "rejects invalid patch" do
+      assert {:error, :invalid_patch_format} = Diff.apply_patch(%{})
+    end
+  end
+
+  describe "round-trip" do
+    test "export then apply on clean DB reproduces graph" do
+      {root, child} = build_small_graph()
+      {:ok, patch} = Diff.export_patch(node_ids: [root.id, child.id])
+
+      Loomkin.Repo.delete_all(Loomkin.Schemas.DecisionEdge)
+      Loomkin.Repo.delete_all(Loomkin.Schemas.DecisionNode)
+
+      assert {:ok, _} = Diff.apply_patch(patch)
+
+      nodes = Graph.list_nodes()
+      assert length(nodes) == 2
+
+      edges = Graph.list_edges()
+      assert length(edges) == 1
+      assert hd(edges).edge_type == :leads_to
+    end
+  end
+end

--- a/test/loomkin/decisions/git_linker_test.exs
+++ b/test/loomkin/decisions/git_linker_test.exs
@@ -1,0 +1,234 @@
+defmodule Loomkin.Decisions.GitLinkerTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.Graph
+  alias Loomkin.Decisions.GitLinker
+
+  defp node_attrs(overrides) do
+    Map.merge(%{node_type: :goal, title: "Test goal"}, overrides)
+  end
+
+  describe "nodes_for_commit/1" do
+    test "finds nodes tagged with a specific commit hash" do
+      hash = "abc123def456"
+
+      {:ok, _n1} =
+        Graph.add_node(node_attrs(%{title: "Linked node", metadata: %{"commit" => hash}}))
+
+      {:ok, _n2} =
+        Graph.add_node(node_attrs(%{title: "Other node", metadata: %{"commit" => "other"}}))
+
+      {:ok, _n3} = Graph.add_node(node_attrs(%{title: "No commit"}))
+
+      results = GitLinker.nodes_for_commit(hash)
+      assert length(results) == 1
+      assert hd(results).title == "Linked node"
+    end
+
+    test "returns empty list when no nodes match" do
+      assert GitLinker.nodes_for_commit("nonexistent") == []
+    end
+  end
+
+  describe "commits_for_node/1" do
+    test "collects commit hashes from node and descendants" do
+      {:ok, root} =
+        Graph.add_node(node_attrs(%{title: "Root", metadata: %{"commit" => "aaa111"}}))
+
+      {:ok, child} =
+        Graph.add_node(
+          node_attrs(%{node_type: :action, title: "Child", metadata: %{"commit" => "bbb222"}})
+        )
+
+      {:ok, grandchild} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :outcome,
+            title: "Grandchild",
+            metadata: %{"commit" => "ccc333"}
+          })
+        )
+
+      {:ok, _} = Graph.add_edge(root.id, child.id, :leads_to)
+      {:ok, _} = Graph.add_edge(child.id, grandchild.id, :leads_to)
+
+      commits = GitLinker.commits_for_node(root.id)
+      assert "aaa111" in commits
+      assert "bbb222" in commits
+      assert "ccc333" in commits
+      assert length(commits) == 3
+    end
+
+    test "skips nodes without commit metadata" do
+      {:ok, root} =
+        Graph.add_node(node_attrs(%{title: "Root", metadata: %{"commit" => "aaa111"}}))
+
+      {:ok, child} = Graph.add_node(node_attrs(%{node_type: :action, title: "No commit child"}))
+
+      {:ok, _} = Graph.add_edge(root.id, child.id, :leads_to)
+
+      commits = GitLinker.commits_for_node(root.id)
+      assert commits == ["aaa111"]
+    end
+
+    test "deduplicates commit hashes" do
+      hash = "same_hash"
+
+      {:ok, root} =
+        Graph.add_node(node_attrs(%{title: "Root", metadata: %{"commit" => hash}}))
+
+      {:ok, child} =
+        Graph.add_node(
+          node_attrs(%{node_type: :action, title: "Child", metadata: %{"commit" => hash}})
+        )
+
+      {:ok, _} = Graph.add_edge(root.id, child.id, :leads_to)
+
+      commits = GitLinker.commits_for_node(root.id)
+      assert commits == [hash]
+    end
+  end
+
+  describe "export_history/1" do
+    test "groups nodes by commit hash" do
+      hash = "export_hash_1"
+
+      {:ok, n1} =
+        Graph.add_node(
+          node_attrs(%{node_type: :action, title: "Action 1", metadata: %{"commit" => hash}})
+        )
+
+      {:ok, n2} =
+        Graph.add_node(
+          node_attrs(%{node_type: :outcome, title: "Outcome 1", metadata: %{"commit" => hash}})
+        )
+
+      {:ok, result} = GitLinker.export_history()
+
+      assert length(result) == 1
+      entry = hd(result)
+      assert entry.commit == hash
+      assert n1.id in entry.node_ids
+      assert n2.id in entry.node_ids
+    end
+
+    test "returns empty list when no commits in graph" do
+      {:ok, _} = Graph.add_node(node_attrs(%{title: "No commit node"}))
+      {:ok, result} = GitLinker.export_history()
+      assert result == []
+    end
+  end
+
+  describe "auto_link/1" do
+    test "links unlinked action nodes to matching commits" do
+      # Create a temp git repo for testing
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "git_linker_test_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+
+      System.cmd("git", ["init"], cd: tmp_dir)
+      System.cmd("git", ["config", "user.email", "test@test.com"], cd: tmp_dir)
+      System.cmd("git", ["config", "user.name", "Test"], cd: tmp_dir)
+
+      File.write!(Path.join(tmp_dir, "auth.ex"), "defmodule Auth do end")
+      System.cmd("git", ["add", "."], cd: tmp_dir)
+
+      System.cmd("git", ["commit", "-m", "implement token refresh authentication flow"],
+        cd: tmp_dir
+      )
+
+      {hash_output, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: tmp_dir)
+      commit_hash = String.trim(hash_output)
+
+      {:ok, _node} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :action,
+            title: "Implement token refresh authentication flow"
+          })
+        )
+
+      {:ok, linked} = GitLinker.auto_link(project_path: tmp_dir, min_overlap: 3)
+
+      assert length(linked) == 1
+      {_node_id, linked_hash} = hd(linked)
+      assert linked_hash == commit_hash
+
+      File.rm_rf!(tmp_dir)
+    end
+
+    test "does not link nodes below overlap threshold" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "git_linker_test_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+
+      System.cmd("git", ["init"], cd: tmp_dir)
+      System.cmd("git", ["config", "user.email", "test@test.com"], cd: tmp_dir)
+      System.cmd("git", ["config", "user.name", "Test"], cd: tmp_dir)
+
+      File.write!(Path.join(tmp_dir, "readme.md"), "hello")
+      System.cmd("git", ["add", "."], cd: tmp_dir)
+      System.cmd("git", ["commit", "-m", "initial commit"], cd: tmp_dir)
+
+      {:ok, _node} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :action,
+            title: "Completely unrelated quantum physics calculation"
+          })
+        )
+
+      {:ok, linked} = GitLinker.auto_link(project_path: tmp_dir, min_overlap: 3)
+      assert linked == []
+
+      File.rm_rf!(tmp_dir)
+    end
+
+    test "skips already-linked nodes" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "git_linker_test_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+
+      System.cmd("git", ["init"], cd: tmp_dir)
+      System.cmd("git", ["config", "user.email", "test@test.com"], cd: tmp_dir)
+      System.cmd("git", ["config", "user.name", "Test"], cd: tmp_dir)
+
+      File.write!(Path.join(tmp_dir, "auth.ex"), "defmodule Auth do end")
+      System.cmd("git", ["add", "."], cd: tmp_dir)
+      System.cmd("git", ["commit", "-m", "implement token refresh flow"], cd: tmp_dir)
+
+      {:ok, _node} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :action,
+            title: "Implement token refresh flow",
+            metadata: %{"commit" => "already_linked"}
+          })
+        )
+
+      {:ok, linked} = GitLinker.auto_link(project_path: tmp_dir, min_overlap: 3)
+      assert linked == []
+
+      File.rm_rf!(tmp_dir)
+    end
+  end
+
+  describe "Graph.list_nodes/1 branch filter" do
+    test "filters nodes by branch in metadata" do
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{title: "Feature node", metadata: %{"branch" => "feature/auth"}})
+        )
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{title: "Main node", metadata: %{"branch" => "main"}}))
+
+      results = Graph.list_nodes(branch: "feature/auth")
+      assert length(results) == 1
+      assert hd(results).title == "Feature node"
+    end
+  end
+end

--- a/test/loomkin/decisions/graph_merge_test.exs
+++ b/test/loomkin/decisions/graph_merge_test.exs
@@ -1,0 +1,134 @@
+defmodule Loomkin.Decisions.GraphMergeTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.Graph
+
+  defp node_attrs(overrides \\ %{}) do
+    Map.merge(%{node_type: :goal, title: "Test node"}, overrides)
+  end
+
+  defp build_chain do
+    {:ok, root} = Graph.add_node(node_attrs(%{title: "Root"}))
+    {:ok, child1} = Graph.add_node(node_attrs(%{title: "Child 1", node_type: :decision}))
+    {:ok, child2} = Graph.add_node(node_attrs(%{title: "Child 2", node_type: :action}))
+    {:ok, _} = Graph.add_edge(root.id, child1.id, :leads_to)
+    {:ok, _} = Graph.add_edge(child1.id, child2.id, :chosen)
+    {root, child1, child2}
+  end
+
+  describe "merge_subtree/3" do
+    test "copies a single node under target" do
+      {:ok, source} = Graph.add_node(node_attrs(%{title: "Source"}))
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:ok, result} = Graph.merge_subtree(source.id, target.id)
+      assert result.merged_count == 1
+      assert result.root_id != source.id
+
+      copied = Graph.get_node(result.root_id)
+      assert copied.title == "Source"
+    end
+
+    test "copies a chain of nodes preserving edges" do
+      {root, _child1, _child2} = build_chain()
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:ok, result} = Graph.merge_subtree(root.id, target.id)
+      assert result.merged_count == 3
+      assert map_size(result.id_mapping) == 3
+
+      # Verify the copied root is linked to target
+      edges = Graph.list_edges(from_node_id: target.id)
+      assert length(edges) == 1
+      assert hd(edges).to_node_id == result.root_id
+
+      # Verify internal edges were recreated
+      new_root = Graph.get_node(result.root_id)
+      downstream = Graph.walk_downstream(new_root.id, [:leads_to, :chosen], max_depth: 5)
+      assert length(downstream) == 2
+    end
+
+    test "handles diamond paths without duplicates" do
+      {:ok, root} = Graph.add_node(node_attrs(%{title: "Root"}))
+      {:ok, left} = Graph.add_node(node_attrs(%{title: "Left", node_type: :decision}))
+      {:ok, right} = Graph.add_node(node_attrs(%{title: "Right", node_type: :decision}))
+      {:ok, bottom} = Graph.add_node(node_attrs(%{title: "Bottom", node_type: :action}))
+
+      {:ok, _} = Graph.add_edge(root.id, left.id, :leads_to)
+      {:ok, _} = Graph.add_edge(root.id, right.id, :leads_to)
+      {:ok, _} = Graph.add_edge(left.id, bottom.id, :leads_to)
+      {:ok, _} = Graph.add_edge(right.id, bottom.id, :leads_to)
+
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:ok, result} = Graph.merge_subtree(root.id, target.id)
+      # Should have exactly 4 unique nodes (no duplicates)
+      assert result.merged_count == 4
+    end
+
+    test "applies prefix_titles option" do
+      {:ok, source} = Graph.add_node(node_attrs(%{title: "Original"}))
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:ok, result} =
+               Graph.merge_subtree(source.id, target.id, prefix_titles: "[Merged] ")
+
+      copied = Graph.get_node(result.root_id)
+      assert copied.title == "[Merged] Original"
+    end
+
+    test "applies metadata_merge option" do
+      {:ok, source} =
+        Graph.add_node(node_attrs(%{title: "Source", metadata: %{"existing" => "value"}}))
+
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:ok, result} =
+               Graph.merge_subtree(source.id, target.id,
+                 metadata_merge: %{"branch" => "speculative"}
+               )
+
+      copied = Graph.get_node(result.root_id)
+      assert copied.metadata["existing"] == "value"
+      assert copied.metadata["branch"] == "speculative"
+    end
+
+    test "supersede_source marks original nodes as superseded" do
+      {root, child1, child2} = build_chain()
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:ok, _result} =
+               Graph.merge_subtree(root.id, target.id, supersede_source: true)
+
+      assert Graph.get_node(root.id).status == :superseded
+      assert Graph.get_node(child1.id).status == :superseded
+      assert Graph.get_node(child2.id).status == :superseded
+    end
+
+    test "uses custom edge_type for link to target" do
+      {:ok, source} = Graph.add_node(node_attrs(%{title: "Source"}))
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:ok, result} =
+               Graph.merge_subtree(source.id, target.id, edge_type: :supports)
+
+      edges = Graph.list_edges(from_node_id: target.id)
+      assert hd(edges).edge_type == :supports
+      assert hd(edges).to_node_id == result.root_id
+    end
+
+    test "returns error for missing source" do
+      {:ok, target} = Graph.add_node(node_attrs(%{title: "Target"}))
+
+      assert {:error, :source_not_found} =
+               Graph.merge_subtree(Ecto.UUID.generate(), target.id)
+    end
+
+    test "returns error for missing target" do
+      {:ok, source} = Graph.add_node(node_attrs(%{title: "Source"}))
+
+      assert {:error, :target_not_found} =
+               Graph.merge_subtree(source.id, Ecto.UUID.generate())
+    end
+  end
+end

--- a/test/loomkin/decisions/graph_pivot_test.exs
+++ b/test/loomkin/decisions/graph_pivot_test.exs
@@ -1,0 +1,149 @@
+defmodule Loomkin.Decisions.GraphPivotTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.Graph
+
+  defp node_attrs(overrides) do
+    Map.merge(
+      %{node_type: :decision, title: "Original approach", status: :active},
+      overrides
+    )
+  end
+
+  describe "create_pivot_chain/4" do
+    test "creates observation, revisit, and decision nodes" do
+      {:ok, old} = Graph.add_node(node_attrs(%{title: "Use REST API"}))
+
+      assert {:ok, result} =
+               Graph.create_pivot_chain(
+                 old.id,
+                 "REST API has rate limits",
+                 "Switch to GraphQL"
+               )
+
+      assert result.observation.node_type == :observation
+      assert result.observation.title == "REST API has rate limits"
+
+      assert result.revisit.node_type == :revisit
+      assert result.revisit.title == "Reconsidering: Use REST API"
+
+      assert result.decision.node_type == :decision
+      assert result.decision.title == "Switch to GraphQL"
+    end
+
+    test "creates correct edge chain" do
+      {:ok, old} = Graph.add_node(node_attrs(%{title: "Old"}))
+
+      {:ok, result} = Graph.create_pivot_chain(old.id, "Observation", "New approach")
+
+      # old -> observation
+      edges_from_old = Graph.list_edges(from_node_id: old.id)
+      target_ids = Enum.map(edges_from_old, & &1.to_node_id)
+      assert result.observation.id in target_ids
+      assert result.decision.id in target_ids
+
+      # observation -> revisit
+      [obs_edge] = Graph.list_edges(from_node_id: result.observation.id)
+      assert obs_edge.to_node_id == result.revisit.id
+      assert obs_edge.edge_type == :leads_to
+
+      # revisit -> decision
+      [rev_edge] = Graph.list_edges(from_node_id: result.revisit.id)
+      assert rev_edge.to_node_id == result.decision.id
+      assert rev_edge.edge_type == :leads_to
+    end
+
+    test "supersedes the old node" do
+      {:ok, old} = Graph.add_node(node_attrs(%{title: "Old"}))
+
+      {:ok, _result} = Graph.create_pivot_chain(old.id, "Observation", "New")
+
+      updated_old = Graph.get_node(old.id)
+      assert updated_old.status == :superseded
+
+      # Supersedes edge exists
+      supersedes_edges =
+        Graph.list_edges(from_node_id: old.id, edge_type: :supersedes)
+
+      assert length(supersedes_edges) == 1
+    end
+
+    test "propagates metadata from old node" do
+      team_id = Ecto.UUID.generate()
+      keeper_id = Ecto.UUID.generate()
+
+      {:ok, old} =
+        Graph.add_node(
+          node_attrs(%{
+            title: "Old",
+            metadata: %{"team_id" => team_id, "keeper_id" => keeper_id},
+            agent_name: "researcher"
+          })
+        )
+
+      {:ok, result} = Graph.create_pivot_chain(old.id, "Obs", "New")
+
+      for node <- [result.observation, result.revisit, result.decision] do
+        assert node.metadata["team_id"] == team_id
+        assert node.metadata["keeper_id"] == keeper_id
+        assert node.agent_name == "researcher"
+      end
+    end
+
+    test "merges opts metadata with old node metadata" do
+      {:ok, old} =
+        Graph.add_node(node_attrs(%{title: "Old", metadata: %{"team_id" => "t1"}}))
+
+      {:ok, result} =
+        Graph.create_pivot_chain(old.id, "Obs", "New", metadata: %{"extra" => "data"})
+
+      assert result.decision.metadata["team_id"] == "t1"
+      assert result.decision.metadata["extra"] == "data"
+    end
+
+    test "accepts confidence option for new decision" do
+      {:ok, old} = Graph.add_node(node_attrs(%{title: "Old"}))
+
+      {:ok, result} =
+        Graph.create_pivot_chain(old.id, "Obs", "New", confidence: 75)
+
+      assert result.decision.confidence == 75
+    end
+
+    test "returns error for non-existent node" do
+      assert {:error, :old_node_not_found} =
+               Graph.create_pivot_chain(Ecto.UUID.generate(), "Obs", "New")
+    end
+
+    test "returns error for non-active node" do
+      {:ok, old} = Graph.add_node(node_attrs(%{title: "Old", status: :superseded}))
+
+      assert {:error, :old_node_not_active} =
+               Graph.create_pivot_chain(old.id, "Obs", "New")
+    end
+
+    test "broadcasts pivot_created event" do
+      Phoenix.PubSub.subscribe(Loomkin.PubSub, "decision_graph")
+
+      {:ok, old} = Graph.add_node(node_attrs(%{title: "Old"}))
+      {:ok, result} = Graph.create_pivot_chain(old.id, "Obs", "New")
+
+      # Drain node_added messages (4 nodes: old + observation + revisit + decision)
+      for _ <- 1..3 do
+        assert_receive {:node_added, _}
+      end
+
+      assert_receive {:pivot_created, ^result}
+    end
+
+    test "is atomic - all or nothing" do
+      # Using a non-existent old node ensures rollback
+      assert {:error, :old_node_not_found} =
+               Graph.create_pivot_chain(Ecto.UUID.generate(), "Obs", "New")
+
+      # No nodes or edges should have been created
+      assert Graph.list_nodes() == []
+      assert Graph.list_edges() == []
+    end
+  end
+end

--- a/test/loomkin/decisions/pulse_health_test.exs
+++ b/test/loomkin/decisions/pulse_health_test.exs
@@ -1,0 +1,169 @@
+defmodule Loomkin.Decisions.PulseHealthTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.Graph
+  alias Loomkin.Decisions.Pulse
+
+  defp node_attrs(overrides) do
+    Map.merge(%{node_type: :goal, title: "Test goal"}, overrides)
+  end
+
+  describe "compute_health/1" do
+    test "returns 100 for empty graph" do
+      assert Pulse.compute_health() == 100
+    end
+
+    test "penalizes coverage gaps (goals with no action/outcome)" do
+      {:ok, _} = Graph.add_node(node_attrs(%{node_type: :goal, title: "Uncovered goal"}))
+
+      health = Pulse.compute_health()
+      # 1 gap => -10
+      assert health == 90
+    end
+
+    test "penalizes coverage gaps for decisions too" do
+      {:ok, _} = Graph.add_node(node_attrs(%{node_type: :decision, title: "Uncovered decision"}))
+
+      health = Pulse.compute_health()
+      # 1 gap (decision) + 1 orphan (non-goal with no edges) => -10 - 5 = 85
+      assert health == 85
+    end
+
+    test "no gap penalty when goal has action child" do
+      {:ok, goal} = Graph.add_node(node_attrs(%{node_type: :goal, title: "Covered goal"}))
+      {:ok, action} = Graph.add_node(node_attrs(%{node_type: :action, title: "Action"}))
+      {:ok, _} = Graph.add_edge(goal.id, action.id, :leads_to)
+
+      health = Pulse.compute_health()
+      assert health == 100
+    end
+
+    test "penalizes orphan nodes (non-goal active nodes with no edges)" do
+      {:ok, _} = Graph.add_node(node_attrs(%{node_type: :action, title: "Orphan action"}))
+      {:ok, _} = Graph.add_node(node_attrs(%{node_type: :observation, title: "Orphan obs"}))
+
+      health = Pulse.compute_health()
+      # 2 orphans => -10
+      assert health == 90
+    end
+
+    test "goals are not counted as orphans" do
+      {:ok, _} = Graph.add_node(node_attrs(%{node_type: :goal, title: "Lone goal"}))
+
+      health = Pulse.compute_health()
+      # 1 gap (goal with no action/outcome) => -10, but no orphan penalty
+      assert health == 90
+    end
+
+    test "penalizes low confidence nodes" do
+      {:ok, goal} = Graph.add_node(node_attrs(%{node_type: :goal, title: "Goal", confidence: 30}))
+
+      {:ok, action} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Act", confidence: 20}))
+
+      {:ok, _} = Graph.add_edge(goal.id, action.id, :leads_to)
+
+      health = Pulse.compute_health()
+      # 0 gaps (goal has action), 0 orphans (both connected), 2 low conf => -6
+      assert health == 94
+    end
+
+    test "caps gap penalty at 50" do
+      for i <- 1..10 do
+        Graph.add_node(node_attrs(%{node_type: :goal, title: "Gap #{i}"}))
+      end
+
+      health = Pulse.compute_health()
+      # 10 gaps => min(100, 50) = -50
+      assert health == 50
+    end
+
+    test "caps orphan penalty at 30" do
+      for i <- 1..10 do
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Orphan #{i}"}))
+      end
+
+      health = Pulse.compute_health()
+      # 0 gaps, 10 orphans => min(50, 30) = -30
+      assert health == 70
+    end
+
+    test "caps low confidence penalty at 20" do
+      {:ok, goal} = Graph.add_node(node_attrs(%{node_type: :goal, title: "Goal"}))
+
+      for i <- 1..10 do
+        {:ok, action} =
+          Graph.add_node(node_attrs(%{node_type: :action, title: "Low #{i}", confidence: 10}))
+
+        Graph.add_edge(goal.id, action.id, :leads_to)
+      end
+
+      health = Pulse.compute_health()
+      # 0 gaps (goal has action children), 0 orphans, 10 low conf => min(30, 20) = -20
+      assert health == 80
+    end
+
+    test "combined penalties" do
+      # 1 uncovered goal (gap)
+      {:ok, _} = Graph.add_node(node_attrs(%{node_type: :goal, title: "Gap"}))
+      # 1 orphan action with low confidence
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Orphan", confidence: 10}))
+
+      health = Pulse.compute_health()
+      # 1 gap (-10) + 1 orphan (-5) + 1 low conf (-3) = 82
+      assert health == 82
+    end
+
+    test "scopes by team_id" do
+      team_a = Ecto.UUID.generate()
+      team_b = Ecto.UUID.generate()
+
+      # Team A: uncovered goal
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{node_type: :goal, title: "Team A goal", metadata: %{"team_id" => team_a}})
+        )
+
+      # Team B: covered goal
+      {:ok, goal_b} =
+        Graph.add_node(
+          node_attrs(%{node_type: :goal, title: "Team B goal", metadata: %{"team_id" => team_b}})
+        )
+
+      {:ok, action_b} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :action,
+            title: "Team B action",
+            metadata: %{"team_id" => team_b}
+          })
+        )
+
+      {:ok, _} = Graph.add_edge(goal_b.id, action_b.id, :leads_to)
+
+      # Team A has a gap
+      assert Pulse.compute_health(team_id: team_a) == 90
+      # Team B is healthy
+      assert Pulse.compute_health(team_id: team_b) == 100
+    end
+
+    test "health_score is included in generate/1" do
+      report = Pulse.generate()
+      assert Map.has_key?(report, :health_score)
+      assert is_integer(report.health_score)
+      assert report.health_score >= 0 and report.health_score <= 100
+    end
+
+    test "superseded nodes are not counted" do
+      {:ok, _old} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Old", status: :superseded}))
+
+      {:ok, _new} = Graph.add_node(node_attrs(%{node_type: :action, title: "New"}))
+
+      health = Pulse.compute_health()
+      # Only 1 orphan (the new active action), old is superseded and ignored
+      assert health == 95
+    end
+  end
+end

--- a/test/loomkin/decisions/writeup_test.exs
+++ b/test/loomkin/decisions/writeup_test.exs
@@ -1,0 +1,164 @@
+defmodule Loomkin.Decisions.WriteupTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Decisions.Graph
+  alias Loomkin.Decisions.Writeup
+
+  alias Loomkin.Schemas.Session
+
+  defp node_attrs(overrides) do
+    Map.merge(%{node_type: :goal, title: "Test goal"}, overrides)
+  end
+
+  defp create_session do
+    %Session{}
+    |> Session.changeset(%{model: "test-model", project_path: "/tmp/test"})
+    |> Repo.insert!()
+  end
+
+  describe "generate/1" do
+    test "generates writeup with all sections from a graph" do
+      {:ok, goal} =
+        Graph.add_node(node_attrs(%{title: "Fix auth bug", description: "Users can't login"}))
+
+      {:ok, decision} =
+        Graph.add_node(node_attrs(%{node_type: :decision, title: "Token vs Session"}))
+
+      {:ok, option_a} = Graph.add_node(node_attrs(%{node_type: :option, title: "JWT tokens"}))
+
+      {:ok, option_b} =
+        Graph.add_node(node_attrs(%{node_type: :option, title: "Server sessions"}))
+
+      {:ok, action} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Implement JWT refresh"}))
+
+      {:ok, outcome} =
+        Graph.add_node(node_attrs(%{node_type: :outcome, title: "Auth latency reduced by 50%"}))
+
+      {:ok, _} = Graph.add_edge(goal.id, decision.id, :leads_to)
+      {:ok, _} = Graph.add_edge(decision.id, option_a.id, :chosen)
+      {:ok, _} = Graph.add_edge(decision.id, option_b.id, :rejected)
+      {:ok, _} = Graph.add_edge(option_a.id, action.id, :leads_to)
+      {:ok, _} = Graph.add_edge(action.id, outcome.id, :leads_to)
+
+      {:ok, markdown} = Writeup.generate(title: "Fix Auth")
+
+      assert markdown =~ "# Fix Auth"
+      assert markdown =~ "## Summary"
+      assert markdown =~ "Fix auth bug"
+      assert markdown =~ "## Key Decisions"
+      assert markdown =~ "Token vs Session"
+      assert markdown =~ "[x] JWT tokens"
+      assert markdown =~ "[ ] Server sessions"
+      assert markdown =~ "## Implementation"
+      assert markdown =~ "Implement JWT refresh"
+      assert markdown =~ "## Results"
+      assert markdown =~ "Auth latency reduced by 50%"
+      assert markdown =~ "## Test Plan"
+    end
+
+    test "scopes by root_ids using BFS" do
+      {:ok, root} = Graph.add_node(node_attrs(%{title: "Root goal"}))
+      {:ok, child} = Graph.add_node(node_attrs(%{node_type: :action, title: "Child action"}))
+
+      {:ok, _unrelated} =
+        Graph.add_node(node_attrs(%{node_type: :action, title: "Unrelated action"}))
+
+      {:ok, _} = Graph.add_edge(root.id, child.id, :leads_to)
+
+      {:ok, markdown} = Writeup.generate(root_ids: [root.id])
+
+      assert markdown =~ "Root goal"
+      assert markdown =~ "Child action"
+      refute markdown =~ "Unrelated action"
+    end
+
+    test "scopes by team_id" do
+      team_id = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{title: "Team goal", metadata: %{"team_id" => team_id}}))
+
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{title: "Other goal", metadata: %{"team_id" => Ecto.UUID.generate()}})
+        )
+
+      {:ok, markdown} = Writeup.generate(team_id: team_id)
+
+      assert markdown =~ "Team goal"
+      refute markdown =~ "Other goal"
+    end
+
+    test "scopes by session_id" do
+      session1 = create_session()
+      session2 = create_session()
+
+      {:ok, _} = Graph.add_node(node_attrs(%{title: "Session goal", session_id: session1.id}))
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{title: "Other session goal", session_id: session2.id}))
+
+      {:ok, markdown} = Writeup.generate(session_id: session1.id)
+
+      assert markdown =~ "Session goal"
+      refute markdown =~ "Other session goal"
+    end
+
+    test "includes prior attempts for superseded nodes" do
+      {:ok, _old} = Graph.add_node(node_attrs(%{title: "Old approach", status: :superseded}))
+      {:ok, _new} = Graph.add_node(node_attrs(%{title: "New approach"}))
+
+      # Default collects active nodes only, so use root_ids to include superseded
+      {:ok, _} = Graph.add_node(node_attrs(%{title: "Abandoned idea", status: :abandoned}))
+
+      # Use team_id to get all statuses
+      team_id = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{title: "Active goal", metadata: %{"team_id" => team_id}}))
+
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{title: "Old way", status: :superseded, metadata: %{"team_id" => team_id}})
+        )
+
+      {:ok, markdown} = Writeup.generate(team_id: team_id)
+
+      assert markdown =~ "## Prior Attempts"
+      assert markdown =~ "~~Old way~~ (superseded)"
+    end
+
+    test "excludes test plan when include_test_plan is false" do
+      {:ok, _} = Graph.add_node(node_attrs(%{title: "A goal"}))
+
+      {:ok, markdown} = Writeup.generate(include_test_plan: false)
+
+      refute markdown =~ "## Test Plan"
+    end
+
+    test "handles empty graph gracefully" do
+      {:ok, markdown} = Writeup.generate()
+
+      assert markdown =~ "# Pull Request"
+      refute markdown =~ "## Summary"
+      refute markdown =~ "## Key Decisions"
+    end
+
+    test "includes observations in summary" do
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :observation,
+            title: "Memory usage high",
+            description: "Peak at 2GB"
+          })
+        )
+
+      {:ok, markdown} = Writeup.generate()
+
+      assert markdown =~ "Memory usage high"
+      assert markdown =~ "Peak at 2GB"
+    end
+  end
+end

--- a/test/loomkin/teams/agent_checkpoint_test.exs
+++ b/test/loomkin/teams/agent_checkpoint_test.exs
@@ -117,7 +117,12 @@ defmodule Loomkin.Teams.AgentCheckpointTest do
           reason: :user_requested
         }
 
-        %{state | status: :paused, paused_state: paused_state, messages: [%{role: :user, content: "hello"}]}
+        %{
+          state
+          | status: :paused,
+            paused_state: paused_state,
+            messages: [%{role: :user, content: "hello"}]
+        }
       end)
 
       state = :sys.get_state(pid)
@@ -147,7 +152,12 @@ defmodule Loomkin.Teams.AgentCheckpointTest do
           reason: :user_requested
         }
 
-        %{state | status: :paused, paused_state: paused_state, messages: [%{role: :user, content: "original task"}]}
+        %{
+          state
+          | status: :paused,
+            paused_state: paused_state,
+            messages: [%{role: :user, content: "original task"}]
+        }
       end)
 
       result = Agent.steer(pid, "focus on tests instead")
@@ -157,9 +167,10 @@ defmodule Loomkin.Teams.AgentCheckpointTest do
       assert state.status == :working
 
       # Verify guidance was injected into messages
-      guidance_msg = Enum.find(state.messages, fn m ->
-        is_binary(m.content) && String.contains?(m.content, "focus on tests instead")
-      end)
+      guidance_msg =
+        Enum.find(state.messages, fn m ->
+          is_binary(m.content) && String.contains?(m.content, "focus on tests instead")
+        end)
 
       assert guidance_msg != nil
       assert String.contains?(guidance_msg.content, "[User Guidance]")

--- a/test/loomkin/teams/nested_teams_test.exs
+++ b/test/loomkin/teams/nested_teams_test.exs
@@ -147,7 +147,9 @@ defmodule Loomkin.Teams.NestedTeamsTest do
   describe "agent_loop context injection" do
     test "parent_team_id resolves to actual parent for sub-teams" do
       {:ok, parent_id} = Manager.create_team(name: "parent", project_path: "/tmp/test")
-      {:ok, child_id} = Manager.create_sub_team(parent_id, "lead", name: "child", project_path: "/tmp/test")
+
+      {:ok, child_id} =
+        Manager.create_sub_team(parent_id, "lead", name: "child", project_path: "/tmp/test")
 
       parent_team_id =
         case Manager.get_parent_team(child_id) do


### PR DESCRIPTION
## Summary
- **Graph Health Scoring**: Composite 0-100 score in Pulse with gap/orphan/low-confidence penalties, team-scoped
- **Pivot Chains**: Atomic observation→revisit→decision chain with supersession for "we tried X, it failed" patterns
- **PR Writeup Generation**: Markdown PR descriptions auto-generated from decision graph state
- **Git Commit Linking**: Bidirectional commit↔node linking, auto-link by keyword overlap, branch filter
- **Graph Subtree Merging**: Copy subtrees between graph locations preserving internal edges (for speculative execution)
- **Diff/Sync**: JSON patch export/apply with change_id idempotency for multi-instance collaboration

## New Files
- `lib/loomkin/decisions/writeup.ex`, `git_linker.ex`, `diff.ex`
- `lib/loomkin/tools/pivot_decision.ex`, `generate_writeup.ex`, `merge_graph.ex`
- 6 test files covering all new functionality

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] 174 decision graph tests passing, 0 failures
- [x] `mix format` applied
- [ ] Verify health score shows in DecisionQuery pulse results
- [ ] Verify pivot chain creates all 3 nodes + edges atomically
- [ ] Verify writeup generates valid Markdown from graph state

🤖 Generated with [Claude Code](https://claude.com/claude-code)