### PR TITLE
Wire up decision graph end-to-end: PubSub, context injection, agent prompts

### DIFF
--- a/lib/loomkin/decisions/broadcaster.ex
+++ b/lib/loomkin/decisions/broadcaster.ex
@@ -29,6 +29,7 @@ defmodule Loomkin.Decisions.Broadcaster do
     team_id = Keyword.fetch!(opts, :team_id)
 
     Phoenix.PubSub.subscribe(@pubsub, "decision_graph")
+    Phoenix.PubSub.subscribe(@pubsub, "decision_graph:#{team_id}")
 
     state = %{
       team_id: team_id,

--- a/lib/loomkin/decisions/graph.ex
+++ b/lib/loomkin/decisions/graph.ex
@@ -17,6 +17,15 @@ defmodule Loomkin.Decisions.Graph do
          |> Repo.insert() do
       {:ok, node} ->
         Phoenix.PubSub.broadcast(Loomkin.PubSub, "decision_graph", {:node_added, node})
+
+        if team_id = get_in(node.metadata, ["team_id"]) do
+          Phoenix.PubSub.broadcast(
+            Loomkin.PubSub,
+            "decision_graph:#{team_id}",
+            {:node_added, node}
+          )
+        end
+
         {:ok, node}
 
       error ->
@@ -243,6 +252,14 @@ defmodule Loomkin.Decisions.Graph do
       }
 
       Phoenix.PubSub.broadcast(Loomkin.PubSub, "decision_graph", {:pivot_created, result})
+
+      if team_id = get_in(base_metadata, ["team_id"]) do
+        Phoenix.PubSub.broadcast(
+          Loomkin.PubSub,
+          "decision_graph:#{team_id}",
+          {:pivot_created, result}
+        )
+      end
 
       result
     end)

--- a/lib/loomkin/teams/agent.ex
+++ b/lib/loomkin/teams/agent.ex
@@ -1396,6 +1396,7 @@ defmodule Loomkin.Teams.Agent do
       project_path_resolver: project_path_resolver,
       agent_name: state.name,
       team_id: state.team_id,
+      session_id: state.team_id,
       check_permission: permission_callback,
       checkpoint: checkpoint_callback,
       rate_limiter: fn provider ->

--- a/lib/loomkin/teams/role.ex
+++ b/lib/loomkin/teams/role.ex
@@ -38,7 +38,9 @@ defmodule Loomkin.Teams.Role do
 
   @decision_tools [
     Loomkin.Tools.DecisionLog,
-    Loomkin.Tools.DecisionQuery
+    Loomkin.Tools.DecisionQuery,
+    Loomkin.Tools.PivotDecision,
+    Loomkin.Tools.GenerateWriteup
   ]
 
   @write_tools [
@@ -92,6 +94,9 @@ defmodule Loomkin.Teams.Role do
                Loomkin.Tools.Git,
                Loomkin.Tools.DecisionLog,
                Loomkin.Tools.DecisionQuery,
+               Loomkin.Tools.PivotDecision,
+               Loomkin.Tools.GenerateWriteup,
+               Loomkin.Tools.MergeGraph,
                Loomkin.Tools.SubAgent,
                Loomkin.Tools.LspDiagnostics
              ] ++ @lead_tools ++ @peer_tools ++ @cross_team_tools
@@ -129,7 +134,10 @@ defmodule Loomkin.Teams.Role do
     "context_offload" => Loomkin.Tools.ContextOffload,
     "ask_user" => Loomkin.Tools.AskUser,
     "cross_team_query" => Loomkin.Tools.CrossTeamQuery,
-    "list_teams" => Loomkin.Tools.ListTeams
+    "list_teams" => Loomkin.Tools.ListTeams,
+    "pivot_decision" => Loomkin.Tools.PivotDecision,
+    "generate_writeup" => Loomkin.Tools.GenerateWriteup,
+    "merge_graph" => Loomkin.Tools.MergeGraph
   }
 
   # -- Shared behavioral guidance (injected into all roles) --
@@ -314,7 +322,11 @@ defmodule Loomkin.Teams.Role do
       - Summarize findings in bullet points, not walls of text
       - Distinguish between confirmed facts and inferences
       - Note patterns, conventions, and potential issues
-      - Log important discoveries using the decision tools
+
+      ## Decision Graph Protocol
+      - Log significant findings as observations (node_type: "observation") with parent_id linking to the relevant goal
+      - When you identify a recommended approach, log it as a decision with confidence
+      - Use decision_query to check what's already known before starting research
       """
     },
     coder: %{
@@ -322,7 +334,7 @@ defmodule Loomkin.Teams.Role do
       tools:
         @read_only_tools ++
           @write_tools ++
-          @exec_tools ++ [Loomkin.Tools.DecisionLog] ++ @peer_tools ++ @cross_team_tools,
+          @exec_tools ++ @decision_tools ++ @peer_tools ++ @cross_team_tools,
       system_prompt: """
       You are a coding agent. Your job is to implement changes, write code, and run commands.
 
@@ -354,7 +366,11 @@ defmodule Loomkin.Teams.Role do
       ## Error Recovery
       - If your approach is blocked, try alternative approaches rather than brute forcing
       - If a test or command fails, analyze the root cause rather than retrying blindly
-      - Log significant implementation decisions using decision tools
+
+      ## Decision Graph Protocol
+      - Log implementation decisions (node_type: "decision") with confidence and rationale
+      - Log completed work as outcomes (node_type: "outcome") linked to the parent action
+      - If an approach fails, use pivot_decision to record why and what you're trying next
       """
     },
     reviewer: %{
@@ -387,7 +403,7 @@ defmodule Loomkin.Teams.Role do
       model_tier: :default,
       tools:
         @read_only_tools ++
-          [Loomkin.Tools.Shell, Loomkin.Tools.DecisionLog] ++ @peer_tools ++ @cross_team_tools,
+          [Loomkin.Tools.Shell] ++ @decision_tools ++ @peer_tools ++ @cross_team_tools,
       system_prompt: """
       You are a testing agent. Your job is to run tests, validate changes, and report results.
 
@@ -438,6 +454,13 @@ defmodule Loomkin.Teams.Role do
       - For testing: spawn a tester agent
       - For complex tasks: spawn a full team with team_spawn
       - You are NOT an individual contributor — delegate the actual work
+
+      ## Decision Graph Protocol
+      When you make strategic decisions or delegate work:
+      - Log goals with decision_log (node_type: "goal") to track session objectives
+      - Log key decisions with confidence scores (node_type: "decision")
+      - Check decision_query (type: "active_goals") before delegating to see existing context
+      - When an approach fails, use pivot_decision to record the learning and new direction
       """
     },
     orienter: %{
@@ -479,6 +502,12 @@ defmodule Loomkin.Teams.Role do
       - Be fast and concise — use the fast model efficiently
       - If tools fail, skip them and report what you have
       - Always send the brief even if some scans fail
+
+      ## Initial Goal Creation
+      After scanning, if no active goals exist (pulse shows 0 active goals):
+      - Create a goal node using decision_log with node_type "goal"
+      - Base the goal title on project state and recent activity
+      - Set confidence based on clarity of direction
       """
     }
   }

--- a/lib/loomkin_web/live/workspace_live.ex
+++ b/lib/loomkin_web/live/workspace_live.ex
@@ -1427,6 +1427,16 @@ defmodule LoomkinWeb.WorkspaceLive do
     {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
 
+  def handle_info({:node_added, _node}, socket) do
+    refresh_decision_graphs(socket)
+    {:noreply, socket}
+  end
+
+  def handle_info({:pivot_created, _result}, socket) do
+    refresh_decision_graphs(socket)
+    {:noreply, socket}
+  end
+
   def handle_info({:context_update, _from_agent, _payload} = event, socket) do
     {:noreply, socket |> forward_to_activity(event) |> forward_to_cards_and_comms(event)}
   end
@@ -2514,6 +2524,7 @@ defmodule LoomkinWeb.WorkspaceLive do
       Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:tasks")
       Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:context")
       Phoenix.PubSub.subscribe(Loomkin.PubSub, "team:#{team_id}:decisions")
+      Phoenix.PubSub.subscribe(Loomkin.PubSub, "decision_graph:#{team_id}")
 
       socket = assign(socket, subscribed_teams: MapSet.put(subscribed, team_id))
 
@@ -2574,6 +2585,20 @@ defmodule LoomkinWeb.WorkspaceLive do
   # NOTE: Do NOT subscribe to PubSub topics here — this is called from many
   # event handlers and PubSub.subscribe is not idempotent (each call adds
   # another subscription, causing duplicate event delivery).
+  defp refresh_decision_graphs(socket) do
+    send_update(LoomkinWeb.DecisionGraphComponent,
+      id: "decision-graph",
+      session_id: socket.assigns[:session_id],
+      team_id: socket.assigns[:active_team_id]
+    )
+
+    send_update(LoomkinWeb.DecisionGraphComponent,
+      id: "team-decision-graph",
+      session_id: socket.assigns[:session_id],
+      team_id: socket.assigns[:display_team_id]
+    )
+  end
+
   defp refresh_roster(socket) do
     team_id = socket.assigns[:active_team_id]
     agents = roster_agents(team_id)


### PR DESCRIPTION
## Summary

The decision graph backend was fully operational (AutoLogger, Broadcaster, Cascade, ConflictDetector — 54 tests passing) but the UI side panel never showed content due to 3 breaks in the pipeline. This PR fixes all of them.

### Fixes

- **PubSub live updates**: Graph API now broadcasts on team-scoped `"decision_graph:#{team_id}"` topics. WorkspaceLive subscribes and forwards updates to DecisionGraphComponent via `send_update`. Broadcaster also subscribes to scoped topic.
- **Context injection**: Added `session_id: state.team_id` to agent `build_loop_opts` — this was the one-line fix that connects `ContextBuilder.build()` to agent system prompts. Agents now see active goals, recent decisions, and prior attempts in their context.
- **Agent prompts**: Added Decision Graph Protocol sections to Concierge, Researcher, Coder, and Orienter roles with specific instructions on when/how to use decision tools.
- **Tool registration**: PivotDecision and GenerateWriteup added to `@decision_tools` (all roles). MergeGraph added to `@all_tools` (Lead/Concierge only).

### Root cause
`build_loop_opts` never passed `session_id`, so `inject_decision_context` in ContextWindow always short-circuited. The backend was creating nodes but agents never saw them, and the UI never listened for updates.

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] 174 decision graph tests passing, 0 failures
- [ ] Start session, verify decision graph panel populates as agents work
- [ ] Verify Orienter creates initial goal node when no active goals exist
- [ ] Verify agents reference decision graph context in their responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)