### PR TITLE
fix: stabilize codex oauth and cli team messaging

### DIFF
--- a/apps/cli/src/app.tsx
+++ b/apps/cli/src/app.tsx
@@ -298,6 +298,7 @@ export function App() {
             key={pendingApprovals[0].gate_id}
             type="approval"
             gate={pendingApprovals[0]}
+            queueCount={pendingApprovals.length}
             onRespond={respondApproval}
           />
         )}
@@ -309,6 +310,7 @@ export function App() {
             key={pendingSpawnGates[0].gate_id}
             type="spawn_gate"
             gate={pendingSpawnGates[0]}
+            queueCount={pendingSpawnGates.length}
             onRespond={respondSpawnGate}
           />
         )}

--- a/apps/cli/src/app.tsx
+++ b/apps/cli/src/app.tsx
@@ -268,6 +268,7 @@ export function App() {
           messages={messages}
           pendingToolCalls={pendingToolCalls}
           isStreaming={isStreaming}
+          termWidth={termWidth}
         />
       ) : (
         <MessageList
@@ -276,6 +277,7 @@ export function App() {
           isStreaming={isStreaming}
           maxLines={termHeight - 6}
           scrollOffset={sessionState.scrollOffset}
+          estimatedWidth={termWidth - 4}
         />
       )}
       {latestError && <ErrorBanner error={latestError} />}

--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -27,6 +27,10 @@ function formatAgent(agent: AgentInfo, indent = ""): string {
   let detail = "";
   if (agent.currentTool) {
     detail = pc.dim(` → ${agent.currentTool}`);
+  } else if (agent.currentThought || agent.lastThought) {
+    const thought = (agent.currentThought ?? agent.lastThought ?? "").replace(/\s+/g, " ").trim();
+    const preview = thought.length > 50 ? thought.slice(0, 50) + "…" : thought;
+    detail = pc.dim(` — thinking: ${preview}`);
   } else if (agent.currentTask) {
     const taskPreview =
       agent.currentTask.length > 50

--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -47,7 +47,12 @@ function formatAgent(agent: AgentInfo, indent = ""): string {
     worktree = pc.dim(` [wt:${agent.worktreePath}]`);
   }
 
-  return `${indent}${icon} ${name} ${pc.dim(`[${status}]`)} ${role}  ${pc.dim(modelDisplay)}${detail}${cost}${worktree}`;
+  let published = "";
+  if ((agent.publishedFindingsCount ?? 0) > 0) {
+    published = pc.green(` · pub:${agent.publishedFindingsCount}`);
+  }
+
+  return `${indent}${icon} ${name} ${pc.dim(`[${status}]`)} ${role}  ${pc.dim(modelDisplay)}${detail}${cost}${worktree}${published}`;
 }
 
 register({

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -9,6 +9,28 @@ import { useAppStore } from "../stores/appStore.js";
 import { formatTokens, formatCost } from "../lib/format.js";
 import { getSession } from "../lib/api.js";
 
+function agentDetail(agent: {
+  currentTool?: string;
+  currentTask?: string;
+  currentThought?: string;
+  lastThought?: string;
+}): string {
+  if (agent.currentTool) {
+    return `— ${agent.currentTool}`;
+  }
+
+  const thought = (agent.currentThought ?? agent.lastThought ?? "").replace(/\s+/g, " ").trim();
+  if (thought) {
+    return `— thinking: ${thought.slice(0, 40)}${thought.length > 40 ? "…" : ""}`;
+  }
+
+  if (agent.currentTask) {
+    return `— ${agent.currentTask.slice(0, 40)}${agent.currentTask.length > 40 ? "…" : ""}`;
+  }
+
+  return "Idle";
+}
+
 async function renderDashboard(ctx: CommandContext) {
   const { sessionId } = useSessionStore.getState();
   const { agents } = useAgentStore.getState();
@@ -47,7 +69,7 @@ async function renderDashboard(ctx: CommandContext) {
         (agent.publishedFindingsCount ?? 0) > 0
           ? ` ${pc.green(`[pub:${agent.publishedFindingsCount}]`)}`
           : "";
-      const agentLine = `  ${agent.status === 'working' ? pc.green('●') : pc.dim('○')} ${pc.bold(agent.name)} ${pc.cyan(`[${agent.role}]`)}${published} ${pc.dim(agent.currentTask ? `— ${agent.currentTask.slice(0, 40)}...` : 'Idle')}`;
+      const agentLine = `  ${agent.status === 'working' ? pc.green('●') : pc.dim('○')} ${pc.bold(agent.name)} ${pc.cyan(`[${agent.role}]`)}${published} ${pc.dim(agentDetail(agent))}`;
       lines.push(pc.bold(pc.cyan("┃")) + agentLine + " ".repeat(78 - stripAnsi(agentLine).length) + pc.bold(pc.cyan("┃")));
     });
   }

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -43,7 +43,11 @@ async function renderDashboard(ctx: CommandContext) {
     lines.push(pc.bold(pc.cyan("┃")) + noAgentsLine + " ".repeat(78 - stripAnsi(noAgentsLine).length) + pc.bold(pc.cyan("┃")));
   } else {
     Array.from(agents.values()).forEach(agent => {
-      const agentLine = `  ${agent.status === 'working' ? pc.green('●') : pc.dim('○')} ${pc.bold(agent.name)} ${pc.cyan(`[${agent.role}]`)} ${pc.dim(agent.currentTask ? `— ${agent.currentTask.slice(0, 40)}...` : 'Idle')}`;
+      const published =
+        (agent.publishedFindingsCount ?? 0) > 0
+          ? ` ${pc.green(`[pub:${agent.publishedFindingsCount}]`)}`
+          : "";
+      const agentLine = `  ${agent.status === 'working' ? pc.green('●') : pc.dim('○')} ${pc.bold(agent.name)} ${pc.cyan(`[${agent.role}]`)}${published} ${pc.dim(agent.currentTask ? `— ${agent.currentTask.slice(0, 40)}...` : 'Idle')}`;
       lines.push(pc.bold(pc.cyan("┃")) + agentLine + " ".repeat(78 - stripAnsi(agentLine).length) + pc.bold(pc.cyan("┃")));
     });
   }

--- a/apps/cli/src/components/ApprovalGatePrompt.tsx
+++ b/apps/cli/src/components/ApprovalGatePrompt.tsx
@@ -7,11 +7,13 @@ type Props =
   | {
       type: "approval";
       gate: ApprovalRequest;
+      queueCount?: number;
       onRespond: (gateId: string, outcome: "approved" | "denied", context?: string, reason?: string) => void;
     }
   | {
       type: "spawn_gate";
       gate: SpawnGateRequest;
+      queueCount?: number;
       onRespond: (gateId: string, outcome: "approved" | "denied", reason?: string) => void;
     };
 
@@ -120,6 +122,9 @@ export function ApprovalGatePrompt(props: Props) {
       )}
 
       <Text color={timeColor}>{remaining}s remaining</Text>
+      {props.queueCount && props.queueCount > 1 && (
+        <Text dimColor>Showing 1 of {props.queueCount} pending requests</Text>
+      )}
 
       {mode === "choose" && (
         <Box marginTop={1}>

--- a/apps/cli/src/components/InputArea.tsx
+++ b/apps/cli/src/components/InputArea.tsx
@@ -547,6 +547,7 @@ export function InputArea({ onSubmit, commandContext, termWidth = 80 }: Props) {
     placeholder.length > availableWidth
       ? placeholder.slice(0, Math.max(0, availableWidth - 1)) + "…"
       : placeholder;
+  const dividerWidth = Math.max(10, termWidth - 2);
 
   const wasAuto = modelPickerAutoRef.current;
 
@@ -615,6 +616,9 @@ export function InputArea({ onSubmit, commandContext, termWidth = 80 }: Props) {
         />
       ) : (
         <>
+          <Box paddingX={1}>
+            <Text dimColor>{"─".repeat(dividerWidth)}</Text>
+          </Box>
           <Box borderStyle="single" borderColor={promptColor} paddingX={1}>
             <Text color={promptColor} bold>
               {promptChar}{" "}

--- a/apps/cli/src/components/Message.tsx
+++ b/apps/cli/src/components/Message.tsx
@@ -67,16 +67,18 @@ export function Message({
     );
   }
 
-  const roleLabel = agent_name ? `${role}:${agent_name}` : role;
+  const roleLabel = agent_name || "assistant";
 
   return (
     <Box flexDirection="column" marginBottom={1}>
       {role === "user" && (
-        <Box>
-          <Text color="blue" bold>
-            {">"}{" "}
+        <Box flexDirection="column">
+          <Text color="blue" bold dimColor>
+            you
           </Text>
-          <Text>{content}</Text>
+          {(content ?? "").split("\n").map((line, i) => (
+            <Text key={i}>{line}</Text>
+          ))}
         </Box>
       )}
 

--- a/apps/cli/src/components/MessageList.tsx
+++ b/apps/cli/src/components/MessageList.tsx
@@ -11,22 +11,35 @@ interface Props {
   maxLines?: number;
   scrollOffset?: number;
   agentFilter?: string | null;
+  estimatedWidth?: number;
+}
+
+function estimateWrappedLines(text: string | null | undefined, width: number): number {
+  const wrapWidth = Math.max(20, width);
+  const lines = (text ?? "").split("\n");
+
+  return lines.reduce((total, line) => {
+    const length = Math.max(1, line.length);
+    return total + Math.max(1, Math.ceil(length / wrapWidth));
+  }, 0);
 }
 
 // Rough line-height estimate for a message (content lines + 1 margin row).
-function estimateHeight(msg: MessageType): number {
+function estimateHeight(msg: MessageType, estimatedWidth = 80): number {
   const margin = 1;
+  const contentWidth = Math.max(20, estimatedWidth - 4);
+
   switch (msg.role) {
     case "system":
-      return (msg.content ?? "").split("\n").length + margin;
+      return estimateWrappedLines(msg.content, contentWidth) + margin;
     case "user":
-      return 1 + margin;
+      return 1 + estimateWrappedLines(msg.content, contentWidth) + margin;
     case "tool":
-      return 2 + margin;
+      return 1 + estimateWrappedLines((msg.content ?? "").slice(0, 300), contentWidth) + margin;
     case "assistant": {
-      const contentLines = Math.max(1, Math.ceil((msg.content?.length ?? 0) / 80));
+      const contentLines = estimateWrappedLines(msg.content, contentWidth);
       const toolLines = (msg.tool_calls?.length ?? 0) * 2;
-      return contentLines + toolLines + margin;
+      return 1 + contentLines + toolLines + margin;
     }
     default:
       return 2;
@@ -41,6 +54,7 @@ export function MessageList({
   maxLines,
   scrollOffset = 0,
   agentFilter,
+  estimatedWidth = 80,
 }: Props) {
   // Filter by agent if specified
   const filtered =
@@ -59,7 +73,7 @@ export function MessageList({
     let budget = maxLines;
     const kept: MessageType[] = [];
     for (let i = recent.length - 1; i >= 0; i--) {
-      const h = estimateHeight(recent[i]);
+      const h = estimateHeight(recent[i], estimatedWidth);
       if (budget - h < 0 && kept.length > 0) break;
       budget -= h;
       kept.unshift(recent[i]);

--- a/apps/cli/src/components/ModelPicker.tsx
+++ b/apps/cli/src/components/ModelPicker.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { ModelProvider } from "../lib/types.js";
+import {
+  buildModelOptions,
+  getCenteredWindowStart,
+  getInitialModelIndex,
+  getWindowStartForSelection,
+} from "./modelPickerState.js";
 
 const VISIBLE_COUNT = 12;
 
@@ -10,10 +16,6 @@ const OAUTH_PROVIDERS = [
   { id: "openai", name: "OpenAI" },
 ] as const;
 
-type FlatItem =
-  | { kind: "separator"; label: string }
-  | { kind: "model"; id: string; label: string; context?: string };
-
 interface Props {
   providers: ModelProvider[];
   currentModel: string;
@@ -22,57 +24,28 @@ interface Props {
   onOAuth: (id: string, name: string) => void;
 }
 
-function buildFlatItems(providers: ModelProvider[]): FlatItem[] {
-  const items: FlatItem[] = [];
-  for (const provider of providers) {
-    if (provider.models.length === 0) continue;
-    items.push({ kind: "separator", label: `── ${provider.name} ──` });
-    for (const model of provider.models) {
-      items.push({ kind: "model", id: model.id, label: model.label, context: model.context ?? undefined });
-    }
-  }
-  return items;
-}
-
-function firstModelIndex(items: FlatItem[]): number {
-  return items.findIndex((item) => item.kind === "model");
-}
-
-function prevModelIndex(items: FlatItem[], from: number): number {
-  for (let i = from - 1; i >= 0; i--) {
-    if (items[i].kind === "model") return i;
-  }
-  return from;
-}
-
-function nextModelIndex(items: FlatItem[], from: number): number {
-  for (let i = from + 1; i < items.length; i++) {
-    if (items[i].kind === "model") return i;
-  }
-  return from;
-}
-
 export function ModelPicker({ providers, currentModel, onSelect, onCancel, onOAuth }: Props) {
-  const flatItems = useMemo(() => buildFlatItems(providers), [providers]);
+  const modelOptions = useMemo(() => buildModelOptions(providers), [providers]);
 
   const initialIndex = useMemo(() => {
-    const currentIdx = flatItems.findIndex(
-      (item) => item.kind === "model" && item.id === currentModel,
-    );
-    return currentIdx !== -1 ? currentIdx : firstModelIndex(flatItems);
-  }, [flatItems, currentModel]);
+    return getInitialModelIndex(modelOptions, currentModel);
+  }, [modelOptions, currentModel]);
 
   const [selectedIndex, setSelectedIndex] = useState(initialIndex);
-  const [windowStart, setWindowStart] = useState(() => Math.max(0, initialIndex - Math.floor(VISIBLE_COUNT / 2)));
+  const [windowStart, setWindowStart] = useState(() =>
+    getCenteredWindowStart(initialIndex, VISIBLE_COUNT),
+  );
   const [oauthView, setOauthView] = useState(false);
   const [oauthIndex, setOauthIndex] = useState(0);
 
-  // Keep selected item within the visible window
+  useEffect(() => {
+    setSelectedIndex(initialIndex);
+    setWindowStart(getCenteredWindowStart(initialIndex, VISIBLE_COUNT));
+  }, [initialIndex]);
+
   useEffect(() => {
     setWindowStart((ws) => {
-      if (selectedIndex < ws) return selectedIndex;
-      if (selectedIndex >= ws + VISIBLE_COUNT) return selectedIndex - VISIBLE_COUNT + 1;
-      return ws;
+      return getWindowStartForSelection(ws, selectedIndex, VISIBLE_COUNT);
     });
   }, [selectedIndex]);
 
@@ -106,16 +79,16 @@ export function ModelPicker({ providers, currentModel, onSelect, onCancel, onOAu
     }
 
     if (key.upArrow) {
-      setSelectedIndex((i) => prevModelIndex(flatItems, i));
+      setSelectedIndex((i) => Math.max(0, i - 1));
       return;
     }
     if (key.downArrow) {
-      setSelectedIndex((i) => nextModelIndex(flatItems, i));
+      setSelectedIndex((i) => Math.min(modelOptions.length - 1, i + 1));
       return;
     }
     if (key.return) {
-      const item = flatItems[selectedIndex];
-      if (item?.kind === "model") {
+      const item = modelOptions[selectedIndex];
+      if (item) {
         onSelect(item.id, item.label);
       }
       return;
@@ -144,7 +117,7 @@ export function ModelPicker({ providers, currentModel, onSelect, onCancel, onOAu
     );
   }
 
-  if (flatItems.length === 0) {
+  if (modelOptions.length === 0) {
     return (
       <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
         <Text dimColor>No models available — connect a provider first</Text>
@@ -162,34 +135,31 @@ export function ModelPicker({ providers, currentModel, onSelect, onCancel, onOAu
       {windowStart > 0 && (
         <Text dimColor>  ▲ {windowStart} more above</Text>
       )}
-      {flatItems.slice(windowStart, windowStart + VISIBLE_COUNT).map((item, offset) => {
+      {modelOptions.slice(windowStart, windowStart + VISIBLE_COUNT).map((item, offset) => {
         const i = windowStart + offset;
-        if (item.kind === "separator") {
-          return (
-            <Text key={i} dimColor>
-              {item.label}
-            </Text>
-          );
-        }
-
         const isSelected = i === selectedIndex;
         const isCurrent = item.id === currentModel;
+        const previous = modelOptions[i - 1];
+        const showProviderHeader = i === 0 || previous?.providerId !== item.providerId;
 
         return (
-          <Box key={item.id} gap={1}>
-            <Text color={isSelected ? "blue" : undefined} bold={isSelected}>
-              {isSelected ? "▸" : " "}
-              {isCurrent ? "✔" : " "}
-              {item.label}
-            </Text>
-            {item.context && (
-              <Text dimColor>{item.context}</Text>
+          <React.Fragment key={`${item.providerId}:${item.id}`}>
+            {showProviderHeader && (
+              <Text dimColor>── {item.providerName} ──</Text>
             )}
-          </Box>
+            <Box gap={1}>
+              <Text color={isSelected ? "blue" : undefined} bold={isSelected}>
+                {isSelected ? "▸" : " "}
+                {isCurrent ? "✔" : " "}
+                {item.label}
+              </Text>
+              {item.context && <Text dimColor>{item.context}</Text>}
+            </Box>
+          </React.Fragment>
         );
       })}
-      {windowStart + VISIBLE_COUNT < flatItems.length && (
-        <Text dimColor>  ▼ {flatItems.length - windowStart - VISIBLE_COUNT} more below</Text>
+      {windowStart + VISIBLE_COUNT < modelOptions.length && (
+        <Text dimColor>  ▼ {modelOptions.length - windowStart - VISIBLE_COUNT} more below</Text>
       )}
     </Box>
   );

--- a/apps/cli/src/components/ProcessingStatus.tsx
+++ b/apps/cli/src/components/ProcessingStatus.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Box, Text } from "ink";
 import { useStore } from "zustand";
 import { useSessionStore } from "../stores/sessionStore.js";
+import { useAgentStore } from "../stores/agentStore.js";
 
 // Spool of thread rotating — the loom is winding up
 const WAIT_FRAMES = ["◐", "◓", "◑", "◒"];
@@ -11,10 +12,60 @@ const LOOM_FRAMES = ["◌", "○", "◎", "◉", "●", "◉", "◎", "○"];
 const STREAM_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const INTERVAL_MS = 160;
 
+function compactName(name: string): string {
+  if (name.length <= 24) return name;
+  return `${name.slice(0, 23)}…`;
+}
+
+function normalizePreview(text: string | undefined): string {
+  if (!text) return "";
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function trimPreview(text: string, max = 42): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}
+
+function summarizeAgent(agent: {
+  name: string;
+  currentTool?: string;
+  currentTask?: string;
+  currentThought?: string;
+  lastThought?: string;
+}): string {
+  if (agent.currentTool) {
+    return `${compactName(agent.name)} tool:${trimPreview(agent.currentTool, 24)}`;
+  }
+
+  const thought = normalizePreview(agent.currentThought || agent.lastThought);
+  if (thought) {
+    return `${compactName(agent.name)} thinking:${trimPreview(thought)}`;
+  }
+
+  if (agent.currentTask) {
+    return `${compactName(agent.name)} ${trimPreview(normalizePreview(agent.currentTask))}`;
+  }
+
+  return `${compactName(agent.name)} working`;
+}
+
 export function ProcessingStatus() {
   const isStreaming = useStore(useSessionStore, (s) => s.isStreaming);
   const isPendingResponse = useStore(useSessionStore, (s) => s.isPendingResponse);
   const messages = useStore(useSessionStore, (s) => s.messages);
+  const agents = useStore(useAgentStore, (s) => s.agents);
+  const activeAgents = useMemo(
+    () =>
+      Array.from(agents.values())
+        .filter((agent) => {
+          if (agent.status === "working") return true;
+          return Boolean(agent.currentTool || agent.currentThought || agent.currentTask);
+        })
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+        .slice(0, 2),
+    [agents],
+  );
 
   const lastMessage = messages[messages.length - 1];
   const hasStreamingContent =
@@ -22,10 +73,16 @@ export function ProcessingStatus() {
     lastMessage?.role === "assistant" &&
     (lastMessage.content?.length ?? 0) > 0;
 
-  const stateKey = hasStreamingContent ? "streaming" : isStreaming ? "looming" : "waiting";
+  const hasAgentActivity = activeAgents.length > 0;
+  const stateKey =
+    hasStreamingContent ? "streaming"
+    : isStreaming ? "looming"
+    : isPendingResponse ? "waiting"
+    : hasAgentActivity ? "agents"
+    : null;
   const frames =
     stateKey === "streaming" ? STREAM_FRAMES
-    : stateKey === "looming" ? LOOM_FRAMES
+    : stateKey === "looming" || stateKey === "agents" ? LOOM_FRAMES
     : WAIT_FRAMES;
 
   const [frame, setFrame] = useState(0);
@@ -37,17 +94,18 @@ export function ProcessingStatus() {
 
   // Advance spinner while active
   useEffect(() => {
-    if (!isPendingResponse && !isStreaming) return;
+    if (!isPendingResponse && !isStreaming && !hasAgentActivity) return;
     const id = setInterval(
       () => setFrame((f) => (f + 1) % frames.length),
       INTERVAL_MS,
     );
     return () => clearInterval(id);
-  }, [isPendingResponse, isStreaming, frames.length]);
+  }, [isPendingResponse, isStreaming, hasAgentActivity, frames.length]);
 
-  if (!isPendingResponse && !isStreaming) return null;
+  if (!isPendingResponse && !isStreaming && !hasAgentActivity) return null;
 
   const spinner = frames[frame] ?? frames[0];
+  const agentSummary = activeAgents.map(summarizeAgent).join("  ·  ");
 
   return (
     <Box paddingX={1} gap={1} flexShrink={0}>
@@ -55,6 +113,7 @@ export function ProcessingStatus() {
       {stateKey === "waiting" && <Text color="yellow">waiting...</Text>}
       {stateKey === "looming" && <Text color="yellow">looming...</Text>}
       {stateKey === "streaming" && <Text color="yellow">streaming...</Text>}
+      {stateKey === "agents" && <Text color="cyan">kin working: {agentSummary}</Text>}
     </Box>
   );
 }

--- a/apps/cli/src/components/SplitPaneLayout.tsx
+++ b/apps/cli/src/components/SplitPaneLayout.tsx
@@ -12,12 +12,14 @@ interface Props {
   messages: Message[];
   pendingToolCalls: ToolCall[];
   isStreaming?: boolean;
+  termWidth: number;
 }
 
 export function SplitPaneLayout({
   messages,
   pendingToolCalls,
   isStreaming = false,
+  termWidth,
 }: Props) {
   const focusedPane = useStore(usePaneStore, (s) => s.focusedPane);
   const selectedAgent = useStore(usePaneStore, (s) => s.selectedAgent);
@@ -34,6 +36,7 @@ export function SplitPaneLayout({
   const rightTitle = showConversation
     ? `Conversation`
     : selectedAgent ?? "No agent";
+  const paneWidth = Math.max(20, Math.floor(termWidth / 2) - 4);
 
   return (
     <Box flexDirection="row" flexGrow={1}>
@@ -54,6 +57,7 @@ export function SplitPaneLayout({
           isStreaming={isStreaming}
           agentFilter={null}
           scrollOffset={leftScrollOffset}
+          estimatedWidth={paneWidth}
         />
       </Box>
       <Box
@@ -76,6 +80,7 @@ export function SplitPaneLayout({
             isStreaming={isStreaming}
             agentFilter={selectedAgent}
             scrollOffset={rightScrollOffset}
+            estimatedWidth={paneWidth}
           />
         )}
       </Box>

--- a/apps/cli/src/components/StatusBar.tsx
+++ b/apps/cli/src/components/StatusBar.tsx
@@ -42,6 +42,13 @@ export function StatusBar() {
     }
     return count;
   });
+  const agentsWithPublishedFindingsCount = useStore(useAgentStore, (s) => {
+    let count = 0;
+    for (const agent of s.agents.values()) {
+      if ((agent.publishedFindingsCount ?? 0) > 0) count++;
+    }
+    return count;
+  });
   const splitMode = useStore(usePaneStore, (s) => s.splitMode);
   const selectedAgent = useStore(usePaneStore, (s) => s.selectedAgent);
   const focusedTarget = useStore(usePaneStore, (s) => s.focusedTarget);
@@ -137,6 +144,13 @@ export function StatusBar() {
           <Text dimColor>
             agents:<Text bold color={workingCount > 0 ? "green" : undefined}>
               {workingCount}/{agentCount}
+            </Text>
+          </Text>
+        )}
+        {agentCount > 0 && agentsWithPublishedFindingsCount > 0 && (
+          <Text dimColor>
+            pub:<Text bold color="cyan">
+              {agentsWithPublishedFindingsCount}/{agentCount}
             </Text>
           </Text>
         )}

--- a/apps/cli/src/components/modelPickerState.test.ts
+++ b/apps/cli/src/components/modelPickerState.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildModelOptions,
+  getCenteredWindowStart,
+  getInitialModelIndex,
+  getWindowStartForSelection,
+} from "./modelPickerState.js";
+import type { ModelProvider } from "../lib/types.js";
+
+const providers: ModelProvider[] = [
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    status: { type: "oauth", status: "connected" },
+    models: [
+      { id: "anthropic:claude-sonnet", label: "Claude Sonnet", context: "200K ctx" },
+    ],
+  },
+  {
+    id: "openai",
+    name: "OpenAI",
+    status: { type: "oauth", status: "connected" },
+    models: [
+      { id: "openai:gpt-5.3-codex", label: "gpt-5.3-codex", context: null },
+      { id: "openai:gpt-5.4", label: "gpt-5.4", context: null },
+    ],
+  },
+];
+
+describe("modelPickerState", () => {
+  test("buildModelOptions flattens models without separator rows", () => {
+    const options = buildModelOptions(providers);
+
+    expect(options).toHaveLength(3);
+    expect(options.map((option) => option.id)).toEqual([
+      "anthropic:claude-sonnet",
+      "openai:gpt-5.3-codex",
+      "openai:gpt-5.4",
+    ]);
+  });
+
+  test("getInitialModelIndex selects the current model when present", () => {
+    const options = buildModelOptions(providers);
+
+    expect(getInitialModelIndex(options, "openai:gpt-5.4")).toBe(2);
+    expect(getInitialModelIndex(options, "missing:model")).toBe(0);
+  });
+
+  test("window helpers keep selection centered and then pinned in view", () => {
+    expect(getCenteredWindowStart(6, 5)).toBe(4);
+    expect(getWindowStartForSelection(4, 3, 5)).toBe(3);
+    expect(getWindowStartForSelection(4, 8, 5)).toBe(4);
+    expect(getWindowStartForSelection(4, 10, 5)).toBe(6);
+  });
+});

--- a/apps/cli/src/components/modelPickerState.ts
+++ b/apps/cli/src/components/modelPickerState.ts
@@ -1,0 +1,49 @@
+import type { ModelProvider } from "../lib/types.js";
+
+export interface ModelPickerOption {
+  providerId: string;
+  providerName: string;
+  id: string;
+  label: string;
+  context?: string;
+}
+
+export function buildModelOptions(providers: ModelProvider[]): ModelPickerOption[] {
+  return providers.flatMap((provider) =>
+    provider.models.map((model) => ({
+      providerId: provider.id,
+      providerName: provider.name,
+      id: model.id,
+      label: model.label,
+      context: model.context ?? undefined,
+    })),
+  );
+}
+
+export function getInitialModelIndex(
+  options: ModelPickerOption[],
+  currentModel: string,
+): number {
+  const currentIndex = options.findIndex((item) => item.id === currentModel);
+  return currentIndex >= 0 ? currentIndex : 0;
+}
+
+export function getCenteredWindowStart(
+  selectedIndex: number,
+  visibleCount: number,
+): number {
+  return Math.max(0, selectedIndex - Math.floor(visibleCount / 2));
+}
+
+export function getWindowStartForSelection(
+  currentWindowStart: number,
+  selectedIndex: number,
+  visibleCount: number,
+): number {
+  if (selectedIndex < currentWindowStart) return selectedIndex;
+  if (selectedIndex >= currentWindowStart + visibleCount) {
+    return Math.max(0, selectedIndex - visibleCount + 1);
+  }
+
+  return currentWindowStart;
+}

--- a/apps/cli/src/hooks/useAgentChannel.ts
+++ b/apps/cli/src/hooks/useAgentChannel.ts
@@ -131,6 +131,23 @@ export function useAgentChannel() {
       },
     );
 
+    on<{ agent_name: string; topic?: string | null; source?: string; team_id: string }>(
+      "agent_findings_published",
+      (payload) => {
+        const existing = useAgentStore.getState().agents.get(payload.agent_name);
+        const nextCount = (existing?.publishedFindingsCount ?? 0) + 1;
+
+        useAgentStore.getState().upsertAgent(payload.agent_name, {
+          publishedFindingsCount: nextCount,
+          lastPublishedAt: new Date().toISOString(),
+          lastPublishedTopic: payload.topic ?? existing?.lastPublishedTopic,
+        });
+
+        const topicSuffix = payload.topic ? `: ${payload.topic}` : "";
+        notify(`📚 ${payload.agent_name} published findings${topicSuffix}`);
+      },
+    );
+
     on<{ agent_name: string; role: string; team_id: string; worktree_path?: string; parent_agent?: string }>("agent_spawned", (payload) => {
       useAgentStore.getState().upsertAgent(payload.agent_name, {
         role: payload.role,

--- a/apps/cli/src/hooks/useAgentChannel.ts
+++ b/apps/cli/src/hooks/useAgentChannel.ts
@@ -287,8 +287,12 @@ export function useAgentChannel() {
           ...payload,
           received_at: Date.now(),
         });
-        const roleNames = payload.roles.map((r) => r.role).join(", ");
-        notify(`🔒 ${payload.agent_name} wants to spawn: ${roleNames} ($${payload.estimated_cost.toFixed(4)})`);
+        const roleNames = payload.roles
+          .map((r) => (r.name ? `${r.name} (${r.role})` : r.role))
+          .filter(Boolean)
+          .join(", ");
+        const summary = roleNames || payload.team_name || payload.purpose || "new team";
+        notify(`🔒 ${payload.agent_name} wants to spawn: ${summary} ($${payload.estimated_cost.toFixed(4)})`);
       },
     );
 

--- a/apps/cli/src/hooks/useAgentChannel.ts
+++ b/apps/cli/src/hooks/useAgentChannel.ts
@@ -26,6 +26,14 @@ function makeNotifyMessage(content: string, counter: { current: number }): Messa
   };
 }
 
+const MAX_THOUGHT_CHARS = 280;
+
+function appendThought(existing: string | undefined, token: string): string {
+  const next = `${existing ?? ""}${token}`;
+  if (next.length <= MAX_THOUGHT_CHARS) return next;
+  return next.slice(-MAX_THOUGHT_CHARS);
+}
+
 /**
  * Subscribes to agent-related events on the shared Phoenix channel.
  * The channel lifecycle is owned by useChannelLifecycle — this hook
@@ -70,9 +78,20 @@ export function useAgentChannel() {
     // --- Agent events ---
 
     on<{ agent_name: string; status: string; pause_queued?: boolean }>("agent_status", (payload) => {
+      const clearTransientState = ["idle", "done", "completed", "error"].includes(
+        payload.status,
+      );
+
       useAgentStore.getState().upsertAgent(payload.agent_name, {
         status: payload.status,
         pauseQueued: payload.pause_queued,
+        ...(clearTransientState
+          ? {
+              currentTool: undefined,
+              currentTask: undefined,
+              currentThought: undefined,
+            }
+          : {}),
       });
       if (payload.status === "done" || payload.status === "completed") {
         notify(`✓ ${payload.agent_name} finished`);
@@ -89,8 +108,12 @@ export function useAgentChannel() {
     });
 
     on<{ agent_name: string; tool_name: string }>("agent_tool_executing", (payload) => {
+      const existing = useAgentStore.getState().agents.get(payload.agent_name);
+
       useAgentStore.getState().upsertAgent(payload.agent_name, {
         currentTool: payload.tool_name,
+        currentThought: undefined,
+        lastThought: existing?.currentThought ?? existing?.lastThought,
         status: "working",
       });
     });
@@ -98,6 +121,33 @@ export function useAgentChannel() {
     on<{ agent_name: string; tool_name: string }>("agent_tool_complete", (payload) => {
       useAgentStore.getState().upsertAgent(payload.agent_name, {
         currentTool: undefined,
+      });
+    });
+
+    on<{ agent_name: string; team_id: string }>("agent_stream_start", (payload) => {
+      useAgentStore.getState().upsertAgent(payload.agent_name, {
+        status: "working",
+        currentThought: "",
+      });
+    });
+
+    on<{ agent_name: string; team_id: string; token: string }>("agent_stream_delta", (payload) => {
+      const existing = useAgentStore.getState().agents.get(payload.agent_name);
+      const currentThought = appendThought(existing?.currentThought, payload.token);
+
+      useAgentStore.getState().upsertAgent(payload.agent_name, {
+        status: "working",
+        currentThought,
+        lastThought: currentThought,
+      });
+    });
+
+    on<{ agent_name: string; team_id: string }>("agent_stream_end", (payload) => {
+      const existing = useAgentStore.getState().agents.get(payload.agent_name);
+
+      useAgentStore.getState().upsertAgent(payload.agent_name, {
+        currentThought: undefined,
+        lastThought: existing?.currentThought ?? existing?.lastThought,
       });
     });
 
@@ -164,6 +214,14 @@ export function useAgentChannel() {
         role: payload.role,
       }).catch(() => {});
     });
+
+    on<{ child_team_id: string; team_name: string; depth: number }>(
+      "child_team_created",
+      (payload) => {
+        const label = payload.team_name || payload.child_team_id;
+        notify(`🧭 Child team ready: ${label} (${payload.child_team_id})`);
+      },
+    );
 
     // --- Collaboration events ---
 
@@ -270,8 +328,13 @@ export function useAgentChannel() {
       "team_task_update",
       (payload) => {
         if (payload.agent_name && payload.task) {
+          const clearTask = ["idle", "done", "completed", "cancelled"].includes(
+            payload.status ?? "",
+          );
+
           useAgentStore.getState().upsertAgent(payload.agent_name, {
-            currentTask: payload.task,
+            currentTask: clearTask ? undefined : payload.task,
+            ...(payload.status ? { status: payload.status } : {}),
           });
         }
       },

--- a/apps/cli/src/hooks/useSessionChannel.ts
+++ b/apps/cli/src/hooks/useSessionChannel.ts
@@ -65,23 +65,14 @@ export function useSessionChannel() {
       const store = useSessionStore.getState();
       store.setPendingResponse(false);
       store.setStreaming(true);
-      if (payload.message_id) {
-        store.startStreamingMessage(payload.message_id);
-      }
+      store.ensureStreamingMessage(payload.message_id);
     });
 
     on("stream_token", (raw) => {
       const payload = raw as { message_id?: string; token: string };
       const store = useSessionStore.getState();
-      if (payload.message_id) {
-        store.appendStreamContent(payload.message_id, payload.token);
-      } else {
-        const msgs = store.messages;
-        const last = msgs[msgs.length - 1];
-        if (last?.role === "assistant") {
-          store.appendStreamContent(last.id, payload.token);
-        }
-      }
+      const streamId = store.ensureStreamingMessage(payload.message_id);
+      store.appendStreamContent(streamId, payload.token);
     });
 
     on("stream_end", (raw) => {

--- a/apps/cli/src/stores/__tests__/sessionStore.test.ts
+++ b/apps/cli/src/stores/__tests__/sessionStore.test.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
     sessionId: null,
     messages: [],
     isStreaming: false,
+    currentStreamingMessageId: null,
     pendingToolCalls: [],
     scrollOffset: 0,
   });
@@ -110,6 +111,27 @@ test("startStreamingMessage creates a placeholder assistant message", () => {
   expect(messages[0].id).toBe("stream-1");
   expect(messages[0].role).toBe("assistant");
   expect(messages[0].content).toBe("");
+});
+
+test("ensureStreamingMessage creates a placeholder when the server does not send a message id", () => {
+  const streamId = sessionStore.getState().ensureStreamingMessage();
+  const state = sessionStore.getState();
+
+  expect(streamId).toBeTruthy();
+  expect(state.currentStreamingMessageId).toBe(streamId);
+  expect(state.messages).toHaveLength(1);
+  expect(state.messages[0].id).toBe(streamId);
+  expect(state.messages[0].role).toBe("assistant");
+});
+
+test("ensureStreamingMessage reuses the active placeholder instead of duplicating it", () => {
+  const firstId = sessionStore.getState().ensureStreamingMessage();
+  const secondId = sessionStore.getState().ensureStreamingMessage();
+  const state = sessionStore.getState();
+
+  expect(secondId).toBe(firstId);
+  expect(state.messages).toHaveLength(1);
+  expect(state.messages[0].id).toBe(firstId);
 });
 
 test("appendStreamContent concatenates tokens to existing message", () => {

--- a/apps/cli/src/stores/agentStore.ts
+++ b/apps/cli/src/stores/agentStore.ts
@@ -8,6 +8,8 @@ export interface AgentInfo {
   teamId?: string;
   currentTool?: string;
   currentTask?: string;
+  currentThought?: string;
+  lastThought?: string;
   tokensUsed?: number;
   costUsd?: number;
   lastError?: string;

--- a/apps/cli/src/stores/agentStore.ts
+++ b/apps/cli/src/stores/agentStore.ts
@@ -14,6 +14,9 @@ export interface AgentInfo {
   pauseQueued?: boolean;
   worktreePath?: string;
   parentAgent?: string;
+  publishedFindingsCount?: number;
+  lastPublishedAt?: string;
+  lastPublishedTopic?: string;
   updatedAt: string;
 }
 

--- a/apps/cli/src/stores/sessionStore.ts
+++ b/apps/cli/src/stores/sessionStore.ts
@@ -10,6 +10,23 @@ import type {
 } from "../lib/types.js";
 import { calculateCost } from "../lib/costTracker.js";
 
+function makeStreamingMessage(id: string): Message {
+  return {
+    id,
+    role: "assistant",
+    content: "",
+    tool_calls: null,
+    tool_call_id: null,
+    token_count: null,
+    agent_name: null,
+    inserted_at: new Date().toISOString(),
+  };
+}
+
+function generateStreamingMessageId(): string {
+  return `stream-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 export interface SessionState {
   sessionId: string | null;
   messages: Message[];
@@ -52,6 +69,7 @@ export interface SessionState {
   setStreaming: (streaming: boolean) => void;
   setPendingResponse: (pending: boolean) => void;
   startStreamingMessage: (id: string) => void;
+  ensureStreamingMessage: (id?: string | null) => string;
   appendStreamContent: (id: string, token: string) => void;
   addPendingToolCall: (toolCall: ToolCall) => void;
   removePendingToolCall: (id: string) => void;
@@ -131,20 +149,25 @@ export const sessionStore = createStore<SessionState>((set, _get) => ({
   startStreamingMessage: (id) =>
     set((state) => ({
       currentStreamingMessageId: id,
-      messages: [
-        ...state.messages,
-        {
-          id,
-          role: "assistant" as const,
-          content: "",
-          tool_calls: null,
-          tool_call_id: null,
-          token_count: null,
-          agent_name: null,
-          inserted_at: new Date().toISOString(),
-        },
-      ],
+      messages: [...state.messages, makeStreamingMessage(id)],
     })),
+
+  ensureStreamingMessage: (id) => {
+    const state = _get();
+    const streamId = id ?? state.currentStreamingMessageId ?? generateStreamingMessageId();
+    const hasMessage = state.messages.some((message) => message.id === streamId);
+
+    if (!hasMessage || state.currentStreamingMessageId !== streamId) {
+      set({
+        currentStreamingMessageId: streamId,
+        messages: hasMessage
+          ? state.messages
+          : [...state.messages, makeStreamingMessage(streamId)],
+      });
+    }
+
+    return streamId;
+  },
 
   appendStreamContent: (id, token) =>
     set((state) => ({

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -28,9 +28,9 @@ defmodule Loomkin.AgentLoop do
                        "context_retrieve"
                      ])
   @coordination_warning_threshold 2
-  @coordination_abort_threshold 4
+  @coordination_abort_threshold 6
   @concierge_coordination_warning_threshold 1
-  @concierge_coordination_abort_threshold 3
+  @concierge_coordination_abort_threshold 5
   @coordination_warning """
   You have spent multiple consecutive iterations on coordination/context tools.
   Stop planning and move the task forward. Either:
@@ -1077,7 +1077,14 @@ defmodule Loomkin.AgentLoop do
   end
 
   defp build_req_messages(windowed_messages) do
-    Enum.map(windowed_messages, &to_req_message/1)
+    windowed_messages
+    |> Enum.reduce([], fn msg, acc ->
+      case to_req_message(msg) do
+        nil -> acc
+        req_msg -> [req_msg | acc]
+      end
+    end)
+    |> Enum.reverse()
   end
 
   @doc false
@@ -1105,21 +1112,26 @@ defmodule Loomkin.AgentLoop do
     end
   end
 
+  def to_req_message(nil) do
+    Logger.warning("[Kin:data] dropping nil message from llm context window")
+    nil
+  end
+
   @doc false
-  def to_req_message(msg) do
+  def to_req_message(msg) when is_map(msg) do
     role = msg[:role] || msg["role"]
     content = msg[:content] || msg["content"] || ""
     metadata = msg[:metadata] || msg["metadata"] || %{}
     tool_calls = msg[:tool_calls] || msg["tool_calls"]
 
     case role do
-      :system ->
+      role when role in [:system, "system"] ->
         ReqLLM.Context.system(content)
 
-      :user ->
+      role when role in [:user, "user"] ->
         ReqLLM.Context.user(content)
 
-      :assistant ->
+      role when role in [:assistant, "assistant"] ->
         if is_list(tool_calls) and tool_calls != [] do
           tool_calls =
             Enum.map(tool_calls, fn tc ->
@@ -1132,12 +1144,27 @@ defmodule Loomkin.AgentLoop do
           ReqLLM.Context.assistant(content, metadata: metadata)
         end
 
-      :tool ->
+      role when role in [:tool, "tool"] ->
         ReqLLM.Context.tool_result(
           msg[:tool_call_id] || msg["tool_call_id"] || "",
           content
         )
+
+      other ->
+        Logger.warning(
+          "[Kin:data] dropping malformed message from llm context window role=#{inspect(other)} payload=#{inspect(msg, limit: 120)}"
+        )
+
+        nil
     end
+  end
+
+  def to_req_message(msg) do
+    Logger.warning(
+      "[Kin:data] dropping non-map message from llm context window payload=#{inspect(msg, limit: 120)}"
+    )
+
+    nil
   end
 
   defp emit(config, event_name, payload) do

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -28,6 +28,7 @@ defmodule Loomkin.AgentLoop do
                        "context_retrieve"
                      ])
   @coordination_warning_threshold 2
+  @coordination_abort_threshold 4
   @coordination_warning """
   You have spent multiple consecutive iterations on coordination/context tools.
   Stop planning and move the task forward. Either:
@@ -36,6 +37,11 @@ defmodule Loomkin.AgentLoop do
   - provide your best current answer.
 
   Do NOT call more coordination tools until new external input arrives.
+  """
+  @coordination_abort_message """
+  Agent stopped after repeated coordination-only iterations.
+  It kept using planning/context tools without moving the task forward.
+  Try again with a more specific ask, approve delegation, or provide fresh input.
   """
 
   @type on_event :: (atom(), map() -> :ok)
@@ -309,7 +315,13 @@ defmodule Loomkin.AgentLoop do
               |> maybe_inject_cycle_warning(classified.tool_calls, config)
               |> maybe_inject_coordination_warning(classified.tool_calls, config)
 
-            do_loop(messages, config, iteration + 1)
+            case maybe_stop_coordination_loop(messages, config, response) do
+              {:stop, response_text, messages, metadata} ->
+                {:ok, response_text, messages, metadata}
+
+              {:continue, messages} ->
+                do_loop(messages, config, iteration + 1)
+            end
 
           {:paused, reason, messages} ->
             emit_usage(config, response)
@@ -904,6 +916,26 @@ defmodule Loomkin.AgentLoop do
   end
 
   def coordination_only_tool_calls?(_tool_calls), do: false
+
+  @doc false
+  def maybe_stop_coordination_loop(messages, config, response) do
+    streak = Process.get(:loomkin_coordination_streak, 0)
+
+    if streak >= @coordination_abort_threshold do
+      Logger.warning(
+        "[Kin:loop] coordination_abort agent=#{config.agent_name || "-"} team=#{config.team_id || "-"} streak=#{streak}"
+      )
+
+      assistant_msg = %{role: :assistant, content: String.trim(@coordination_abort_message)}
+      emit(config, :coordination_loop_stopped, %{streak: streak})
+      emit(config, :new_message, assistant_msg)
+
+      {:stop, assistant_msg.content, messages ++ [assistant_msg],
+       %{usage: extract_usage(response)}}
+    else
+      {:continue, messages}
+    end
+  end
 
   defp tool_call_signature(tool_calls) when is_list(tool_calls) do
     tool_calls

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -61,6 +61,10 @@ defmodule Loomkin.AgentLoop do
   - ask the human one focused question, or
   - give the user your best current synthesis.
 
+  If the latest user message already gave you a concrete task, do NOT ask what they want next
+  and do NOT ask them to restate the task. Route it now.
+  If clarification is truly required, ask only for the one missing detail.
+
   Do NOT run more coordination/context tools right now.
   Do NOT become the deepest worker in the loop.
   """

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -1204,9 +1204,11 @@ defmodule Loomkin.AgentLoop do
 
   @doc false
   def normalize_history_messages(messages) when is_list(messages) do
+    tool_result_ids = extract_tool_result_ids(messages)
+
     messages
     |> Enum.reduce([], fn msg, acc ->
-      normalize_history_message(msg, acc)
+      normalize_history_message(msg, acc, tool_result_ids)
     end)
     |> Enum.reverse()
   end
@@ -1293,18 +1295,18 @@ defmodule Loomkin.AgentLoop do
     nil
   end
 
-  defp normalize_history_message(nil, acc) do
+  defp normalize_history_message(nil, acc, _tool_result_ids) do
     Logger.warning("[Kin:data] dropping nil message from agent history")
     acc
   end
 
-  defp normalize_history_message(%{} = msg, acc) do
+  defp normalize_history_message(%{} = msg, acc, tool_result_ids) do
     cond do
       valid_history_role?(msg[:role] || msg["role"]) ->
         [normalize_regular_history_message(msg) | acc]
 
       raw_tool_call_message?(msg) ->
-        attach_or_drop_orphan_tool_call(msg, acc)
+        attach_or_rebuild_or_drop_orphan_tool_call(msg, acc, tool_result_ids)
 
       true ->
         Logger.warning(
@@ -1315,7 +1317,7 @@ defmodule Loomkin.AgentLoop do
     end
   end
 
-  defp normalize_history_message(msg, acc) do
+  defp normalize_history_message(msg, acc, _tool_result_ids) do
     Logger.warning(
       "[Kin:data] dropping non-map message from agent history payload=#{inspect(msg, limit: 120)}"
     )
@@ -1359,7 +1361,11 @@ defmodule Loomkin.AgentLoop do
 
   defp raw_tool_call_message?(_), do: false
 
-  defp attach_or_drop_orphan_tool_call(msg, [%{role: role} = assistant | rest])
+  defp attach_or_rebuild_or_drop_orphan_tool_call(
+         msg,
+         [%{role: role} = assistant | rest],
+         _tool_result_ids
+       )
        when role in [:assistant, "assistant"] do
     normalized_tool_call = normalize_tool_call(msg)
     tool_calls = normalize_tool_calls(assistant[:tool_calls] || assistant["tool_calls"] || [])
@@ -1371,12 +1377,23 @@ defmodule Loomkin.AgentLoop do
     [Map.put(assistant, :tool_calls, tool_calls ++ [normalized_tool_call]) | rest]
   end
 
-  defp attach_or_drop_orphan_tool_call(msg, acc) do
-    Logger.warning(
-      "[Kin:data] dropping orphan tool_call from agent history payload=#{inspect(msg, limit: 120)}"
-    )
+  defp attach_or_rebuild_or_drop_orphan_tool_call(msg, acc, tool_result_ids) do
+    normalized_tool_call = normalize_tool_call(msg)
+    tool_call_id = normalized_tool_call[:id]
 
-    acc
+    if is_binary(tool_call_id) and MapSet.member?(tool_result_ids, tool_call_id) do
+      Logger.warning(
+        "[Kin:data] rebuilt orphan tool_call with synthetic assistant id=#{inspect(tool_call_id)} name=#{inspect(normalized_tool_call[:name])}"
+      )
+
+      [%{role: :assistant, content: "", tool_calls: [normalized_tool_call]} | acc]
+    else
+      Logger.warning(
+        "[Kin:data] dropping orphan tool_call from agent history payload=#{inspect(msg, limit: 120)}"
+      )
+
+      acc
+    end
   end
 
   defp normalize_tool_calls(tool_calls) when is_list(tool_calls) do
@@ -1393,6 +1410,23 @@ defmodule Loomkin.AgentLoop do
       name: tool_call[:name] || tool_call["name"],
       arguments: tool_call[:arguments] || tool_call["arguments"] || %{}
     }
+  end
+
+  defp extract_tool_result_ids(messages) when is_list(messages) do
+    messages
+    |> Enum.flat_map(fn
+      %{role: role, tool_call_id: tool_call_id}
+      when role in [:tool, "tool"] and is_binary(tool_call_id) ->
+        [tool_call_id]
+
+      %{"role" => role, "tool_call_id" => tool_call_id}
+      when role in [:tool, "tool"] and is_binary(tool_call_id) ->
+        [tool_call_id]
+
+      _ ->
+        []
+    end)
+    |> MapSet.new()
   end
 
   defp valid_history_role?(role),

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -964,7 +964,7 @@ defmodule Loomkin.AgentLoop do
     Process.put(:loomkin_prev_tool_signature, current_sig)
 
     if prev_sig == current_sig and prev_sig != nil do
-      warning_msg = %{role: :user, content: @cycle_warning}
+      warning_msg = %{role: :system, content: @cycle_warning}
       emit(config, :cycle_detected, %{signature: current_sig})
       emit(config, :new_message, warning_msg)
       messages ++ [warning_msg]
@@ -991,7 +991,7 @@ defmodule Loomkin.AgentLoop do
         )
 
         warning_msg = %{
-          role: :user,
+          role: :system,
           content: warning_content
         }
 
@@ -1031,7 +1031,7 @@ defmodule Loomkin.AgentLoop do
         )
 
         warning_msg = %{
-          role: :user,
+          role: :system,
           content: String.trim(@research_warning)
         }
 

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -253,6 +253,8 @@ defmodule Loomkin.AgentLoop do
   end
 
   defp do_loop(messages, config, iteration) do
+    messages = normalize_history_messages(messages)
+
     # Auto-offload context if agent is above threshold
     messages = maybe_auto_offload(messages, config)
 
@@ -1190,6 +1192,7 @@ defmodule Loomkin.AgentLoop do
 
   defp build_req_messages(windowed_messages) do
     windowed_messages
+    |> normalize_history_messages()
     |> Enum.reduce([], fn msg, acc ->
       case to_req_message(msg) do
         nil -> acc
@@ -1198,6 +1201,17 @@ defmodule Loomkin.AgentLoop do
     end)
     |> Enum.reverse()
   end
+
+  @doc false
+  def normalize_history_messages(messages) when is_list(messages) do
+    messages
+    |> Enum.reduce([], fn msg, acc ->
+      normalize_history_message(msg, acc)
+    end)
+    |> Enum.reverse()
+  end
+
+  def normalize_history_messages(messages), do: messages
 
   @doc false
   def assistant_message_from_response(classified, response) when is_map(classified) do
@@ -1278,6 +1292,111 @@ defmodule Loomkin.AgentLoop do
 
     nil
   end
+
+  defp normalize_history_message(nil, acc) do
+    Logger.warning("[Kin:data] dropping nil message from agent history")
+    acc
+  end
+
+  defp normalize_history_message(%{} = msg, acc) do
+    cond do
+      valid_history_role?(msg[:role] || msg["role"]) ->
+        [normalize_regular_history_message(msg) | acc]
+
+      raw_tool_call_message?(msg) ->
+        attach_or_drop_orphan_tool_call(msg, acc)
+
+      true ->
+        Logger.warning(
+          "[Kin:data] dropping malformed message from agent history role=#{inspect(msg[:role] || msg["role"])} payload=#{inspect(msg, limit: 120)}"
+        )
+
+        acc
+    end
+  end
+
+  defp normalize_history_message(msg, acc) do
+    Logger.warning(
+      "[Kin:data] dropping non-map message from agent history payload=#{inspect(msg, limit: 120)}"
+    )
+
+    acc
+  end
+
+  defp normalize_regular_history_message(msg) do
+    role = msg[:role] || msg["role"]
+    content = msg[:content] || msg["content"] || ""
+    metadata = msg[:metadata] || msg["metadata"]
+    tool_call_id = msg[:tool_call_id] || msg["tool_call_id"]
+    tool_calls = normalize_tool_calls(msg[:tool_calls] || msg["tool_calls"] || [])
+
+    %{}
+    |> Map.put(:role, role)
+    |> Map.put(:content, content)
+    |> maybe_put_non_empty(:metadata, metadata)
+    |> maybe_put_non_empty(:tool_call_id, tool_call_id)
+    |> maybe_put_non_empty(:tool_calls, tool_calls)
+    |> maybe_copy_history_key(msg, :priority)
+    |> maybe_copy_history_key(msg, "priority")
+  end
+
+  defp maybe_copy_history_key(map, source, key) do
+    case Map.fetch(source, key) do
+      {:ok, value} -> Map.put_new(map, :priority, value)
+      :error -> map
+    end
+  end
+
+  defp maybe_put_non_empty(map, _key, nil), do: map
+  defp maybe_put_non_empty(map, _key, []), do: map
+  defp maybe_put_non_empty(map, key, value), do: Map.put(map, key, value)
+
+  defp raw_tool_call_message?(msg) when is_map(msg) do
+    (is_binary(msg[:name] || msg["name"]) or is_atom(msg[:name])) and
+      is_map(msg[:arguments] || msg["arguments"] || %{}) and
+      not valid_history_role?(msg[:role] || msg["role"])
+  end
+
+  defp raw_tool_call_message?(_), do: false
+
+  defp attach_or_drop_orphan_tool_call(msg, [%{role: role} = assistant | rest])
+       when role in [:assistant, "assistant"] do
+    normalized_tool_call = normalize_tool_call(msg)
+    tool_calls = normalize_tool_calls(assistant[:tool_calls] || assistant["tool_calls"] || [])
+
+    Logger.warning(
+      "[Kin:data] repaired orphan tool_call in agent history id=#{inspect(normalized_tool_call[:id])} name=#{inspect(normalized_tool_call[:name])}"
+    )
+
+    [Map.put(assistant, :tool_calls, tool_calls ++ [normalized_tool_call]) | rest]
+  end
+
+  defp attach_or_drop_orphan_tool_call(msg, acc) do
+    Logger.warning(
+      "[Kin:data] dropping orphan tool_call from agent history payload=#{inspect(msg, limit: 120)}"
+    )
+
+    acc
+  end
+
+  defp normalize_tool_calls(tool_calls) when is_list(tool_calls) do
+    tool_calls
+    |> Enum.filter(&raw_tool_call_message?/1)
+    |> Enum.map(&normalize_tool_call/1)
+  end
+
+  defp normalize_tool_calls(_), do: []
+
+  defp normalize_tool_call(tool_call) do
+    %{
+      id: tool_call[:id] || tool_call["id"] || "call_#{Ecto.UUID.generate()}",
+      name: tool_call[:name] || tool_call["name"],
+      arguments: tool_call[:arguments] || tool_call["arguments"] || %{}
+    }
+  end
+
+  defp valid_history_role?(role),
+    do: role in [:system, "system", :user, "user", :assistant, "assistant", :tool, "tool"]
 
   defp emit(config, event_name, payload) do
     config.on_event.(event_name, payload)

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -260,11 +260,7 @@ defmodule Loomkin.AgentLoop do
     })
 
     # Build assistant message with tool calls
-    assistant_msg = %{
-      role: :assistant,
-      content: classified.text,
-      tool_calls: classified.tool_calls
-    }
+    assistant_msg = assistant_message_from_response(classified, response)
 
     messages = messages ++ [assistant_msg]
     emit(config, :new_message, assistant_msg)
@@ -320,7 +316,7 @@ defmodule Loomkin.AgentLoop do
        ) do
     response_text = classified.text
 
-    assistant_msg = %{role: :assistant, content: response_text}
+    assistant_msg = assistant_message_from_response(classified, response)
     messages = messages ++ [assistant_msg]
     emit(config, :new_message, assistant_msg)
 
@@ -881,34 +877,67 @@ defmodule Loomkin.AgentLoop do
   end
 
   defp build_req_messages(windowed_messages) do
-    Enum.map(windowed_messages, fn msg ->
-      case msg.role do
-        :system ->
-          ReqLLM.Context.system(msg.content)
+    Enum.map(windowed_messages, &to_req_message/1)
+  end
 
-        :user ->
-          ReqLLM.Context.user(msg.content)
+  @doc false
+  def assistant_message_from_response(classified, response) when is_map(classified) do
+    base = %{
+      role: :assistant,
+      content: classified[:text] || classified["text"] || ""
+    }
 
-        :assistant ->
-          if msg[:tool_calls] && msg[:tool_calls] != [] do
-            tool_calls =
-              Enum.map(msg.tool_calls, fn tc ->
-                {tc[:name] || tc["name"], tc[:arguments] || tc["arguments"] || %{},
-                 id: tc[:id] || tc["id"]}
-              end)
+    base =
+      case classified[:tool_calls] || classified["tool_calls"] do
+        tool_calls when is_list(tool_calls) and tool_calls != [] ->
+          Map.put(base, :tool_calls, tool_calls)
 
-            ReqLLM.Context.assistant(msg.content || "", tool_calls: tool_calls)
-          else
-            ReqLLM.Context.assistant(msg.content || "")
-          end
-
-        :tool ->
-          ReqLLM.Context.tool_result(
-            msg[:tool_call_id] || "",
-            msg.content || ""
-          )
+        _ ->
+          base
       end
-    end)
+
+    case response do
+      %{message: %{metadata: metadata}} when is_map(metadata) and map_size(metadata) > 0 ->
+        Map.put(base, :metadata, metadata)
+
+      _ ->
+        base
+    end
+  end
+
+  @doc false
+  def to_req_message(msg) do
+    role = msg[:role] || msg["role"]
+    content = msg[:content] || msg["content"] || ""
+    metadata = msg[:metadata] || msg["metadata"] || %{}
+    tool_calls = msg[:tool_calls] || msg["tool_calls"]
+
+    case role do
+      :system ->
+        ReqLLM.Context.system(content)
+
+      :user ->
+        ReqLLM.Context.user(content)
+
+      :assistant ->
+        if is_list(tool_calls) and tool_calls != [] do
+          tool_calls =
+            Enum.map(tool_calls, fn tc ->
+              {tc[:name] || tc["name"], tc[:arguments] || tc["arguments"] || %{},
+               id: tc[:id] || tc["id"]}
+            end)
+
+          ReqLLM.Context.assistant(content, tool_calls: tool_calls, metadata: metadata)
+        else
+          ReqLLM.Context.assistant(content, metadata: metadata)
+        end
+
+      :tool ->
+        ReqLLM.Context.tool_result(
+          msg[:tool_call_id] || msg["tool_call_id"] || "",
+          content
+        )
+    end
   end
 
   defp emit(config, event_name, payload) do

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -958,7 +958,8 @@ defmodule Loomkin.AgentLoop do
                    "the same calls. Either use the results you already have to form a " <>
                    "final answer, or try a different approach."
 
-  defp maybe_inject_cycle_warning(tool_calls, messages, config) do
+  @doc false
+  def maybe_inject_cycle_warning(messages, tool_calls, config) do
     prev_sig = Process.get(:loomkin_prev_tool_signature)
     current_sig = tool_call_signature(tool_calls)
     Process.put(:loomkin_prev_tool_signature, current_sig)

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -254,6 +254,8 @@ defmodule Loomkin.AgentLoop do
          config,
          iteration
        ) do
+    log_tool_plan(config, iteration, classified.tool_calls)
+
     emit(config, :tool_calls_received, %{
       tool_calls: classified.tool_calls,
       text: classified.text
@@ -761,6 +763,61 @@ defmodule Loomkin.AgentLoop do
   defp maybe_track_read_file(_tool_name, _tool_args, _project_path, _result_text), do: :ok
 
   # -- Cycle detection ---------------------------------------------------------
+
+  defp log_tool_plan(config, iteration, tool_calls) do
+    summaries =
+      tool_calls
+      |> Enum.map(&summarize_tool_call/1)
+      |> Enum.join(" | ")
+
+    Logger.info(
+      "[Kin:loop] tool_plan agent=#{config.agent_name || "-"} team=#{config.team_id || "-"} iteration=#{iteration} count=#{length(tool_calls)} tools=#{summaries}"
+    )
+  end
+
+  defp summarize_tool_call(tool_call) do
+    name = tool_call[:name] || tool_call["name"] || "unknown"
+    args = tool_call[:arguments] || tool_call["arguments"] || %{}
+    "#{name}(#{tool_arg_preview(args)})"
+  end
+
+  defp tool_arg_preview(args) when is_map(args) do
+    interesting_keys =
+      ~w(query query_type search_term title topic node_type purpose team_name limit)a
+
+    preview_parts =
+      args
+      |> Enum.filter(fn {key, _value} ->
+        key in interesting_keys or to_string(key) in Enum.map(interesting_keys, &to_string/1)
+      end)
+      |> Enum.take(3)
+      |> Enum.map(fn {key, value} -> "#{key}=#{preview_tool_value(value)}" end)
+
+    case preview_parts do
+      [] ->
+        args
+        |> Map.keys()
+        |> Enum.map(&to_string/1)
+        |> Enum.sort()
+        |> Enum.take(3)
+        |> Enum.join(",")
+
+      parts ->
+        Enum.join(parts, ", ")
+    end
+  end
+
+  defp tool_arg_preview(_args), do: "-"
+
+  defp preview_tool_value(value) when is_binary(value) do
+    value
+    |> String.replace(~r/\s+/, " ")
+    |> String.slice(0, 40)
+  end
+
+  defp preview_tool_value(value) when is_list(value), do: "list[#{length(value)}]"
+  defp preview_tool_value(value) when is_map(value), do: "map(keys=#{map_size(value)})"
+  defp preview_tool_value(value), do: inspect(value, limit: 20)
 
   @cycle_warning "You already called the same tool(s) with identical arguments " <>
                    "in the previous iteration and got the same results. Do NOT repeat " <>

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -29,6 +29,8 @@ defmodule Loomkin.AgentLoop do
                      ])
   @coordination_warning_threshold 2
   @coordination_abort_threshold 4
+  @concierge_coordination_warning_threshold 1
+  @concierge_coordination_abort_threshold 3
   @coordination_warning """
   You have spent multiple consecutive iterations on coordination/context tools.
   Stop planning and move the task forward. Either:
@@ -38,9 +40,26 @@ defmodule Loomkin.AgentLoop do
 
   Do NOT call more coordination tools until new external input arrives.
   """
+  @concierge_coordination_warning """
+  You are the concierge. Stay available for the human instead of sinking into research or planning.
+  You have already done enough orientation.
+
+  Your next step must be one of:
+  - spawn a specialist or team to do the actual research/work,
+  - ask the human one focused question, or
+  - give the user your best current synthesis.
+
+  Do NOT run more coordination/context tools right now.
+  Do NOT become the deepest worker in the loop.
+  """
   @coordination_abort_message """
   Agent stopped after repeated coordination-only iterations.
   It kept using planning/context tools without moving the task forward.
+  Try again with a more specific ask, approve delegation, or provide fresh input.
+  """
+  @concierge_coordination_abort_message """
+  Concierge stopped after repeated coordination-only iterations.
+  It was staying busy on planning/context work instead of delegating and staying available for the user.
   Try again with a more specific ask, approve delegation, or provide fresh input.
   """
 
@@ -882,10 +901,12 @@ defmodule Loomkin.AgentLoop do
       prev_streak = Process.get(:loomkin_coordination_streak, 0)
       streak = prev_streak + 1
       Process.put(:loomkin_coordination_streak, streak)
+      role = Map.get(config, :role)
+      threshold = coordination_warning_threshold(role)
 
-      if prev_streak < @coordination_warning_threshold and
-           streak >= @coordination_warning_threshold do
+      if prev_streak < threshold and streak >= threshold do
         tools = tool_calls |> Enum.map(&tool_name/1) |> Enum.uniq()
+        warning_content = coordination_warning_message(role)
 
         Logger.warning(
           "[Kin:loop] coordination_streak agent=#{config.agent_name || "-"} team=#{config.team_id || "-"} streak=#{streak} tools=#{Enum.join(tools, ",")}"
@@ -893,7 +914,7 @@ defmodule Loomkin.AgentLoop do
 
         warning_msg = %{
           role: :user,
-          content: @coordination_warning
+          content: warning_content
         }
 
         emit(config, :coordination_loop_detected, %{streak: streak, tools: tools})
@@ -920,13 +941,19 @@ defmodule Loomkin.AgentLoop do
   @doc false
   def maybe_stop_coordination_loop(messages, config, response) do
     streak = Process.get(:loomkin_coordination_streak, 0)
+    role = Map.get(config, :role)
+    threshold = coordination_abort_threshold(role)
 
-    if streak >= @coordination_abort_threshold do
+    if streak >= threshold do
       Logger.warning(
         "[Kin:loop] coordination_abort agent=#{config.agent_name || "-"} team=#{config.team_id || "-"} streak=#{streak}"
       )
 
-      assistant_msg = %{role: :assistant, content: String.trim(@coordination_abort_message)}
+      assistant_msg = %{
+        role: :assistant,
+        content: coordination_abort_message(role)
+      }
+
       emit(config, :coordination_loop_stopped, %{streak: streak})
       emit(config, :new_message, assistant_msg)
 
@@ -936,6 +963,20 @@ defmodule Loomkin.AgentLoop do
       {:continue, messages}
     end
   end
+
+  defp coordination_warning_threshold(:concierge), do: @concierge_coordination_warning_threshold
+  defp coordination_warning_threshold(_role), do: @coordination_warning_threshold
+
+  defp coordination_abort_threshold(:concierge), do: @concierge_coordination_abort_threshold
+  defp coordination_abort_threshold(_role), do: @coordination_abort_threshold
+
+  defp coordination_warning_message(:concierge), do: String.trim(@concierge_coordination_warning)
+  defp coordination_warning_message(_role), do: String.trim(@coordination_warning)
+
+  defp coordination_abort_message(:concierge),
+    do: String.trim(@concierge_coordination_abort_message)
+
+  defp coordination_abort_message(_role), do: String.trim(@coordination_abort_message)
 
   defp tool_call_signature(tool_calls) when is_list(tool_calls) do
     tool_calls

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -27,10 +27,22 @@ defmodule Loomkin.AgentLoop do
                        "team_progress",
                        "context_retrieve"
                      ])
+  @research_scan_tools MapSet.new([
+                         "file_read",
+                         "file_search",
+                         "content_search",
+                         "directory_list",
+                         "decision_query",
+                         "search_keepers",
+                         "context_retrieve",
+                         "introspect_decision_history",
+                         "introspect_failure_patterns"
+                       ])
   @coordination_warning_threshold 2
   @coordination_abort_threshold 6
   @concierge_coordination_warning_threshold 1
   @concierge_coordination_abort_threshold 5
+  @research_warning_threshold 3
   @coordination_warning """
   You have spent multiple consecutive iterations on coordination/context tools.
   Stop planning and move the task forward. Either:
@@ -61,6 +73,18 @@ defmodule Loomkin.AgentLoop do
   Concierge stopped after repeated coordination-only iterations.
   It was staying busy on planning/context work instead of delegating and staying available for the user.
   Try again with a more specific ask, approve delegation, or provide fresh input.
+  """
+  @research_warning """
+  You are a researcher. You have already spent multiple iterations scanning and reading.
+  If you can answer the assigned research questions, stop exploring and publish what you found now.
+
+  Next step:
+  - summarize the concrete findings,
+  - persist them with context_offload,
+  - broadcast the key points with peer_discovery or peer_message,
+  - then finish with peer_complete_task.
+
+  Do NOT keep researching just to be thorough if you already have enough to answer.
   """
 
   @type on_event :: (atom(), map() -> :ok)
@@ -105,6 +129,8 @@ defmodule Loomkin.AgentLoop do
     Process.put(:loomkin_prev_tool_signature, nil)
     # Track repeated coordination-only turns so we can steer agents out of planning loops.
     Process.put(:loomkin_coordination_streak, 0)
+    # Track researchers who keep scanning without publishing findings.
+    Process.put(:loomkin_research_scan_streak, 0)
 
     # Bootstrap failure memory: inject lessons from past errors
     messages = bootstrap_failure_memory(messages, config)
@@ -333,6 +359,7 @@ defmodule Loomkin.AgentLoop do
               messages
               |> maybe_inject_cycle_warning(classified.tool_calls, config)
               |> maybe_inject_coordination_warning(classified.tool_calls, config)
+              |> maybe_inject_research_warning(classified.tool_calls, config)
 
             case maybe_stop_coordination_loop(messages, config, response) do
               {:stop, response_text, messages, metadata} ->
@@ -937,6 +964,46 @@ defmodule Loomkin.AgentLoop do
   end
 
   def coordination_only_tool_calls?(_tool_calls), do: false
+
+  @doc false
+  def maybe_inject_research_warning(messages, tool_calls, config) do
+    if Map.get(config, :role) == :researcher and research_scan_only_tool_calls?(tool_calls) do
+      prev_streak = Process.get(:loomkin_research_scan_streak, 0)
+      streak = prev_streak + 1
+      Process.put(:loomkin_research_scan_streak, streak)
+
+      if prev_streak < @research_warning_threshold and streak >= @research_warning_threshold do
+        tools = tool_calls |> Enum.map(&tool_name/1) |> Enum.uniq()
+
+        Logger.warning(
+          "[Kin:loop] research_scan_streak agent=#{config.agent_name || "-"} team=#{config.team_id || "-"} streak=#{streak} tools=#{Enum.join(tools, ",")}"
+        )
+
+        warning_msg = %{
+          role: :user,
+          content: String.trim(@research_warning)
+        }
+
+        emit(config, :research_loop_detected, %{streak: streak, tools: tools})
+        emit(config, :new_message, warning_msg)
+        messages ++ [warning_msg]
+      else
+        messages
+      end
+    else
+      Process.put(:loomkin_research_scan_streak, 0)
+      messages
+    end
+  end
+
+  @doc false
+  def research_scan_only_tool_calls?(tool_calls) when is_list(tool_calls) and tool_calls != [] do
+    Enum.all?(tool_calls, fn tool_call ->
+      MapSet.member?(@research_scan_tools, tool_name(tool_call))
+    end)
+  end
+
+  def research_scan_only_tool_calls?(_tool_calls), do: false
 
   @doc false
   def maybe_stop_coordination_loop(messages, config, response) do

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -41,7 +41,7 @@ defmodule Loomkin.AgentLoop do
   @coordination_warning_threshold 2
   @coordination_abort_threshold 6
   @concierge_coordination_warning_threshold 1
-  @concierge_coordination_abort_threshold 5
+  @concierge_coordination_abort_threshold 7
   @research_warning_threshold 3
   @coordination_warning """
   You have spent multiple consecutive iterations on coordination/context tools.

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -86,6 +86,12 @@ defmodule Loomkin.AgentLoop do
 
   Do NOT keep researching just to be thorough if you already have enough to answer.
   """
+  @empty_publication_state %{
+    offloaded: false,
+    discovery_shared: false,
+    published_count: 0,
+    last_topic: nil
+  }
 
   @type on_event :: (atom(), map() -> :ok)
 
@@ -131,6 +137,8 @@ defmodule Loomkin.AgentLoop do
     Process.put(:loomkin_coordination_streak, 0)
     # Track researchers who keep scanning without publishing findings.
     Process.put(:loomkin_research_scan_streak, 0)
+    # Track whether this loop has already published durable findings.
+    Process.put(:loomkin_publication_state, @empty_publication_state)
 
     # Bootstrap failure memory: inject lessons from past errors
     messages = bootstrap_failure_memory(messages, config)
@@ -461,7 +469,9 @@ defmodule Loomkin.AgentLoop do
       agent_name: config.agent_name,
       team_id: config.team_id,
       parent_team_id: parent_team_id,
-      model: config.model
+      model: config.model,
+      role: config.role,
+      publication_state: current_publication_state()
     }
 
     emit(config, :tool_executing, %{tool_name: tool_name, tool_target: tool_path})
@@ -571,6 +581,7 @@ defmodule Loomkin.AgentLoop do
 
                   # Track successful file_read calls
                   maybe_track_read_file(tool_name, tool_args, effective_path, result_text)
+                  maybe_track_findings_publication(tool_name, tool_args, result_text, config)
 
                   messages =
                     record_tool_result(messages, config, tool_name, tool_call_id, result_text)
@@ -844,6 +855,40 @@ defmodule Loomkin.AgentLoop do
   end
 
   defp maybe_track_read_file(_tool_name, _tool_args, _project_path, _result_text), do: :ok
+
+  defp maybe_track_findings_publication(tool_name, tool_args, result_text, config) do
+    cond do
+      tool_name in ["context_offload", :context_offload] and
+          String.starts_with?(result_text, "Offloaded ") ->
+        topic = tool_args["topic"] || tool_args[:topic]
+
+        update_publication_state(fn state ->
+          state
+          |> Map.put(:offloaded, true)
+          |> Map.put(:last_topic, topic || state.last_topic)
+          |> Map.update!(:published_count, &(&1 + 1))
+        end)
+
+        emit(config, :context_offloaded, %{topic: topic, source: "context_offload"})
+
+      tool_name in ["peer_discovery", :peer_discovery] and
+          String.starts_with?(result_text, "Discovery broadcast") ->
+        update_publication_state(fn state ->
+          Map.put(state, :discovery_shared, true)
+        end)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp current_publication_state do
+    Process.get(:loomkin_publication_state, @empty_publication_state)
+  end
+
+  defp update_publication_state(updater) when is_function(updater, 1) do
+    Process.put(:loomkin_publication_state, updater.(current_publication_state()))
+  end
 
   # -- Cycle detection ---------------------------------------------------------
 

--- a/loomkin-server/lib/loomkin/agent_loop.ex
+++ b/loomkin-server/lib/loomkin/agent_loop.ex
@@ -19,6 +19,24 @@ defmodule Loomkin.AgentLoop do
 
   @default_max_rate_limit_retries 3
   @default_max_iterations 30
+  @orientation_tools MapSet.new([
+                       "decision_query",
+                       "query_backlog",
+                       "search_keepers",
+                       "decision_log",
+                       "team_progress",
+                       "context_retrieve"
+                     ])
+  @coordination_warning_threshold 2
+  @coordination_warning """
+  You have spent multiple consecutive iterations on coordination/context tools.
+  Stop planning and move the task forward. Either:
+  - delegate to a specialist,
+  - ask the human one focused question, or
+  - provide your best current answer.
+
+  Do NOT call more coordination tools until new external input arrives.
+  """
 
   @type on_event :: (atom(), map() -> :ok)
 
@@ -60,6 +78,8 @@ defmodule Loomkin.AgentLoop do
     Process.put(:loomkin_read_files, MapSet.new())
     # Initialize cycle detection tracker (previous tool-call signature)
     Process.put(:loomkin_prev_tool_signature, nil)
+    # Track repeated coordination-only turns so we can steer agents out of planning loops.
+    Process.put(:loomkin_coordination_streak, 0)
 
     # Bootstrap failure memory: inject lessons from past errors
     messages = bootstrap_failure_memory(messages, config)
@@ -283,7 +303,12 @@ defmodule Loomkin.AgentLoop do
         case execute_tool_calls(classified.tool_calls, messages, config, iteration) do
           {:ok, messages} ->
             emit_usage(config, response)
-            messages = maybe_inject_cycle_warning(classified.tool_calls, messages, config)
+
+            messages =
+              messages
+              |> maybe_inject_cycle_warning(classified.tool_calls, config)
+              |> maybe_inject_coordination_warning(classified.tool_calls, config)
+
             do_loop(messages, config, iteration + 1)
 
           {:paused, reason, messages} ->
@@ -839,6 +864,47 @@ defmodule Loomkin.AgentLoop do
     end
   end
 
+  @doc false
+  def maybe_inject_coordination_warning(messages, tool_calls, config) do
+    if coordination_only_tool_calls?(tool_calls) do
+      prev_streak = Process.get(:loomkin_coordination_streak, 0)
+      streak = prev_streak + 1
+      Process.put(:loomkin_coordination_streak, streak)
+
+      if prev_streak < @coordination_warning_threshold and
+           streak >= @coordination_warning_threshold do
+        tools = tool_calls |> Enum.map(&tool_name/1) |> Enum.uniq()
+
+        Logger.warning(
+          "[Kin:loop] coordination_streak agent=#{config.agent_name || "-"} team=#{config.team_id || "-"} streak=#{streak} tools=#{Enum.join(tools, ",")}"
+        )
+
+        warning_msg = %{
+          role: :user,
+          content: @coordination_warning
+        }
+
+        emit(config, :coordination_loop_detected, %{streak: streak, tools: tools})
+        emit(config, :new_message, warning_msg)
+        messages ++ [warning_msg]
+      else
+        messages
+      end
+    else
+      Process.put(:loomkin_coordination_streak, 0)
+      messages
+    end
+  end
+
+  @doc false
+  def coordination_only_tool_calls?(tool_calls) when is_list(tool_calls) and tool_calls != [] do
+    Enum.all?(tool_calls, fn tool_call ->
+      MapSet.member?(@orientation_tools, tool_name(tool_call))
+    end)
+  end
+
+  def coordination_only_tool_calls?(_tool_calls), do: false
+
   defp tool_call_signature(tool_calls) when is_list(tool_calls) do
     tool_calls
     |> Enum.map(fn tc ->
@@ -848,6 +914,10 @@ defmodule Loomkin.AgentLoop do
     end)
     |> Enum.sort()
     |> Enum.join("|")
+  end
+
+  defp tool_name(tool_call) do
+    tool_call[:name] || tool_call["name"] || "unknown"
   end
 
   # -- Helpers -----------------------------------------------------------------

--- a/loomkin-server/lib/loomkin/conversations/agent.ex
+++ b/loomkin-server/lib/loomkin/conversations/agent.ex
@@ -134,6 +134,10 @@ defmodule Loomkin.Conversations.Agent do
     messages = build_messages(history, topic, context, state)
     tool_defs = Jido.AI.ToolAdapter.from_actions(@conversation_tools)
 
+    Logger.debug(
+      "[Kin:conversation_agent] turn_start conversation=#{state.conversation_id} agent=#{state.name} model=#{inspect(state.model)} history_entries=#{length(history)} prompt_messages=#{length(messages)} opening_turn=#{history == []}"
+    )
+
     exec_context = %{
       conversation_id: state.conversation_id,
       agent_name: state.name,
@@ -147,6 +151,12 @@ defmodule Loomkin.Conversations.Agent do
          end) do
       {:ok, response} ->
         tokens = extract_token_count(response)
+        tool_calls = extract_tool_calls(response)
+
+        Logger.debug(
+          "[Kin:conversation_agent] turn_done conversation=#{state.conversation_id} agent=#{state.name} tokens=#{tokens} tool_calls=#{length(tool_calls)}"
+        )
+
         execute_tool_calls(response, exec_context)
         {:ok, tokens}
 
@@ -157,7 +167,8 @@ defmodule Loomkin.Conversations.Agent do
     end
   end
 
-  defp build_messages(history, topic, context, state) do
+  @doc false
+  def build_messages(history, topic, context, state) do
     system = Persona.system_prompt(state.persona, topic, context)
 
     conversation_msgs =
@@ -171,7 +182,20 @@ defmodule Loomkin.Conversations.Agent do
         end
       end)
 
-    [%{role: "system", content: system} | conversation_msgs]
+    seeded_msgs =
+      if conversation_msgs == [] do
+        [
+          %{
+            role: "user",
+            content:
+              "It is your turn to open the discussion on #{topic}. Share your perspective in 2-4 sentences, or use one of the conversation tools if that fits better."
+          }
+        ]
+      else
+        conversation_msgs
+      end
+
+    [%{role: "system", content: system} | seeded_msgs]
   end
 
   defp execute_tool_calls(response, exec_context) do
@@ -194,7 +218,17 @@ defmodule Loomkin.Conversations.Agent do
     end)
   end
 
-  defp extract_tool_calls(response) when is_map(response) do
+  @doc false
+  def extract_tool_calls(%ReqLLM.Response{} = response) do
+    response
+    |> ReqLLM.Response.tool_calls()
+    |> Enum.map(fn tool_call ->
+      tool_call = ReqLLM.ToolCall.from_map(tool_call)
+      {tool_call.name, tool_call.arguments}
+    end)
+  end
+
+  def extract_tool_calls(response) when is_map(response) do
     content = Map.get(response, "content", Map.get(response, :content, []))
 
     content
@@ -211,7 +245,7 @@ defmodule Loomkin.Conversations.Agent do
     end)
   end
 
-  defp extract_tool_calls(_), do: []
+  def extract_tool_calls(_), do: []
 
   defp extract_token_count(response) when is_map(response) do
     usage = Map.get(response, "usage", Map.get(response, :usage, %{}))

--- a/loomkin-server/lib/loomkin/decisions/graph.ex
+++ b/loomkin-server/lib/loomkin/decisions/graph.ex
@@ -84,6 +84,10 @@ defmodule Loomkin.Decisions.Graph do
     query |> where([n], n.status == ^status) |> apply_node_filters(rest)
   end
 
+  defp apply_node_filters(query, [{:title, title} | rest]) do
+    query |> where([n], n.title == ^title) |> apply_node_filters(rest)
+  end
+
   defp apply_node_filters(query, [{:session_id, sid} | rest]) do
     # session_id is a :binary_id (UUID) — skip filter if the value isn't a valid UUID
     if valid_uuid?(sid) do
@@ -168,25 +172,44 @@ defmodule Loomkin.Decisions.Graph do
 
   # --- Convenience ---
 
-  def active_goals do
-    list_nodes(node_type: :goal, status: :active)
+  def active_goals(opts \\ []) do
+    opts
+    |> Keyword.merge(node_type: :goal, status: :active)
+    |> list_nodes()
   end
 
   def recent_decisions(limit \\ 10, opts \\ []) do
     query =
       DecisionNode
       |> where([n], n.node_type in [:decision, :option])
+      |> maybe_scope_decision_nodes(opts)
       |> order_by([n], desc: n.inserted_at)
       |> limit(^limit)
 
-    query =
-      case Keyword.get(opts, :team_id) do
-        nil -> query
-        team_id -> where(query, [n], fragment("? ->> 'team_id' = ?", n.metadata, ^team_id))
-      end
-
     Repo.all(query)
   end
+
+  defp maybe_scope_decision_nodes(query, opts) do
+    query
+    |> maybe_filter_team(Keyword.get(opts, :team_id))
+    |> maybe_filter_session(Keyword.get(opts, :session_id))
+  end
+
+  defp maybe_filter_team(query, nil), do: query
+
+  defp maybe_filter_team(query, team_id) do
+    where(query, [n], fragment("? ->> 'team_id' = ?", n.metadata, ^team_id))
+  end
+
+  defp maybe_filter_session(query, session_id) when is_binary(session_id) do
+    if valid_uuid?(session_id) do
+      where(query, [n], n.session_id == ^session_id)
+    else
+      query
+    end
+  end
+
+  defp maybe_filter_session(query, _session_id), do: query
 
   def supersede(old_node_id, new_node_id, rationale) do
     Repo.transaction(fn ->

--- a/loomkin-server/lib/loomkin/decisions/pulse.ex
+++ b/loomkin-server/lib/loomkin/decisions/pulse.ex
@@ -20,10 +20,10 @@ defmodule Loomkin.Decisions.Pulse do
     :ok
   end
 
-  @doc "Invalidates the cached health score for a team (or global when nil)."
-  def invalidate_cache(team_id \\ nil) do
+  @doc "Invalidates the cached health score for a scope (team, session, or global when nil)."
+  def invalidate_cache(scope_key \\ nil) do
     if :ets.whereis(@cache_table) != :undefined do
-      :ets.delete(@cache_table, team_id)
+      :ets.delete(@cache_table, scope_key)
     end
 
     :ok
@@ -44,11 +44,13 @@ defmodule Loomkin.Decisions.Pulse do
         config_decisions(:pulse_stale_days, @default_stale_days)
       )
 
-    active_goals = Graph.active_goals()
-    recent_decisions = Graph.recent_decisions()
-    coverage_gaps = find_coverage_gaps(active_goals)
-    low_confidence = find_low_confidence(confidence_threshold)
-    stale_nodes = find_stale_nodes(stale_days)
+    scope = scope_filters(opts)
+
+    active_goals = Graph.active_goals(scope)
+    recent_decisions = Graph.recent_decisions(10, scope)
+    coverage_gaps = find_coverage_gaps(scope)
+    low_confidence = find_low_confidence(confidence_threshold, scope)
+    stale_nodes = find_stale_nodes(stale_days, scope)
     health_score = compute_health(Keyword.put(opts, :confidence_threshold, confidence_threshold))
 
     %{
@@ -65,25 +67,26 @@ defmodule Loomkin.Decisions.Pulse do
 
   @doc "Computes a 0-100 health score for the decision graph. Results are cached per team_id."
   def compute_health(opts \\ []) do
-    team_id = Keyword.get(opts, :team_id)
+    scope = scope_filters(opts)
+    cache_key = cache_key(scope)
     ttl = Keyword.get(opts, :cache_ttl_ms, config_cache_ttl())
 
     ensure_cache_table()
 
-    case lookup_cache(team_id, ttl) do
+    case lookup_cache(cache_key, ttl) do
       {:ok, score} ->
         score
 
       :miss ->
-        score = compute_health_uncached(team_id, opts)
-        :ets.insert(@cache_table, {team_id, score, System.monotonic_time(:millisecond)})
+        score = compute_health_uncached(scope, opts)
+        :ets.insert(@cache_table, {cache_key, score, System.monotonic_time(:millisecond)})
         score
     end
   end
 
-  defp lookup_cache(team_id, ttl) do
-    case :ets.lookup(@cache_table, team_id) do
-      [{^team_id, score, cached_at}] ->
+  defp lookup_cache(cache_key, ttl) do
+    case :ets.lookup(@cache_table, cache_key) do
+      [{^cache_key, score, cached_at}] ->
         now = System.monotonic_time(:millisecond)
 
         if now - cached_at < ttl do
@@ -97,7 +100,7 @@ defmodule Loomkin.Decisions.Pulse do
     end
   end
 
-  defp compute_health_uncached(team_id, opts) do
+  defp compute_health_uncached(scope, opts) do
     confidence_threshold =
       Keyword.get(
         opts,
@@ -105,32 +108,22 @@ defmodule Loomkin.Decisions.Pulse do
         config_decisions(:pulse_confidence_threshold, @default_confidence_threshold)
       )
 
-    gap_count = count_coverage_gaps_db(team_id)
-    orphan_count = count_orphans_db(team_id)
-    low_confidence_count = count_low_confidence_db(team_id, confidence_threshold)
+    gap_count = count_coverage_gaps_db(scope)
+    orphan_count = count_orphans_db(scope)
+    low_confidence_count = count_low_confidence_db(scope, confidence_threshold)
 
     100 - min(gap_count * 10, 50) - min(orphan_count * 5, 30) - min(low_confidence_count * 3, 20)
   end
 
-  defp count_low_confidence_db(nil, threshold) do
-    DecisionNode
-    |> where([n], n.status == :active)
+  defp count_low_confidence_db(scope, threshold) do
+    active_nodes_query(scope)
     |> where([n], not is_nil(n.confidence))
     |> where([n], n.confidence < ^threshold)
     |> Repo.aggregate(:count)
   end
 
-  defp count_low_confidence_db(team_id, threshold) do
-    DecisionNode
-    |> where([n], n.status == :active)
-    |> where([n], fragment("? ->> 'team_id' = ?", n.metadata, ^team_id))
-    |> where([n], not is_nil(n.confidence))
-    |> where([n], n.confidence < ^threshold)
-    |> Repo.aggregate(:count)
-  end
-
-  defp count_orphans_db(team_id) do
-    active_q = active_nodes_query(team_id)
+  defp count_orphans_db(scope) do
+    active_q = active_node_refs_query(scope)
 
     # Non-goal active nodes that have no edges (neither from nor to)
     from(n in subquery(active_q),
@@ -146,8 +139,8 @@ defmodule Loomkin.Decisions.Pulse do
     |> Repo.aggregate(:count)
   end
 
-  defp count_coverage_gaps_db(team_id) do
-    active_q = active_nodes_query(team_id)
+  defp count_coverage_gaps_db(scope) do
+    active_q = active_node_refs_query(scope)
 
     # Goal/decision nodes that have no outgoing edge to an :action or :outcome node
     from(n in subquery(active_q),
@@ -166,47 +159,48 @@ defmodule Loomkin.Decisions.Pulse do
     |> Repo.aggregate(:count)
   end
 
-  defp active_nodes_query(nil) do
-    from(n in DecisionNode,
-      where: n.status == :active,
-      select: %{id: n.id, node_type: n.node_type}
-    )
-  end
-
-  defp active_nodes_query(team_id) do
-    from(n in DecisionNode,
-      where: n.status == :active,
-      where: fragment("? ->> 'team_id' = ?", n.metadata, ^team_id),
-      select: %{id: n.id, node_type: n.node_type}
-    )
-  end
-
-  defp find_coverage_gaps(goals) do
-    Enum.filter(goals, fn goal ->
-      connected_types =
-        DecisionEdge
-        |> where([e], e.from_node_id == ^goal.id)
-        |> join(:inner, [e], n in DecisionNode, on: e.to_node_id == n.id)
-        |> select([_e, n], n.node_type)
-        |> Repo.all()
-
-      not Enum.any?(connected_types, &(&1 in [:action, :outcome]))
-    end)
-  end
-
-  defp find_low_confidence(threshold) do
+  defp active_nodes_query(scope) do
     DecisionNode
     |> where([n], n.status == :active)
+    |> maybe_apply_scope(scope)
+  end
+
+  defp active_node_refs_query(scope) do
+    active_nodes_query(scope)
+    |> select([n], %{id: n.id, node_type: n.node_type})
+  end
+
+  defp find_coverage_gaps(scope) do
+    from(n in DecisionNode,
+      as: :node,
+      where: n.status == :active and n.node_type == :goal
+    )
+    |> maybe_apply_scope(scope)
+    |> where(
+      [n],
+      not exists(
+        from(e in DecisionEdge,
+          join: target in DecisionNode,
+          on: target.id == e.to_node_id,
+          where: e.from_node_id == parent_as(:node).id,
+          where: target.node_type in [:action, :outcome]
+        )
+      )
+    )
+    |> Repo.all()
+  end
+
+  defp find_low_confidence(threshold, scope) do
+    active_nodes_query(scope)
     |> where([n], not is_nil(n.confidence))
     |> where([n], n.confidence < ^threshold)
     |> Repo.all()
   end
 
-  defp find_stale_nodes(days) do
+  defp find_stale_nodes(days, scope) do
     cutoff = DateTime.utc_now() |> DateTime.add(-days * 86400, :second)
 
-    DecisionNode
-    |> where([n], n.status == :active)
+    active_nodes_query(scope)
     |> where([n], n.updated_at < ^cutoff)
     |> Repo.all()
   end
@@ -230,4 +224,37 @@ defmodule Loomkin.Decisions.Pulse do
   defp config_cache_ttl do
     Loomkin.Config.get(:decisions, :pulse_cache_ttl_ms) || @default_cache_ttl_ms
   end
+
+  defp scope_filters(opts) do
+    team_id = Keyword.get(opts, :team_id)
+    session_id = Keyword.get(opts, :session_id)
+
+    cond do
+      is_binary(team_id) and team_id != "" ->
+        [team_id: team_id]
+
+      valid_uuid?(session_id) ->
+        [session_id: session_id]
+
+      true ->
+        []
+    end
+  end
+
+  defp cache_key(team_id: team_id), do: team_id
+  defp cache_key(session_id: session_id), do: {:session, session_id}
+  defp cache_key([]), do: nil
+
+  defp maybe_apply_scope(query, []), do: query
+
+  defp maybe_apply_scope(query, team_id: team_id) do
+    where(query, [n], fragment("? ->> 'team_id' = ?", n.metadata, ^team_id))
+  end
+
+  defp maybe_apply_scope(query, session_id: session_id) do
+    where(query, [n], n.session_id == ^session_id)
+  end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_value), do: false
 end

--- a/loomkin-server/lib/loomkin/llm.ex
+++ b/loomkin-server/lib/loomkin/llm.ex
@@ -22,6 +22,8 @@ defmodule Loomkin.LLM do
 
   alias Loomkin.Auth.ProviderRegistry
   alias Loomkin.Auth.TokenStore
+  alias Loomkin.Providers.OpenAIOAuth
+  alias Loomkin.Providers.OpenAICodexModels
 
   @doc """
   Stream text from an LLM provider, transparently using OAuth when available.
@@ -50,7 +52,15 @@ defmodule Loomkin.LLM do
             end
 
           :passthrough ->
-            ReqLLM.stream_text(model_spec, messages, opts)
+            case maybe_resolve_openai_catalog_gap(model_spec) do
+              {:resolved, model, provider_module} ->
+                with {:ok, context} <- ReqLLM.Context.normalize(messages, opts) do
+                  ReqLLM.Streaming.start_stream(provider_module, model, context, opts)
+                end
+
+              :passthrough ->
+                ReqLLM.stream_text(model_spec, messages, opts)
+            end
         end
     end
   end
@@ -64,47 +74,22 @@ defmodule Loomkin.LLM do
           {:ok, ReqLLM.Response.t()} | {:error, term()}
   def generate_text(model_spec, messages, opts \\ []) do
     case maybe_resolve_local(model_spec) do
-      {:local, model, provider_module} ->
-        with {:ok, request} <- provider_module.prepare_request(:chat, model, messages, opts),
-             {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-
-               Req.request(request) do
-          {:ok, body}
-        else
-          {:ok, %Req.Response{status: status, body: body}} ->
-            {:error,
-             ReqLLM.Error.API.Request.exception(
-               reason: "HTTP #{status}: Request failed",
-               status: status,
-               response_body: body
-             )}
-
-          {:error, error} ->
-            {:error, error}
-        end
+      {kind, model, provider_module} when kind in [:local, :endpoint] ->
+        generate_with_provider(provider_module, model, messages, opts)
 
       :not_local ->
         case maybe_resolve_oauth(model_spec) do
           {:oauth, model, provider_module} ->
-            with {:ok, request} <-
-                   provider_module.prepare_request(:chat, model, messages, opts),
-                 {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-
-                   Req.request(request) do
-              {:ok, body}
-            else
-              {:ok, %Req.Response{status: status, body: body}} ->
-                {:error,
-                 ReqLLM.Error.API.Request.exception(
-                   reason: "HTTP #{status}: Request failed",
-                   status: status,
-                   response_body: body
-                 )}
-
-              {:error, error} ->
-                {:error, error}
-            end
+            generate_with_provider(provider_module, model, messages, opts)
 
           :passthrough ->
-            ReqLLM.generate_text(model_spec, messages, opts)
+            case maybe_resolve_openai_catalog_gap(model_spec) do
+              {:resolved, model, provider_module} ->
+                generate_with_provider(provider_module, model, messages, opts)
+
+              :passthrough ->
+                ReqLLM.generate_text(model_spec, messages, opts)
+            end
         end
     end
   end
@@ -198,7 +183,7 @@ defmodule Loomkin.LLM do
             if TokenStore.get_access_token(provider_atom) != nil do
               oauth_atom = String.to_existing_atom(oauth_provider)
 
-              with {:ok, model} <- ReqLLM.model(model_spec),
+              with {:ok, model} <- resolve_oauth_model(provider, model_spec),
                    {:ok, provider_module} <- ReqLLM.provider(oauth_atom) do
                 {:oauth, model, provider_module}
               else
@@ -217,4 +202,62 @@ defmodule Loomkin.LLM do
   end
 
   defp maybe_resolve_oauth(_model_spec), do: :passthrough
+
+  defp resolve_oauth_model("openai", model_spec) do
+    case ReqLLM.model(model_spec) do
+      {:error, :not_found} -> OpenAICodexModels.resolve_model(model_spec)
+      result -> result
+    end
+  end
+
+  defp resolve_oauth_model(_provider, model_spec), do: ReqLLM.model(model_spec)
+
+  defp maybe_resolve_openai_catalog_gap(model_spec) when is_binary(model_spec) do
+    case String.split(model_spec, ":", parts: 2) do
+      ["openai", _model_id] ->
+        with {:ok, model} <- OpenAICodexModels.resolve_model(model_spec),
+             {:ok, provider_module} <- ReqLLM.provider(:openai) do
+          {:resolved, model, provider_module}
+        else
+          _ -> :passthrough
+        end
+
+      _ ->
+        :passthrough
+    end
+  rescue
+    _ -> :passthrough
+  end
+
+  defp maybe_resolve_openai_catalog_gap(_model_spec), do: :passthrough
+
+  defp generate_with_provider(provider_module, model, messages, opts) do
+    if stream_backed_generate?(provider_module) do
+      with {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
+           {:ok, stream_response} <-
+             ReqLLM.Streaming.start_stream(provider_module, model, context, opts) do
+        ReqLLM.StreamResponse.process_stream(stream_response)
+      end
+    else
+      with {:ok, request} <- provider_module.prepare_request(:chat, model, messages, opts),
+           {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-
+             Req.request(request) do
+        {:ok, body}
+      else
+        {:ok, %Req.Response{status: status, body: body}} ->
+          {:error,
+           ReqLLM.Error.API.Request.exception(
+             reason: "HTTP #{status}: Request failed",
+             status: status,
+             response_body: body
+           )}
+
+        {:error, error} ->
+          {:error, error}
+      end
+    end
+  end
+
+  @doc false
+  def stream_backed_generate?(provider_module), do: provider_module == OpenAIOAuth
 end

--- a/loomkin-server/lib/loomkin/models.ex
+++ b/loomkin-server/lib/loomkin/models.ex
@@ -9,6 +9,8 @@ defmodule Loomkin.Models do
   Users can also type any `provider:model` string directly.
   """
 
+  alias Loomkin.Providers.OpenAICodexModels
+
   # Provider atom → {display name, env var name}
   @providers %{
     anthropic: {"Anthropic", "ANTHROPIC_API_KEY"},
@@ -48,7 +50,7 @@ defmodule Loomkin.Models do
         provider_available?(provider)
       end)
       |> Enum.map(fn {provider, {display_name, _env_var}} ->
-        models = fetch_provider_models(provider)
+        models = fetch_provider_models(provider, api_key_status(provider))
         {display_name, models}
       end)
       |> Enum.reject(fn {_name, models} -> models == [] end)
@@ -134,7 +136,7 @@ defmodule Loomkin.Models do
         provider_available?(provider)
       end)
       |> Enum.map(fn {provider, {display_name, _env_var}} ->
-        models = fetch_provider_models_enriched(provider)
+        models = fetch_provider_models_enriched(provider, api_key_status(provider))
         {display_name, models}
       end)
       |> Enum.reject(fn {_name, models} -> models == [] end)
@@ -159,8 +161,8 @@ defmodule Loomkin.Models do
 
         models =
           case status do
-            {:set, _} -> fetch_provider_models_enriched(provider)
-            {:oauth, :connected} -> fetch_provider_models_enriched(provider)
+            {:set, _} -> fetch_provider_models_enriched(provider, status)
+            {:oauth, :connected} -> fetch_provider_models_enriched(provider, status)
             _ -> []
           end
 
@@ -195,29 +197,51 @@ defmodule Loomkin.Models do
     end
   end
 
-  defp fetch_provider_models(provider) do
-    LLMDB.models(provider)
-    |> Enum.filter(&chat_capable?/1)
-    |> Enum.reject(fn m -> m.deprecated || m.retired end)
-    |> Enum.sort_by(&model_sort_key/1, :desc)
+  defp fetch_provider_models(provider, status) do
+    provider
+    |> fetch_catalog_models(status)
     |> Enum.map(fn m ->
       {m.name || m.id, "#{provider}:#{m.id}"}
     end)
-  rescue
-    _ -> []
   end
 
-  defp fetch_provider_models_enriched(provider) do
-    LLMDB.models(provider)
-    |> Enum.filter(&chat_capable?/1)
-    |> Enum.reject(fn m -> m.deprecated || m.retired end)
-    |> Enum.sort_by(&model_sort_key/1, :desc)
+  defp fetch_provider_models_enriched(provider, status) do
+    provider
+    |> fetch_catalog_models(status)
     |> Enum.map(fn m ->
       ctx_label = format_context_window(m)
       {m.name || m.id, "#{provider}:#{m.id}", ctx_label}
     end)
+  end
+
+  defp fetch_catalog_models(:openai, {:oauth, :connected}) do
+    OpenAICodexModels.list_models()
+  end
+
+  defp fetch_catalog_models(:openai, {:set, _env_var}) do
+    merge_models(OpenAICodexModels.list_models(), fetch_catalog_models_from_llmdb(:openai))
+  end
+
+  defp fetch_catalog_models(provider, _status) do
+    fetch_catalog_models_from_llmdb(provider)
+  end
+
+  defp fetch_catalog_models_from_llmdb(provider) do
+    LLMDB.models(provider)
+    |> Enum.filter(&chat_capable?/1)
+    |> Enum.reject(fn m -> m.deprecated || m.retired end)
+    |> Enum.sort_by(&model_sort_key/1, :desc)
   rescue
     _ -> []
+  end
+
+  defp merge_models(primary, secondary) do
+    seen_ids = MapSet.new(primary, & &1.id)
+
+    primary ++
+      Enum.reject(secondary, fn model ->
+        MapSet.member?(seen_ids, model.id)
+      end)
   end
 
   defp chat_capable?(%{capabilities: %{chat: true}}), do: true
@@ -307,18 +331,11 @@ defmodule Loomkin.Models do
     Loomkin.Providers.OpenAICompatibleProvider.get_all_endpoints()
     |> Enum.reject(&(&1 == "ollama"))
     |> Enum.flat_map(fn provider ->
-      base_url =
-        case Loomkin.Config.get_provider_endpoint(provider) do
-          %{url: url} when is_binary(url) and url != "" -> String.trim_trailing(url, "/")
-          %{"url" => url} when is_binary(url) and url != "" -> String.trim_trailing(url, "/")
-          _ -> nil
-        end
+      base_url = endpoint_base_url(provider)
 
       if base_url do
-        url = "#{base_url}/models"
-
-        case Req.get(url, receive_timeout: 5_000, retry: false) do
-          {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+        case fetch_endpoint_model_list(provider, base_url) do
+          {:ok, data} ->
             entries =
               data
               |> Enum.map(fn m ->
@@ -361,18 +378,11 @@ defmodule Loomkin.Models do
   end
 
   defp fetch_openai_compat_models(provider) do
-    base_url =
-      case Loomkin.Config.get_provider_endpoint(provider) do
-        %{url: url} when is_binary(url) and url != "" -> String.trim_trailing(url, "/")
-        %{"url" => url} when is_binary(url) and url != "" -> String.trim_trailing(url, "/")
-        _ -> nil
-      end
+    base_url = endpoint_base_url(provider)
 
     if base_url do
-      url = "#{base_url}/models"
-
-      case Req.get(url, receive_timeout: 5_000, retry: false) do
-        {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+      case fetch_endpoint_model_list(provider, base_url) do
+        {:ok, data} ->
           entries =
             data
             |> Enum.map(fn m ->
@@ -391,4 +401,42 @@ defmodule Loomkin.Models do
       []
     end
   end
+
+  defp endpoint_base_url(provider) do
+    case Loomkin.Config.get_provider_endpoint(provider) do
+      %{url: url} when is_binary(url) and url != "" -> String.trim_trailing(url, "/")
+      %{"url" => url} when is_binary(url) and url != "" -> String.trim_trailing(url, "/")
+      _ -> nil
+    end
+  end
+
+  defp endpoint_auth_headers(provider) do
+    case Loomkin.Config.get_provider_endpoint(provider) do
+      %{auth_key: key} when is_binary(key) and key != "" ->
+        [{"authorization", "Bearer #{key}"}]
+
+      %{"auth_key" => key} when is_binary(key) and key != "" ->
+        [{"authorization", "Bearer #{key}"}]
+
+      _ ->
+        []
+    end
+  end
+
+  defp fetch_endpoint_model_list(provider, base_url) do
+    request_opts =
+      [receive_timeout: 5_000, retry: false]
+      |> maybe_put_headers(endpoint_auth_headers(provider))
+
+    case Req.get("#{base_url}/models", request_opts) do
+      {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+        {:ok, data}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp maybe_put_headers(opts, []), do: opts
+  defp maybe_put_headers(opts, headers), do: Keyword.put(opts, :headers, headers)
 end

--- a/loomkin-server/lib/loomkin/providers/openai_codex_models.ex
+++ b/loomkin-server/lib/loomkin/providers/openai_codex_models.ex
@@ -1,0 +1,210 @@
+defmodule Loomkin.Providers.OpenAICodexModels do
+  @moduledoc false
+
+  @fallback_entries [
+    %{
+      "slug" => "gpt-5.4",
+      "display_name" => "gpt-5.4",
+      "visibility" => "list",
+      "supported_in_api" => true,
+      "context_window" => 272_000,
+      "input_modalities" => ["text", "image"],
+      "supports_reasoning_summaries" => true
+    },
+    %{
+      "slug" => "gpt-5.4-mini",
+      "display_name" => "GPT-5.4-Mini",
+      "visibility" => "list",
+      "supported_in_api" => true,
+      "context_window" => 272_000,
+      "input_modalities" => ["text", "image"],
+      "supports_reasoning_summaries" => true
+    },
+    %{
+      "slug" => "gpt-5.3-codex",
+      "display_name" => "gpt-5.3-codex",
+      "visibility" => "list",
+      "supported_in_api" => true,
+      "context_window" => 272_000,
+      "input_modalities" => ["text", "image"],
+      "supports_reasoning_summaries" => true
+    },
+    %{
+      "slug" => "gpt-5.2",
+      "display_name" => "gpt-5.2",
+      "visibility" => "list",
+      "supported_in_api" => true,
+      "context_window" => 272_000,
+      "input_modalities" => ["text", "image"],
+      "supports_reasoning_summaries" => true
+    }
+  ]
+
+  @spec list_models() :: [LLMDB.Model.t()]
+  def list_models do
+    all_entries()
+    |> Enum.filter(&picker_visible?/1)
+    |> Enum.map(&build_model/1)
+  end
+
+  @spec resolve_model(String.t()) :: {:ok, LLMDB.Model.t()} | {:error, :not_found}
+  def resolve_model(model_spec) when is_binary(model_spec) do
+    model_id = canonical_model_id(model_spec)
+
+    case Enum.find(all_entries(), &(entry_slug(&1) == model_id)) do
+      nil ->
+        {:error, :not_found}
+
+      entry ->
+        if supported_in_api?(entry) do
+          {:ok, build_model(entry)}
+        else
+          {:error, :not_found}
+        end
+    end
+  end
+
+  defp all_entries do
+    cache_entries = load_cache_entries()
+    cache_ids = MapSet.new(cache_entries, &entry_slug/1)
+
+    cache_entries ++
+      Enum.reject(@fallback_entries, fn entry ->
+        MapSet.member?(cache_ids, entry_slug(entry))
+      end)
+  end
+
+  defp load_cache_entries do
+    case File.read(cache_path()) do
+      {:ok, body} ->
+        case Jason.decode(body) do
+          {:ok, %{"models" => models}} when is_list(models) ->
+            Enum.filter(models, &is_binary(entry_slug(&1)))
+
+          _ ->
+            []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp cache_path do
+    Application.get_env(:loomkin, __MODULE__, [])
+    |> Keyword.get(:cache_path, Path.join(codex_home(), "models_cache.json"))
+  end
+
+  defp codex_home do
+    System.get_env("CODEX_HOME") || Path.join(System.user_home!(), ".codex")
+  end
+
+  defp build_model(entry) do
+    model_id = entry_slug(entry)
+
+    LLMDB.Model.new!(%{
+      id: model_id,
+      provider: :openai,
+      provider_model_id: model_id,
+      name: entry_display_name(entry),
+      limits: %{
+        context: entry_context_window(entry),
+        output: nil
+      },
+      capabilities: %{
+        chat: true,
+        reasoning: %{enabled: reasoning_enabled?(entry)},
+        tools: %{enabled: true, streaming: true, strict: true, parallel: true},
+        json: %{native: true, schema: true, strict: true},
+        streaming: %{text: true, tool_calls: true}
+      },
+      modalities: %{
+        input: input_modalities(entry),
+        output: [:text]
+      },
+      deprecated: false,
+      retired: false,
+      extra: %{
+        wire: %{protocol: "openai_responses"},
+        loomkin: %{source: "codex_models_cache"},
+        codex: %{
+          visibility: visibility(entry),
+          supported_in_api: supported_in_api?(entry)
+        }
+      }
+    })
+  end
+
+  defp canonical_model_id(model_spec) do
+    model_spec
+    |> String.replace_prefix("openai_oauth:", "")
+    |> String.replace_prefix("openai:", "")
+  end
+
+  defp entry_slug(entry), do: fetch_string(entry, "slug") || fetch_string(entry, "id")
+
+  defp entry_display_name(entry), do: fetch_string(entry, "display_name") || entry_slug(entry)
+
+  defp entry_context_window(entry) do
+    case fetch_value(entry, "context_window") do
+      value when is_integer(value) and value > 0 -> value
+      _ -> nil
+    end
+  end
+
+  defp picker_visible?(entry), do: supported_in_api?(entry) and visibility(entry) == "list"
+
+  defp visibility(entry), do: fetch_string(entry, "visibility") || "list"
+
+  defp supported_in_api?(entry) do
+    case fetch_value(entry, "supported_in_api") do
+      false -> false
+      _ -> true
+    end
+  end
+
+  defp reasoning_enabled?(entry) do
+    case fetch_value(entry, "supports_reasoning_summaries") do
+      false -> false
+      _ -> true
+    end
+  end
+
+  defp input_modalities(entry) do
+    entry
+    |> fetch_value("input_modalities")
+    |> List.wrap()
+    |> Enum.flat_map(&normalize_modality/1)
+    |> case do
+      [] -> [:text]
+      modalities -> Enum.uniq(modalities)
+    end
+  end
+
+  defp normalize_modality("text"), do: [:text]
+  defp normalize_modality("image"), do: [:image]
+  defp normalize_modality("audio"), do: [:audio]
+  defp normalize_modality(:text), do: [:text]
+  defp normalize_modality(:image), do: [:image]
+  defp normalize_modality(:audio), do: [:audio]
+  defp normalize_modality(_), do: []
+
+  defp fetch_string(entry, key) do
+    case fetch_value(entry, key) do
+      value when is_binary(value) and value != "" -> value
+      _ -> nil
+    end
+  end
+
+  defp fetch_value(entry, key) when is_map(entry) do
+    case Map.fetch(entry, key) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        Map.get(entry, String.to_atom(key))
+    end
+  rescue
+    ArgumentError -> Map.get(entry, key)
+  end
+end

--- a/loomkin-server/lib/loomkin/providers/openai_oauth.ex
+++ b/loomkin-server/lib/loomkin/providers/openai_oauth.ex
@@ -29,20 +29,47 @@ defmodule Loomkin.Providers.OpenAIOAuth do
   startup (after TokenStore is started).
   """
 
+  require Logger
+
   use ReqLLM.Provider,
     id: :openai_oauth,
     default_base_url: "https://chatgpt.com/backend-api"
 
   alias Loomkin.Auth.TokenStore
   alias Loomkin.Auth.Providers.OpenAI, as: OpenAIAuth
+  alias Loomkin.Providers.OpenAICodexModels
 
   @openai ReqLLM.Providers.OpenAI
   @responses_api ReqLLM.Providers.OpenAI.ResponsesAPI
 
   @provider_schema [
+    openai_parallel_tool_calls: [
+      type: :boolean,
+      doc: "Override parallel tool call behavior for OpenAI responses requests"
+    ],
+    openai_structured_output_mode: [
+      type: {:in, [:auto, :json_schema, :tool_strict]},
+      doc: "Structured output mode for OpenAI responses requests"
+    ],
+    openai_json_schema_strict: [
+      type: :boolean,
+      doc: "Whether structured JSON schema output should be strict"
+    ],
     max_completion_tokens: [
       type: :integer,
       doc: "Maximum completion tokens (required for reasoning models)"
+    ],
+    response_format: [
+      type: :map,
+      doc: "Response format configuration for structured output"
+    ],
+    previous_response_id: [
+      type: :string,
+      doc: "Previous response id for responses-api resume flows"
+    ],
+    tool_outputs: [
+      type: {:list, :any},
+      doc: "Tool outputs for responses-api resume flows"
     ],
     service_tier: [
       type: {:or, [:atom, :string]},
@@ -99,6 +126,7 @@ defmodule Loomkin.Providers.OpenAIOAuth do
             :max_completion_tokens,
             :reasoning_effort,
             :service_tier,
+            :response_format,
             :compiled_schema,
             :temperature,
             :max_tokens,
@@ -176,6 +204,7 @@ defmodule Loomkin.Providers.OpenAIOAuth do
         :provider_options,
         :reasoning_effort,
         :service_tier,
+        :response_format,
         :fixture,
         :on_unsupported,
         :n,
@@ -190,7 +219,10 @@ defmodule Loomkin.Providers.OpenAIOAuth do
       ] ++
         supported_provider_options()
 
-    req_opts = ReqLLM.Provider.Defaults.filter_req_opts(user_opts)
+    req_opts =
+      user_opts
+      |> ReqLLM.Provider.Defaults.filter_req_opts()
+      |> Keyword.delete(:base_url)
 
     request
     |> Req.Request.register_options(extra_option_keys)
@@ -200,7 +232,9 @@ defmodule Loomkin.Providers.OpenAIOAuth do
     |> Req.Request.put_header("openai-beta", "responses=experimental")
     |> Req.Request.put_header("originator", "opencode")
     |> Req.Request.put_header("accept", "text/event-stream")
-    |> Req.Request.merge_options([model: get_api_model_id(model)] ++ req_opts)
+    |> Req.Request.merge_options(
+      [model: get_api_model_id(model), base_url: base_url()] ++ req_opts
+    )
     |> Req.Request.put_private(:req_llm_model, model)
     |> ReqLLM.Step.Error.attach()
     |> ReqLLM.Step.Retry.attach(user_opts)
@@ -216,12 +250,7 @@ defmodule Loomkin.Providers.OpenAIOAuth do
 
     case Jason.decode(encoded.body) do
       {:ok, body_map} ->
-        patched =
-          body_map
-          |> inject_instructions_from_input()
-          |> Map.put("store", false)
-          |> Map.put("stream", true)
-
+        patched = patch_codex_body(body_map, request.options[:model])
         Map.put(encoded, :body, Jason.encode!(patched))
 
       _ ->
@@ -345,7 +374,13 @@ defmodule Loomkin.Providers.OpenAIOAuth do
         {:error, :no_oauth_token}
 
       token ->
-        account_id = OpenAIAuth.extract_account_id(token)
+        status = TokenStore.get_status(:openai) || %{}
+        stored_account_id = Map.get(status, :account_id) || Map.get(status, "account_id")
+        derived_account_id = OpenAIAuth.extract_account_id(token)
+
+        maybe_log_token_diagnostics(token, derived_account_id, stored_account_id, status)
+
+        account_id = derived_account_id || stored_account_id
 
         {:ok, {token, account_id}}
     end
@@ -356,7 +391,10 @@ defmodule Loomkin.Providers.OpenAIOAuth do
       model_spec
       |> String.replace_prefix("openai_oauth:", "openai:")
 
-    ReqLLM.model(canonical)
+    case ReqLLM.model(canonical) do
+      {:error, :not_found} -> OpenAICodexModels.resolve_model(canonical)
+      result -> result
+    end
   end
 
   defp resolve_model(model_spec), do: ReqLLM.model(model_spec)
@@ -375,7 +413,63 @@ defmodule Loomkin.Providers.OpenAIOAuth do
          String.contains?(haystack, "usage limit") do
       {request, %{response | status: 429}}
     else
+      Logger.warning(
+        "[Kin:openai_oauth] upstream 404 model=#{inspect(request.options[:model])} body=#{preview_body(body_str)}"
+      )
+
       @openai.decode_response({request, response})
+    end
+  end
+
+  defp preview_body(body) when is_binary(body) and byte_size(body) > 220 do
+    binary_part(body, 0, 220) <> "..."
+  end
+
+  defp preview_body(body), do: body
+
+  defp maybe_log_token_diagnostics(token, derived_account_id, stored_account_id, status)
+       when is_binary(token) do
+    scopes = Map.get(status, :scopes) || Map.get(status, "scopes")
+    segment_count = token |> String.split(".") |> length()
+
+    if is_nil(derived_account_id) and not is_nil(stored_account_id) do
+      Logger.debug(
+        "[Kin:openai_oauth] using stored account id because token claims were unavailable token_segments=#{segment_count} stored_account_id=#{inspect(stored_account_id)}"
+      )
+    end
+
+    if suspicious_test_token?(token, stored_account_id, scopes) do
+      Logger.warning(
+        "[Kin:openai_oauth] suspicious oauth token detected len=#{byte_size(token)} token_segments=#{segment_count} stored_account_id=#{inspect(stored_account_id)} scopes=#{inspect(scopes)} reconnect_openai=true"
+      )
+    end
+  end
+
+  defp suspicious_test_token?(token, stored_account_id, scopes) do
+    String.starts_with?(token, "test-") or scopes == "test" or
+      (is_binary(stored_account_id) and String.contains?(stored_account_id, "test"))
+  end
+
+  defp log_tool_resume_shape(model_label, body_map, original_previous_response_id)
+       when is_map(body_map) do
+    input = Map.get(body_map, "input", [])
+
+    function_call_count =
+      Enum.count(input, &(is_map(&1) and Map.get(&1, "type") == "function_call"))
+
+    function_output_count =
+      Enum.count(input, &(is_map(&1) and Map.get(&1, "type") == "function_call_output"))
+
+    if original_previous_response_id || function_call_count > 0 || function_output_count > 0 do
+      Logger.debug(
+        "[Kin:openai_oauth] resume_shape model=#{inspect(model_label)} dropped_previous_response_id=#{inspect(original_previous_response_id)} function_calls=#{function_call_count} function_outputs=#{function_output_count}"
+      )
+    end
+
+    if function_call_count > 0 and function_output_count == 0 do
+      Logger.warning(
+        "[Kin:openai_oauth] function calls present without tool outputs model=#{inspect(model_label)}"
+      )
     end
   end
 
@@ -400,14 +494,64 @@ defmodule Loomkin.Providers.OpenAIOAuth do
     case Jason.decode(body_str) do
       {:ok, body_map} ->
         body_map
-        |> inject_instructions_from_input()
-        |> Map.put("store", false)
-        |> Map.put("stream", true)
+        |> patch_codex_body(get_api_model_id(model))
         |> Jason.encode!()
 
       _ ->
         body_str
     end
+  end
+
+  defp patch_codex_body(body_map, model_label) when is_map(body_map) do
+    previous_response_id = Map.get(body_map, "previous_response_id")
+
+    patched =
+      body_map
+      |> inject_instructions_from_input()
+      |> Map.delete("previous_response_id")
+      |> drop_stale_function_calls(model_label)
+      |> Map.put("store", false)
+      |> Map.put("stream", true)
+
+    log_tool_resume_shape(model_label, patched, previous_response_id)
+    patched
+  end
+
+  defp drop_stale_function_calls(body_map, model_label) when is_map(body_map) do
+    input = Map.get(body_map, "input", [])
+
+    output_call_ids =
+      input
+      |> Enum.flat_map(fn
+        %{"type" => "function_call_output", "call_id" => call_id} when is_binary(call_id) ->
+          [call_id]
+
+        _ ->
+          []
+      end)
+      |> MapSet.new()
+
+    {filtered_input, dropped_count} =
+      Enum.reduce(input, {[], 0}, fn
+        %{"type" => "function_call", "call_id" => call_id} = item, {acc, dropped}
+        when is_binary(call_id) ->
+          if MapSet.member?(output_call_ids, call_id) do
+            {[item | acc], dropped}
+          else
+            {acc, dropped + 1}
+          end
+
+        item, {acc, dropped} ->
+          {[item | acc], dropped}
+      end)
+
+    if dropped_count > 0 do
+      Logger.debug(
+        "[Kin:openai_oauth] dropped stale function calls model=#{inspect(model_label)} count=#{dropped_count}"
+      )
+    end
+
+    Map.put(body_map, "input", Enum.reverse(filtered_input))
   end
 
   defp maybe_put_instructions(body_map, ""), do: body_map

--- a/loomkin-server/lib/loomkin/providers/openai_oauth.ex
+++ b/loomkin-server/lib/loomkin/providers/openai_oauth.ex
@@ -514,6 +514,7 @@ defmodule Loomkin.Providers.OpenAIOAuth do
       |> Map.put("stream", true)
 
     log_tool_resume_shape(model_label, patched, previous_response_id)
+    log_empty_input_shape(model_label, patched)
     patched
   end
 
@@ -552,6 +553,27 @@ defmodule Loomkin.Providers.OpenAIOAuth do
     end
 
     Map.put(body_map, "input", Enum.reverse(filtered_input))
+  end
+
+  defp log_empty_input_shape(model_label, body_map) when is_map(body_map) do
+    input = Map.get(body_map, "input", [])
+
+    cond do
+      input == [] ->
+        Logger.warning(
+          "[Kin:openai_oauth] codex request has empty input model=#{inspect(model_label)} instructions_present=#{Map.has_key?(body_map, "instructions")}"
+        )
+
+      Enum.all?(input, fn item ->
+        is_map(item) and Map.get(item, "type") == "function_call_output"
+      end) ->
+        Logger.warning(
+          "[Kin:openai_oauth] codex request has tool-output-only input model=#{inspect(model_label)} count=#{length(input)}"
+        )
+
+      true ->
+        :ok
+    end
   end
 
   defp maybe_put_instructions(body_map, ""), do: body_map

--- a/loomkin-server/lib/loomkin/session/architect.ex
+++ b/loomkin-server/lib/loomkin/session/architect.ex
@@ -314,20 +314,7 @@ defmodule Loomkin.Session.Architect do
 
   # Find and message the lead agent (or first agent) in a newly spawned team.
   defp bootstrap_team_lead(team_id, user_text) do
-    alias Loomkin.Teams.Agent
-    alias Loomkin.Teams.Manager
-
-    agents = Manager.list_agents(team_id)
-
-    lead =
-      Enum.find(agents, fn a -> a.role == :lead end) ||
-        List.first(agents)
-
-    if lead do
-      Task.Supervisor.start_child(Loomkin.Teams.TaskSupervisor, fn ->
-        Agent.send_message(lead.pid, user_text)
-      end)
-    end
+    Loomkin.Tools.TeamSpawn.bootstrap_spawned_team(team_id, user_text, from: "user")
   end
 
   defp conversational_fallback(user_text, state, model, opts \\ []) do

--- a/loomkin-server/lib/loomkin/session/context_window.ex
+++ b/loomkin-server/lib/loomkin/session/context_window.ex
@@ -439,6 +439,7 @@ defmodule Loomkin.Session.ContextWindow do
 
     high_indices = high_indexed |> Enum.map(fn {_, i} -> i end) |> MapSet.new()
     selected_indices = MapSet.union(high_indices, kept_normal_indices)
+    selected_indices = ensure_latest_non_system_retained(indexed, selected_indices)
 
     # Split into kept and evicted, both in original order.
     # Evicted = normal messages not selected (high-priority are never evicted).
@@ -452,6 +453,30 @@ defmodule Loomkin.Session.ContextWindow do
       end)
 
     {Enum.reverse(kept), Enum.reverse(evicted)}
+  end
+
+  defp ensure_latest_non_system_retained(indexed, selected_indices) do
+    has_non_system_selected? =
+      Enum.any?(indexed, fn {msg, idx} ->
+        MapSet.member?(selected_indices, idx) and msg[:role] not in [:system, "system"]
+      end)
+
+    if has_non_system_selected? do
+      selected_indices
+    else
+      case latest_non_system_index(indexed) do
+        nil -> selected_indices
+        idx -> MapSet.put(selected_indices, idx)
+      end
+    end
+  end
+
+  defp latest_non_system_index(indexed) do
+    indexed
+    |> Enum.reverse()
+    |> Enum.find_value(fn {msg, idx} ->
+      if msg[:role] in [:system, "system"], do: nil, else: idx
+    end)
   end
 
   defp high_priority?(%{priority: :high}), do: true

--- a/loomkin-server/lib/loomkin/teams/agent.ex
+++ b/loomkin-server/lib/loomkin/teams/agent.ex
@@ -1765,7 +1765,11 @@ defmodule Loomkin.Teams.Agent do
   # Agent errors — log at warning level for visibility
   def handle_info(%Jido.Signal{type: "agent.error"} = sig, state) do
     agent = sig.data[:agent_name] || "unknown"
-    reason = sig.data[:reason] || sig.data[:error] || "unknown"
+    payload = sig.data[:payload] || %{}
+
+    reason =
+      sig.data[:reason] || sig.data[:error] || payload[:error] || payload["error"] ||
+        payload[:message] || payload["message"] || "unknown"
 
     Logger.warning(
       "[Kin:signal] agent.error agent=#{agent} reason=#{inspect(reason, limit: 200)}"
@@ -3226,9 +3230,7 @@ defmodule Loomkin.Teams.Agent do
   @default_max_agents_per_team 10
 
   defp run_spawn_gate_intercept(agent_pid, tool_module, tool_args, context, team_id, agent_name) do
-    spawn_type = Map.get(tool_args, "spawn_type", Map.get(tool_args, :spawn_type))
-
-    if spawn_type in [:research, "research"] do
+    if Loomkin.Tools.TeamSpawn.research_spawn?(tool_args, context) do
       run_research_spawn(agent_pid, tool_module, tool_args, context, team_id, agent_name)
     else
       run_human_or_auto_spawn_gate(
@@ -3243,7 +3245,12 @@ defmodule Loomkin.Teams.Agent do
   end
 
   defp run_research_spawn(agent_pid, tool_module, tool_args, context, team_id, agent_name) do
-    roles = tool_args |> Map.get("roles", Map.get(tool_args, :roles, [])) |> atomize_role_keys()
+    roles =
+      case Loomkin.Tools.TeamSpawn.resolve_roles(tool_args, context) do
+        {:ok, resolved_roles} -> atomize_role_keys(resolved_roles)
+        {:error, _reason} -> []
+      end
+
     estimated_cost = estimate_spawn_cost(roles)
     researcher_count = length(roles)
 

--- a/loomkin-server/lib/loomkin/teams/agent.ex
+++ b/loomkin-server/lib/loomkin/teams/agent.ex
@@ -3296,12 +3296,30 @@ defmodule Loomkin.Teams.Agent do
               []
 
             _ ->
+              Logger.info(
+                "[Kin:research] awaiting findings agent=#{agent_name} team=#{team_id} expected=#{researcher_count} timeout_ms=120000"
+              )
+
               # Block in receive loop collecting findings from researchers
-              collect_research_findings(researcher_count, 120_000, [])
+              collect_research_findings(researcher_count, 120_000, [], %{
+                agent_name: agent_name,
+                team_id: team_id,
+                expected: researcher_count
+              })
           end
 
         # Exit awaiting_synthesis; agent returns to :working
         GenServer.cast(agent_pid, :exit_awaiting_synthesis)
+
+        if findings == [] do
+          Logger.warning(
+            "[Kin:research] no findings received agent=#{agent_name} team=#{team_id} expected=#{researcher_count}"
+          )
+        else
+          Logger.info(
+            "[Kin:research] findings collected agent=#{agent_name} team=#{team_id} received=#{length(findings)} expected=#{researcher_count}"
+          )
+        end
 
         summary =
           findings
@@ -3312,15 +3330,23 @@ defmodule Loomkin.Teams.Agent do
     end
   end
 
-  defp collect_research_findings(0, _timeout_ms, acc), do: Enum.reverse(acc)
+  defp collect_research_findings(0, _timeout_ms, acc, _meta), do: Enum.reverse(acc)
 
-  defp collect_research_findings(count, timeout_ms, acc) when count > 0 do
+  defp collect_research_findings(count, timeout_ms, acc, meta) when count > 0 do
     receive do
       {:research_findings, from, content} ->
-        collect_research_findings(count - 1, timeout_ms, [{from, content} | acc])
+        Logger.info(
+          "[Kin:research] finding received agent=#{meta.agent_name} team=#{meta.team_id} from=#{from} remaining=#{count - 1}"
+        )
+
+        collect_research_findings(count - 1, timeout_ms, [{from, content} | acc], meta)
     after
       timeout_ms ->
         # partial findings on timeout — proceed with what arrived
+        Logger.warning(
+          "[Kin:research] findings timeout agent=#{meta.agent_name} team=#{meta.team_id} remaining=#{count} received=#{length(acc)} expected=#{meta.expected}"
+        )
+
         Enum.reverse(acc)
     end
   end
@@ -3528,7 +3554,8 @@ defmodule Loomkin.Teams.Agent do
          team_id,
          agent_name
        ) do
-    result = AgentLoop.default_run_tool(tool_module, tool_args, context)
+    atomized_args = Loomkin.Tools.Registry.atomize_keys(tool_args)
+    result = Jido.Exec.run(tool_module, atomized_args, context, timeout: 60_000)
 
     if gate_id do
       # Publish GateResolved for approved path (human gate)
@@ -3548,11 +3575,62 @@ defmodule Loomkin.Teams.Agent do
       {:ok, %{team_id: child_team_id}} ->
         send(agent_pid, {:child_team_spawned, child_team_id})
 
+        bootstrap_message = build_spawn_work_order(tool_args, context)
+
+        case Loomkin.Tools.TeamSpawn.bootstrap_spawned_team(child_team_id, bootstrap_message,
+               from: to_string(agent_name)
+             ) do
+          {:ok, %{name: bootstrap_agent}} ->
+            Logger.info(
+              "[Kin:team_spawn] bootstrapped child_team=#{child_team_id} parent_team=#{team_id} parent_agent=#{agent_name} target=#{bootstrap_agent}"
+            )
+
+          {:error, reason} ->
+            Logger.warning(
+              "[Kin:team_spawn] bootstrap failed child_team=#{child_team_id} parent_team=#{team_id} parent_agent=#{agent_name} reason=#{inspect(reason)}"
+            )
+        end
+
       _ ->
         :ok
     end
 
     result
+  end
+
+  defp build_spawn_work_order(tool_args, context) do
+    team_name =
+      Map.get(tool_args, "team_name", Map.get(tool_args, :team_name, "child-team"))
+
+    purpose =
+      Map.get(tool_args, "purpose", Map.get(tool_args, :purpose, "Handle the assigned work."))
+
+    requesting_agent = context[:agent_name] || "parent-agent"
+    requester_team_id = context[:team_id]
+
+    reporting_instructions =
+      if is_binary(requester_team_id) and requester_team_id != "" do
+        """
+        When you have progress, blockers, or final findings, send them back immediately with:
+        - `peer_message`
+        - `team_id: "#{requester_team_id}"`
+        - `to: "#{requesting_agent}"`
+        """
+      else
+        "When you have progress, blockers, or final findings, send them back to the requesting agent immediately."
+      end
+
+    """
+    [Spawn Work Order]
+    Team: #{team_name}
+    Requested by: #{requesting_agent}
+
+    #{purpose}
+
+    Start working now. Do not wait for another prompt.
+    #{reporting_instructions}
+    """
+    |> String.trim()
   end
 
   @string_to_atom_keys %{

--- a/loomkin-server/lib/loomkin/teams/agent.ex
+++ b/loomkin-server/lib/loomkin/teams/agent.ex
@@ -63,6 +63,9 @@ defmodule Loomkin.Teams.Agent do
     spawned_child_teams: [],
     auto_approve_spawns: false,
     wake_ref: nil,
+    wake_context: nil,
+    loop_context: nil,
+    last_loop_fingerprint: nil,
     scope_tier: nil,
     files_touched: MapSet.new(),
     task_cost_usd: 0.0
@@ -103,6 +106,11 @@ defmodule Loomkin.Teams.Agent do
   @doc "Send a peer message to this agent."
   def peer_message(pid, from, content) do
     GenServer.cast(pid, {:peer_message, from, content})
+  end
+
+  @doc "Append a system briefing without waking an idle agent."
+  def add_briefing(pid, text) when is_pid(pid) and is_binary(text) do
+    GenServer.cast(pid, {:add_briefing, text})
   end
 
   @doc "Get current agent status."
@@ -355,18 +363,9 @@ defmodule Loomkin.Teams.Agent do
 
     user_message = %{role: :user, content: text}
     messages = state.messages ++ [user_message]
+    trigger = build_trigger_context(:user_message, %{preview: text, from: "user"}, state)
 
-    loop_opts = build_loop_opts(state)
-    snapshot = build_snapshot(state)
-
-    task =
-      Task.Supervisor.async_nolink(Loomkin.Teams.TaskSupervisor, fn ->
-        run_loop_with_escalation(messages, loop_opts, snapshot)
-      end)
-
-    Logger.debug("[Kin:loop] spawned agent=#{state.name} ref=#{inspect(task.ref)}")
-
-    {:noreply, %{state | loop_task: {task, from}}}
+    {:noreply, start_loop(state, messages, from, trigger)}
   end
 
   # Inject broadcast into paused agent's message history without starting a loop
@@ -1120,7 +1119,13 @@ defmodule Loomkin.Teams.Agent do
   def handle_cast({:peer_message, from, content}, state) do
     peer_msg = %{role: :user, content: "[Peer #{from}]: #{content}"}
     state = %{state | messages: state.messages ++ [peer_msg]}
-    {:noreply, maybe_wake_idle(state)}
+    {:noreply, maybe_wake_idle(state, :peer_message, %{from: from, preview: content})}
+  end
+
+  @impl true
+  def handle_cast({:add_briefing, content}, state) do
+    briefing = %{role: :system, content: content}
+    {:noreply, %{state | messages: state.messages ++ [briefing]}}
   end
 
   @impl true
@@ -1213,6 +1218,7 @@ defmodule Loomkin.Teams.Agent do
 
     state = %{state | messages: msgs, failure_count: 0, loop_task: nil, task: nil}
     state = track_usage(state, meta)
+    state = clear_loop_context(state)
 
     state = set_status_and_broadcast(state, :idle)
 
@@ -1248,6 +1254,7 @@ defmodule Loomkin.Teams.Agent do
       %{state | messages: msgs, failure_count: 0, model: new_model, loop_task: nil, task: nil}
 
     state = track_usage(state, meta)
+    state = clear_loop_context(state)
 
     state = set_status_and_broadcast(state, :idle)
 
@@ -1348,11 +1355,7 @@ defmodule Loomkin.Teams.Agent do
     {%Task{}, from} = state.loop_task
     task_id = state.task && state.task[:id]
 
-    require Logger
-
-    Logger.error(
-      "[Kin:agent] loop error name=#{state.name} team=#{state.team_id} reason=#{inspect(reason)}"
-    )
+    log_loop_error(state, reason)
 
     if task_id do
       Context.cache_task(state.team_id, task_id, %{
@@ -1363,6 +1366,7 @@ defmodule Loomkin.Teams.Agent do
     end
 
     state = %{state | messages: msgs, loop_task: nil, pending_permission: nil}
+    state = clear_loop_context(state)
     state = set_status_and_broadcast(state, :idle)
 
     if from do
@@ -1433,11 +1437,7 @@ defmodule Loomkin.Teams.Agent do
       {%Task{ref: ^ref}, from} ->
         task_id = state.task && state.task[:id]
 
-        require Logger
-
-        Logger.error(
-          "[Kin:agent] loop crashed name=#{state.name} team=#{state.team_id} reason=#{inspect(reason)}"
-        )
+        log_loop_crash(state, reason)
 
         if task_id do
           Context.cache_task(state.team_id, task_id, %{
@@ -1448,6 +1448,7 @@ defmodule Loomkin.Teams.Agent do
         end
 
         state = %{state | loop_task: nil, pending_permission: nil}
+        state = clear_loop_context(state)
 
         status =
           if reason in [:normal, :shutdown] do
@@ -1818,7 +1819,7 @@ defmodule Loomkin.Teams.Agent do
   def handle_info({:peer_message, from, content}, state) do
     peer_msg = %{role: :user, content: "[Peer #{from}]: #{content}"}
     state = %{state | messages: state.messages ++ [peer_msg]}
-    {:noreply, maybe_wake_idle(state)}
+    {:noreply, maybe_wake_idle(state, :peer_message, %{from: from, preview: content})}
   end
 
   @impl true
@@ -1876,17 +1877,11 @@ defmodule Loomkin.Teams.Agent do
 
       user_message = %{role: :user, content: description}
       messages = state.messages ++ [user_message]
-      loop_opts = build_loop_opts(state)
-      snapshot = build_snapshot(state)
 
-      async_task =
-        Task.Supervisor.async_nolink(Loomkin.Teams.TaskSupervisor, fn ->
-          run_loop_with_escalation(messages, loop_opts, snapshot)
-        end)
+      trigger =
+        build_trigger_context(:task_assignment, %{task_id: task_id, preview: description}, state)
 
-      Logger.debug("[Kin:loop] spawned agent=#{state.name} ref=#{inspect(async_task.ref)}")
-
-      {:noreply, %{state | loop_task: {async_task, nil}}}
+      {:noreply, start_loop(state, messages, nil, trigger)}
     end
   end
 
@@ -1894,7 +1889,8 @@ defmodule Loomkin.Teams.Agent do
   # task notifications), this starts a new loop so the agent processes them.
   @impl true
   def handle_info(:wake_up, state) do
-    state = %{state | wake_ref: nil}
+    trigger = state.wake_context || build_trigger_context(:wake_up, %{}, state)
+    state = %{state | wake_ref: nil, wake_context: nil}
 
     if state.status != :idle || state.loop_task != nil do
       {:noreply, state}
@@ -1921,17 +1917,8 @@ defmodule Loomkin.Teams.Agent do
         state = set_status_and_broadcast(state, :working)
 
         messages = state.messages
-        loop_opts = build_loop_opts(state)
-        snapshot = build_snapshot(state)
 
-        async_task =
-          Task.Supervisor.async_nolink(Loomkin.Teams.TaskSupervisor, fn ->
-            run_loop_with_escalation(messages, loop_opts, snapshot)
-          end)
-
-        Logger.debug("[Kin:loop] wake spawned agent=#{state.name} ref=#{inspect(async_task.ref)}")
-
-        {:noreply, %{state | loop_task: {async_task, nil}}}
+        {:noreply, start_loop(state, messages, nil, trigger)}
       end
     end
   end
@@ -1976,7 +1963,7 @@ defmodule Loomkin.Teams.Agent do
       }
 
       state = %{state | messages: state.messages ++ [query_msg]}
-      {:noreply, maybe_wake_idle(state)}
+      {:noreply, maybe_wake_idle(state, :query, %{from: from, preview: question})}
     end
   end
 
@@ -1997,7 +1984,7 @@ defmodule Loomkin.Teams.Agent do
     }
 
     state = %{state | messages: state.messages ++ [answer_msg]}
-    {:noreply, maybe_wake_idle(state)}
+    {:noreply, maybe_wake_idle(state, :query_answer, %{from: from, preview: answer})}
   end
 
   @impl true
@@ -2026,7 +2013,12 @@ defmodule Loomkin.Teams.Agent do
       content: "[System] Sub-team #{sub_team_id} completed and dissolved.#{summary}"
     }
 
-    {:noreply, maybe_wake_idle(%{state | messages: state.messages ++ [msg]})}
+    {:noreply,
+     maybe_wake_idle(
+       %{state | messages: state.messages ++ [msg]},
+       :sub_team_completed,
+       %{preview: "sub-team #{sub_team_id} completed"}
+     )}
   end
 
   @impl true
@@ -2195,6 +2187,7 @@ defmodule Loomkin.Teams.Agent do
     }
 
     state = track_usage(state, metadata)
+    state = clear_loop_context(state)
     state = set_status_and_broadcast(state, :idle)
 
     # If there's an active task, complete it with the response
@@ -2207,7 +2200,10 @@ defmodule Loomkin.Teams.Agent do
 
   @impl true
   def handle_info({:loop_resumed, {:error, _reason, messages}}, state) do
-    state = %{state | messages: messages, loop_task: nil, task: nil, pending_permission: nil}
+    state =
+      %{state | messages: messages, loop_task: nil, task: nil, pending_permission: nil}
+      |> clear_loop_context()
+
     state = set_status_and_broadcast(state, :idle)
     {:noreply, drain_queues(state)}
   end
@@ -2416,7 +2412,7 @@ defmodule Loomkin.Teams.Agent do
   def handle_info({:inject_system_message, content}, state) do
     msg = %{role: :system, content: content}
     state = %{state | messages: state.messages ++ [msg]}
-    {:noreply, maybe_wake_idle(state)}
+    {:noreply, maybe_wake_idle(state, :inject_system_message, %{preview: content})}
   end
 
   def handle_info({:child_team_spawned, child_team_id}, state) do
@@ -2739,10 +2735,29 @@ defmodule Loomkin.Teams.Agent do
 
   # Schedule a wake-up for an idle agent after a short debounce.
   # This coalesces rapid-fire messages so we don't start multiple loops.
-  defp maybe_wake_idle(state) do
-    if state.status == :idle and state.loop_task == nil and state.wake_ref == nil do
-      ref = Process.send_after(self(), :wake_up, 500)
-      %{state | wake_ref: ref}
+  defp maybe_wake_idle(state), do: maybe_wake_idle(state, :unspecified, %{})
+
+  defp maybe_wake_idle(state, source, meta) do
+    if state.status == :idle and state.loop_task == nil do
+      context = build_trigger_context(source, meta, state)
+
+      if state.wake_ref == nil do
+        ref = Process.send_after(self(), :wake_up, 500)
+
+        Logger.debug(
+          "[Kin:wake] scheduled agent=#{state.name} team=#{state.team_id} trigger=#{context.source} from=#{context.from || "-"} fingerprint=#{context.fingerprint}"
+        )
+
+        %{state | wake_ref: ref, wake_context: context}
+      else
+        updated = coalesce_wake_context(state.wake_context, context)
+
+        Logger.debug(
+          "[Kin:wake] coalesced agent=#{state.name} team=#{state.team_id} trigger=#{context.source} coalesced=#{updated.coalesced_count} fingerprint=#{updated.fingerprint}"
+        )
+
+        %{state | wake_context: updated}
+      end
     else
       state
     end
@@ -2759,19 +2774,125 @@ defmodule Loomkin.Teams.Agent do
   defp maybe_rerun_after_healing(state) do
     if state.task do
       # Agent had an active task before suspension — re-run the loop to continue
-      loop_opts = build_loop_opts(state)
-      snapshot = build_snapshot(state)
-
-      task =
-        Task.Supervisor.async_nolink(Loomkin.Teams.TaskSupervisor, fn ->
-          run_loop_with_escalation(state.messages, loop_opts, snapshot)
-        end)
-
       state = set_status_and_broadcast(state, :working)
-      %{state | loop_task: {task, nil}}
+
+      trigger =
+        build_trigger_context(
+          :healing_resume,
+          %{
+            reason: state.loop_context && state.loop_context[:source],
+            preview: "[healing resume]"
+          },
+          state
+        )
+
+      start_loop(state, state.messages, nil, trigger)
     else
       state
     end
+  end
+
+  defp start_loop(state, messages, from, trigger) do
+    loop_opts = build_loop_opts(state)
+    snapshot = build_snapshot(state)
+    duplicate_prev = state.last_loop_fingerprint == trigger.fingerprint
+
+    log_loop_start(state, trigger, messages, duplicate_prev)
+
+    task =
+      Task.Supervisor.async_nolink(Loomkin.Teams.TaskSupervisor, fn ->
+        run_loop_with_escalation(messages, loop_opts, snapshot)
+      end)
+
+    Logger.debug("[Kin:loop] spawned agent=#{state.name} ref=#{inspect(task.ref)}")
+
+    %{
+      state
+      | loop_task: {task, from},
+        loop_context: trigger,
+        last_loop_fingerprint: trigger.fingerprint
+    }
+  end
+
+  defp build_trigger_context(source, meta, state) do
+    preview = meta |> Map.get(:preview) |> preview_text()
+    from = meta[:from] && to_string(meta[:from])
+    reason = meta[:reason] && to_string(meta[:reason])
+    task_id = meta[:task_id] || (state.task && state.task[:id])
+
+    base = %{
+      source: source,
+      from: from,
+      reason: reason,
+      task_id: task_id,
+      preview: preview,
+      coalesced_count: 1,
+      queue_depth: length(state.priority_queue) + length(state.pending_updates)
+    }
+
+    Map.put(base, :fingerprint, request_fingerprint(base))
+  end
+
+  defp coalesce_wake_context(nil, context), do: context
+
+  defp coalesce_wake_context(existing, incoming) do
+    recent_sources =
+      [incoming.source | List.wrap(existing[:recent_sources])]
+      |> Enum.take(5)
+
+    existing
+    |> Map.put(:coalesced_count, (existing[:coalesced_count] || 1) + 1)
+    |> Map.put(:recent_sources, recent_sources)
+    |> Map.put(:from, incoming.from || existing[:from])
+    |> Map.put(:reason, incoming.reason || existing[:reason])
+    |> Map.put(:preview, incoming.preview || existing[:preview])
+    |> Map.put(:queue_depth, max(existing[:queue_depth] || 0, incoming[:queue_depth] || 0))
+  end
+
+  defp request_fingerprint(context) do
+    :erlang.phash2({
+      context[:source],
+      context[:from],
+      context[:reason],
+      context[:task_id],
+      context[:preview]
+    })
+  end
+
+  defp preview_text(nil), do: nil
+
+  defp preview_text(text) when is_binary(text) do
+    text
+    |> String.replace(~r/\s+/, " ")
+    |> String.slice(0, 120)
+  end
+
+  defp preview_text(other), do: other |> inspect(limit: 40) |> String.slice(0, 120)
+
+  defp log_loop_start(state, trigger, messages, duplicate_prev) do
+    Logger.info(
+      "[Kin:loop] start agent=#{state.name} team=#{state.team_id} trigger=#{trigger.source} from=#{trigger.from || "-"} reason=#{trigger.reason || "-"} coalesced=#{trigger.coalesced_count || 1} duplicate_prev=#{duplicate_prev} fingerprint=#{trigger.fingerprint} messages=#{length(messages)} priority_queue=#{length(state.priority_queue)} normal_queue=#{length(state.pending_updates)} task=#{trigger.task_id || "-"} preview=#{inspect(trigger.preview || "-", limit: 40)}"
+    )
+  end
+
+  defp log_loop_error(state, reason) do
+    trigger = state.loop_context || %{}
+
+    Logger.error(
+      "[Kin:agent] loop error name=#{state.name} team=#{state.team_id} trigger=#{trigger[:source] || "-"} fingerprint=#{trigger[:fingerprint] || "-"} reason=#{inspect(reason)}"
+    )
+  end
+
+  defp log_loop_crash(state, reason) do
+    trigger = state.loop_context || %{}
+
+    Logger.error(
+      "[Kin:agent] loop crashed name=#{state.name} team=#{state.team_id} trigger=#{trigger[:source] || "-"} fingerprint=#{trigger[:fingerprint] || "-"} reason=#{inspect(reason)}"
+    )
+  end
+
+  defp clear_loop_context(state) do
+    %{state | loop_context: nil}
   end
 
   defp list_full_queue(state) do
@@ -3846,6 +3967,7 @@ defmodule Loomkin.Teams.Agent do
   defp track_usage(state, %{usage: usage}) do
     total_tokens = (usage[:input_tokens] || 0) + (usage[:output_tokens] || 0)
     raw_cost = usage[:total_cost] || 0
+    trigger = state.loop_context || %{}
 
     cost =
       if raw_cost > 0 do
@@ -3881,8 +4003,19 @@ defmodule Loomkin.Teams.Agent do
       input_tokens: usage[:input_tokens] || 0,
       output_tokens: usage[:output_tokens] || 0,
       cost: cost,
-      task_id: state.task && state.task[:id]
+      task_id: state.task && state.task[:id],
+      trigger_source: trigger[:source],
+      trigger_from: trigger[:from],
+      trigger_reason: trigger[:reason],
+      trigger_preview: trigger[:preview],
+      trigger_fingerprint: trigger[:fingerprint],
+      trigger_coalesced_count: trigger[:coalesced_count],
+      trigger_queue_depth: trigger[:queue_depth]
     })
+
+    Logger.info(
+      "[Kin:usage] agent=#{state.name} team=#{state.team_id} model=#{state.model} trigger=#{trigger[:source] || "-"} from=#{trigger[:from] || "-"} coalesced=#{trigger[:coalesced_count] || 1} fingerprint=#{trigger[:fingerprint] || "-"} input_tokens=#{usage[:input_tokens] || 0} output_tokens=#{usage[:output_tokens] || 0} total_tokens=#{total_tokens} cost=#{:erlang.float_to_binary(cost * 1.0, decimals: 6)} task=#{(state.task && state.task[:id]) || "-"}"
+    )
 
     # Emit telemetry for PubSub broadcast only — handlers must NOT
     # write back to CostTracker (already recorded above).

--- a/loomkin-server/lib/loomkin/teams/role.ex
+++ b/loomkin-server/lib/loomkin/teams/role.ex
@@ -721,6 +721,12 @@ defmodule Loomkin.Teams.Role do
          asked, not to become an expert on the entire area. If follow-up research is needed,
          the lead will spawn another researcher.
 
+      ## Research Budget Discipline
+      - Timebox broad exploration. After a few search/read passes, ask yourself whether you can already answer the assigned questions.
+      - If you have enough to produce a useful recommendation, STOP exploring and publish the findings.
+      - Persist before you disappear: use `context_offload` and `peer_discovery` before `peer_complete_task`.
+      - Prefer narrow follow-up questions over endless browsing. If the task still feels too broad, tell the lead exactly what remains unknown.
+
       ## Team Manifest
       {team_manifest}
       """

--- a/loomkin-server/lib/loomkin/teams/role.ex
+++ b/loomkin-server/lib/loomkin/teams/role.ex
@@ -913,6 +913,8 @@ defmodule Loomkin.Teams.Role do
       - Use decision_query (type: "pulse") to scan for active goals and coverage gaps
       - Use search_keepers to check for prior session context before responding
       - Build situational awareness yourself — scan on demand rather than waiting for briefings
+      - Do NOT automatically run query_backlog or decision scans at the start of every turn. Use them only when the user asked about roadmap/planned work, or when they materially change delegation.
+      - If the user already gave you a concrete task, skip most meta-scanning and route the work.
 
       ## Convergence Discipline
       Your job is to move the session forward, not to stay in a planning loop.
@@ -928,6 +930,7 @@ defmodule Loomkin.Teams.Role do
       - Treat your own time as scarce: your value is staying responsive to the user, checking approvals, and synthesizing specialist results.
       - For research-heavy or implementation-heavy tasks, hand the work to a lead, researcher, coder, or full team quickly instead of personally driving every loop.
       - If you already know enough to route the work, spawn the right team now rather than gathering more meta-context.
+      - If the user already gave a concrete request, do NOT ask "what would you like me to move on right now?" and do NOT ask them to restate the task. Route it.
 
       ## Coordination Style
       - You are a warm host, not a cold dispatcher
@@ -962,6 +965,20 @@ defmodule Loomkin.Teams.Role do
         then spawn coder with the research results as context
       - Create tasks with peer_create_task so progress is tracked
       - If a task looks like it could keep you busy for multiple iterations, spawn a lead or full team early so you can return to the user-facing role
+
+      ## Concrete Request Fast Path
+      When the latest user message already names a concrete task like:
+      - "research X"
+      - "fix bug Y"
+      - "implement feature Z"
+      - "summarize the current state of A"
+
+      then do NOT reply with a generic options menu or a broad "what should I do next?" prompt.
+      Instead:
+      1. Acknowledge the task briefly
+      2. Route it immediately to the right specialist or team
+      3. Only ask a clarifying question if one specific missing detail blocks delegation
+      4. If you must clarify, ask for that missing detail directly — not an open-ended restatement request
 
       ## Anti-Pattern: Doing Work Yourself
       NEVER use file_read, content_search, file_search, or shell to investigate code yourself.

--- a/loomkin-server/lib/loomkin/teams/role.ex
+++ b/loomkin-server/lib/loomkin/teams/role.ex
@@ -619,6 +619,14 @@ defmodule Loomkin.Teams.Role do
       ## Conversation Deliberation
       Before decomposing a complex task, consider spawning a `design_review` conversation to explore approaches. Include relevant code snippets, constraints, and requirements as context so the conversation agents can reason concretely.
 
+      ## Convergence Discipline
+      Coordination tools are for orientation, not for infinite planning loops.
+      - Do one quick coordination pass, then delegate or answer.
+      - Do NOT keep alternating between decision_query, query_backlog, search_keepers, or decision_log without new external input.
+      - Do NOT log the same goal repeatedly unless the objective materially changed.
+      - If you still lack clarity after a small coordination pass, ask the human a focused question or delegate to a specialist instead of running more meta-tools yourself.
+      - Never call the same coordination tool twice in a row with nearly identical arguments unless new information arrived since the previous call.
+
       ## Research Protocol (First Message Only)
       When you receive the first message in a team session, before doing anything else:
       1. Identify 1–3 distinct research questions needed to answer the task well
@@ -899,6 +907,14 @@ defmodule Loomkin.Teams.Role do
       - Use decision_query (type: "pulse") to scan for active goals and coverage gaps
       - Use search_keepers to check for prior session context before responding
       - Build situational awareness yourself — scan on demand rather than waiting for briefings
+
+      ## Convergence Discipline
+      Your job is to move the session forward, not to stay in a planning loop.
+      - Use a small number of coordination/meta tools to orient yourself, then either delegate, ask a clarifying question, or answer.
+      - Do NOT keep cycling through decision_query, query_backlog, search_keepers, and decision_log with similar arguments.
+      - Do NOT log a new goal every turn for the same user request; reuse the existing goal unless the objective changed.
+      - If you have already done an initial scan and still need deeper understanding, spawn a specialist instead of doing more coordination scans yourself.
+      - Never call the same coordination tool twice in a row with nearly identical arguments unless something new happened in between.
 
       ## Coordination Style
       - You are a warm host, not a cold dispatcher

--- a/loomkin-server/lib/loomkin/teams/role.ex
+++ b/loomkin-server/lib/loomkin/teams/role.ex
@@ -916,6 +916,13 @@ defmodule Loomkin.Teams.Role do
       - If you have already done an initial scan and still need deeper understanding, spawn a specialist instead of doing more coordination scans yourself.
       - Never call the same coordination tool twice in a row with nearly identical arguments unless something new happened in between.
 
+      ## Availability Contract
+      Stay free for the user.
+      - After one short orientation pass, prefer team_spawn, spawn_conversation, or specialist handoff over doing deeper research yourself.
+      - Treat your own time as scarce: your value is staying responsive to the user, checking approvals, and synthesizing specialist results.
+      - For research-heavy or implementation-heavy tasks, hand the work to a lead, researcher, coder, or full team quickly instead of personally driving every loop.
+      - If you already know enough to route the work, spawn the right team now rather than gathering more meta-context.
+
       ## Coordination Style
       - You are a warm host, not a cold dispatcher
       - Acknowledge the user's request before delegating
@@ -948,6 +955,7 @@ defmodule Loomkin.Teams.Role do
       - For research → implementation flows: spawn researcher first, wait for findings,
         then spawn coder with the research results as context
       - Create tasks with peer_create_task so progress is tracked
+      - If a task looks like it could keep you busy for multiple iterations, spawn a lead or full team early so you can return to the user-facing role
 
       ## Anti-Pattern: Doing Work Yourself
       NEVER use file_read, content_search, file_search, or shell to investigate code yourself.

--- a/loomkin-server/lib/loomkin/tools/decision_log.ex
+++ b/loomkin-server/lib/loomkin/tools/decision_log.ex
@@ -23,6 +23,8 @@ defmodule Loomkin.Tools.DecisionLog do
 
   alias Loomkin.Decisions.Graph
 
+  require Logger
+
   @valid_node_types ~w(goal decision option action outcome observation revisit)
   @valid_edge_types ~w(leads_to chosen rejected requires blocks enables supersedes supports revises summarizes)
 
@@ -67,14 +69,48 @@ defmodule Loomkin.Tools.DecisionLog do
       metadata: metadata
     }
 
-    case Graph.add_node(attrs) do
-      {:ok, node} ->
-        maybe_create_edge(node, params)
+    case maybe_find_existing_goal(node_type, title, metadata, session_id) do
+      {:ok, existing} ->
+        Logger.info(
+          "[Kin:decision_log] reusing active goal id=#{existing.id} title=#{inspect(title)} team=#{metadata["team_id"] || "-"} session=#{session_id || "-"}"
+        )
 
-      {:error, changeset} ->
-        {:error, "Failed to log decision: #{inspect(changeset.errors)}"}
+        {:ok, %{result: "Reused active goal: #{existing.title} (id: #{existing.id})"}}
+
+      :none ->
+        case Graph.add_node(attrs) do
+          {:ok, node} ->
+            maybe_create_edge(node, params)
+
+          {:error, changeset} ->
+            {:error, "Failed to log decision: #{inspect(changeset.errors)}"}
+        end
     end
   end
+
+  defp maybe_find_existing_goal(:goal, title, metadata, session_id) do
+    filters =
+      [limit: 1, node_type: :goal, status: :active, title: title]
+      |> maybe_add_scope_filter(metadata["team_id"], session_id)
+
+    case Graph.list_nodes(filters) do
+      [existing | _] -> {:ok, existing}
+      [] -> :none
+    end
+  end
+
+  defp maybe_find_existing_goal(_node_type, _title, _metadata, _session_id), do: :none
+
+  defp maybe_add_scope_filter(filters, team_id, _session_id)
+       when is_binary(team_id) and team_id != "" do
+    Keyword.put(filters, :team_id, team_id)
+  end
+
+  defp maybe_add_scope_filter(filters, _team_id, session_id) when is_binary(session_id) do
+    Keyword.put(filters, :session_id, session_id)
+  end
+
+  defp maybe_add_scope_filter(filters, _team_id, _session_id), do: filters
 
   defp maybe_create_edge(node, params) do
     case param(params, :parent_id) do

--- a/loomkin-server/lib/loomkin/tools/decision_query.ex
+++ b/loomkin-server/lib/loomkin/tools/decision_query.ex
@@ -15,32 +15,35 @@ defmodule Loomkin.Tools.DecisionQuery do
       limit: [type: :integer, doc: "Maximum results to return (default 10)"]
     ]
 
-  import Loomkin.Tool, only: [param!: 2, param: 3]
+  import Ecto.Query
+  import Loomkin.Tool, only: [param!: 2, param: 2, param: 3]
 
   alias Loomkin.Decisions.Graph
   alias Loomkin.Decisions.Pulse
+  alias Loomkin.Schemas.DecisionNode
 
   @impl true
-  def run(params, _context) do
+  def run(params, context) do
     query_type = param!(params, :query_type)
     limit = param(params, :limit, 10)
+    scope = scope_filters(context)
 
     case query_type do
       "active_goals" ->
-        goals = Graph.active_goals()
+        goals = Graph.active_goals(scope)
         {:ok, %{result: format_nodes("Active Goals", goals)}}
 
       "recent_decisions" ->
-        decisions = Graph.recent_decisions(limit)
+        decisions = Graph.recent_decisions(limit, scope)
         {:ok, %{result: format_nodes("Recent Decisions", decisions)}}
 
       "pulse" ->
-        report = Pulse.generate()
+        report = Pulse.generate(scope)
         {:ok, %{result: "#{report.summary} Health: #{report.health_score}/100."}}
 
       "search" ->
         search_term = param(params, :search_term, "")
-        results = search_nodes(search_term, limit)
+        results = search_nodes(search_term, limit, scope)
         {:ok, %{result: format_nodes("Search Results for '#{search_term}'", results)}}
 
       other ->
@@ -49,18 +52,48 @@ defmodule Loomkin.Tools.DecisionQuery do
     end
   end
 
-  defp search_nodes(term, limit) do
-    import Ecto.Query
-    alias Loomkin.Schemas.DecisionNode
-
+  defp search_nodes(term, limit, scope) do
     pattern = "%#{term}%"
 
     DecisionNode
-    |> where([n], like(n.title, ^pattern) or like(n.description, ^pattern))
+    |> maybe_apply_scope(scope)
+    |> where(
+      [n],
+      ilike(n.title, ^pattern) or ilike(fragment("coalesce(?, '')", n.description), ^pattern)
+    )
     |> limit(^limit)
     |> order_by([n], desc: n.inserted_at)
     |> Loomkin.Repo.all()
   end
+
+  defp scope_filters(context) do
+    team_id = param(context, :team_id)
+    session_id = param(context, :session_id)
+
+    cond do
+      is_binary(team_id) and team_id != "" ->
+        [team_id: team_id]
+
+      valid_uuid?(session_id) ->
+        [session_id: session_id]
+
+      true ->
+        []
+    end
+  end
+
+  defp maybe_apply_scope(query, []), do: query
+
+  defp maybe_apply_scope(query, team_id: team_id) do
+    where(query, [n], fragment("? ->> 'team_id' = ?", n.metadata, ^team_id))
+  end
+
+  defp maybe_apply_scope(query, session_id: session_id) do
+    where(query, [n], n.session_id == ^session_id)
+  end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_value), do: false
 
   defp format_nodes(heading, []) do
     "#{heading}: None found."

--- a/loomkin-server/lib/loomkin/tools/peer_complete_task.ex
+++ b/loomkin-server/lib/loomkin/tools/peer_complete_task.ex
@@ -23,6 +23,7 @@ defmodule Loomkin.Tools.PeerCompleteTask do
 
   import Loomkin.Tool, only: [param!: 2, param: 2]
 
+  alias Loomkin.Teams.ContextOffload
   alias Loomkin.Teams.Tasks
 
   @impl true
@@ -45,7 +46,7 @@ defmodule Loomkin.Tools.PeerCompleteTask do
       :ok ->
         # Verify claimed files actually exist on disk
         file_warnings = verify_files_changed(completion_attrs.files_changed, project_path)
-        do_complete(team_id, task_id, completion_attrs, file_warnings)
+        do_complete(team_id, task_id, completion_attrs, file_warnings, context)
 
       {:error, reason} ->
         {:error, reason}
@@ -102,7 +103,7 @@ defmodule Loomkin.Tools.PeerCompleteTask do
     end)
   end
 
-  defp do_complete(team_id, task_id, completion_attrs, file_warnings) do
+  defp do_complete(team_id, task_id, completion_attrs, file_warnings, context) do
     case Tasks.get_task(task_id) do
       {:error, :not_found} ->
         {:error, "Task not found: #{task_id}"}
@@ -114,43 +115,179 @@ defmodule Loomkin.Tools.PeerCompleteTask do
           "[PeerCompleteTask] Cross-team completion: agent team=#{team_id}, task team=#{task.team_id}, task=#{task_id}"
         )
 
-        do_complete_task(task_id, completion_attrs, file_warnings)
+        do_complete_task(task, completion_attrs, file_warnings, context)
 
-      {:ok, _task} ->
-        do_complete_task(task_id, completion_attrs, file_warnings)
+      {:ok, task} ->
+        do_complete_task(task, completion_attrs, file_warnings, context)
     end
   end
 
-  defp do_complete_task(task_id, completion_attrs, file_warnings) do
-    case Tasks.complete_task(task_id, completion_attrs) do
-      {:ok, task} ->
-        artifact_count =
-          length(completion_attrs.actions_taken) +
-            length(completion_attrs.discoveries) +
-            length(completion_attrs.files_changed)
+  defp do_complete_task(task, completion_attrs, file_warnings, context) do
+    case maybe_persist_research_findings(task, completion_attrs, context) do
+      {:error, reason} ->
+        {:error, reason}
 
-        warning_section =
-          if file_warnings != [] do
-            "\n  ⚠ File verification warnings: #{Enum.join(file_warnings, ", ")}"
-          else
-            ""
-          end
+      {:ok, publication_note} ->
+        case Tasks.complete_task(task.id, completion_attrs) do
+          {:ok, task} ->
+            artifact_count =
+              length(completion_attrs.actions_taken) +
+                length(completion_attrs.discoveries) +
+                length(completion_attrs.files_changed)
 
-        verified_count = length(completion_attrs.files_changed) - length(file_warnings)
+            warning_section =
+              if file_warnings != [] do
+                "\n  ⚠ File verification warnings: #{Enum.join(file_warnings, ", ")}"
+              else
+                ""
+              end
 
-        summary = """
-        Task completed:
-          ID: #{task.id}
-          Title: #{task.title}
-          Status: #{task.status}
-          Artifacts: #{artifact_count} (#{length(completion_attrs.actions_taken)} actions, #{length(completion_attrs.discoveries)} discoveries, #{length(completion_attrs.files_changed)} files)
-          Files verified: #{verified_count}/#{length(completion_attrs.files_changed)}#{warning_section}
-        """
+            publication_section =
+              case publication_note do
+                "" -> ""
+                note -> "\n  Findings published: #{note}"
+              end
 
-        {:ok, %{result: String.trim(summary), task_id: task.id}}
+            verified_count = length(completion_attrs.files_changed) - length(file_warnings)
+
+            summary = """
+            Task completed:
+              ID: #{task.id}
+              Title: #{task.title}
+              Status: #{task.status}
+              Artifacts: #{artifact_count} (#{length(completion_attrs.actions_taken)} actions, #{length(completion_attrs.discoveries)} discoveries, #{length(completion_attrs.files_changed)} files)
+              Files verified: #{verified_count}/#{length(completion_attrs.files_changed)}#{warning_section}#{publication_section}
+            """
+
+            {:ok, %{result: String.trim(summary), task_id: task.id}}
+
+          {:error, reason} ->
+            {:error, "Failed to complete task: #{inspect(reason)}"}
+        end
+    end
+  end
+
+  defp maybe_persist_research_findings(task, completion_attrs, context) do
+    if researcher_role?(context) do
+      publication_state = param(context, :publication_state) || %{}
+
+      if publication_state[:offloaded] do
+        {:ok, ""}
+      else
+        auto_publish_research_findings(task, completion_attrs, context)
+      end
+    else
+      {:ok, ""}
+    end
+  end
+
+  defp auto_publish_research_findings(task, completion_attrs, context) do
+    team_id = task.team_id
+    agent_name = param(context, :agent_name) || task.owner || "researcher"
+    topic = build_research_topic(task)
+
+    metadata = %{
+      "source" => "peer_complete_task",
+      "task_id" => task.id,
+      "task_title" => task.title,
+      "kind" => "research_findings"
+    }
+
+    case ContextOffload.offload_to_keeper(
+           team_id,
+           agent_name,
+           build_research_offload_messages(task, completion_attrs, agent_name),
+           topic: topic,
+           metadata: metadata
+         ) do
+      {:ok, _pid, index_entry} ->
+        publish_findings_offloaded(agent_name, team_id, %{
+          topic: topic,
+          source: "peer_complete_task",
+          task_id: task.id,
+          index_entry: index_entry
+        })
+
+        {:ok, "#{topic} (auto-offloaded from task completion)"}
 
       {:error, reason} ->
-        {:error, "Failed to complete task: #{inspect(reason)}"}
+        {:error,
+         "Task completion rejected: failed to persist research findings before completion. " <>
+           "Try again after context_offload succeeds. Reason: #{inspect(reason)}"}
     end
+  end
+
+  defp build_research_topic(task) do
+    title =
+      task.title
+      |> to_string()
+      |> String.trim()
+
+    "research: #{title}"
+    |> String.slice(0, 80)
+  end
+
+  defp build_research_offload_messages(task, attrs, agent_name) do
+    body = """
+    Task: #{task.title}
+    Researcher: #{agent_name}
+    Completed at: #{DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()}
+
+    Result
+    #{attrs.result}
+
+    Discoveries
+    #{format_bullet_list(attrs.discoveries)}
+
+    Actions Taken
+    #{format_bullet_list(attrs.actions_taken)}
+
+    Decisions Made
+    #{format_bullet_list(attrs.decisions_made)}
+
+    Open Questions
+    #{format_bullet_list(attrs.open_questions)}
+
+    Files Changed
+    #{format_bullet_list(attrs.files_changed)}
+    """
+
+    [
+      %{
+        role: :system,
+        content: "Research findings persisted from peer_complete_task for later retrieval."
+      },
+      %{role: :assistant, content: String.trim(body)}
+    ]
+  end
+
+  defp format_bullet_list([]), do: "- none"
+
+  defp format_bullet_list(items) do
+    items
+    |> Enum.map(&"- #{&1}")
+    |> Enum.join("\n")
+  end
+
+  defp researcher_role?(context) do
+    case param(context, :role) do
+      :researcher -> true
+      "researcher" -> true
+      _ -> false
+    end
+  end
+
+  defp publish_findings_offloaded(agent_name, team_id, payload) do
+    signal =
+      Loomkin.Signals.Context.Offloaded.new!(
+        %{agent_name: to_string(agent_name), team_id: team_id},
+        subject: "payload"
+      )
+      |> Map.put(
+        :data,
+        Map.put(%{agent_name: to_string(agent_name), team_id: team_id}, :payload, payload)
+      )
+
+    Loomkin.Signals.publish(signal)
   end
 end

--- a/loomkin-server/lib/loomkin/tools/search_keepers.ex
+++ b/loomkin-server/lib/loomkin/tools/search_keepers.ex
@@ -1,6 +1,8 @@
 defmodule Loomkin.Tools.SearchKeepers do
   @moduledoc "Search for relevant context keepers by topic."
 
+  require Logger
+
   use Jido.Action,
     name: "search_keepers",
     description:
@@ -16,14 +18,35 @@ defmodule Loomkin.Tools.SearchKeepers do
       ]
     ]
 
-  import Loomkin.Tool, only: [param!: 2]
+  import Loomkin.Tool, only: [param!: 2, param: 2]
 
   @impl true
-  def run(params, _context) do
+  def run(params, context) do
     query = param!(params, :query)
-    team_id = param!(params, :team_id)
+    team_id = effective_team_id(params, context)
     results = Loomkin.Teams.ContextRetrieval.search(team_id, query)
     {:ok, %{result: format_results(results, query)}}
+  end
+
+  defp effective_team_id(params, context) do
+    provided_team_id = param(params, :team_id)
+    context_team_id = param(context, :team_id)
+    agent_name = param(context, :agent_name)
+
+    cond do
+      is_binary(context_team_id) and context_team_id != "" and context_team_id != provided_team_id ->
+        Logger.warning(
+          "[Kin:search_keepers] overriding provided team_id=#{inspect(provided_team_id)} with context team_id=#{inspect(context_team_id)} agent=#{inspect(agent_name)}"
+        )
+
+        context_team_id
+
+      is_binary(context_team_id) and context_team_id != "" ->
+        context_team_id
+
+      true ->
+        param!(params, :team_id)
+    end
   end
 
   defp format_results([], _query), do: "No keepers found matching the query."

--- a/loomkin-server/lib/loomkin/tools/spawn_conversation.ex
+++ b/loomkin-server/lib/loomkin/tools/spawn_conversation.ex
@@ -218,6 +218,10 @@ defmodule Loomkin.Tools.SpawnConversation do
     conversation_id = Ecto.UUID.generate()
     facilitator_name = Map.get(config, :facilitator)
 
+    Logger.debug(
+      "[Kin:spawn_conversation] start team=#{team_id} conversation=#{conversation_id} model=#{inspect(model)} participants=#{length(config.personas)} max_rounds=#{config.max_rounds} potential_turns=#{length(config.personas) * config.max_rounds}"
+    )
+
     # Build participant list with proper structure for ConversationServer
     participants =
       Enum.map(config.personas, fn persona ->

--- a/loomkin-server/lib/loomkin/tools/team_spawn.ex
+++ b/loomkin-server/lib/loomkin/tools/team_spawn.ex
@@ -1,6 +1,8 @@
 defmodule Loomkin.Tools.TeamSpawn do
   @moduledoc "Spawn a team with agents."
 
+  require Logger
+
   @valid_roles Loomkin.Teams.Role.built_in_roles() |> Enum.map(&Atom.to_string/1)
 
   use Jido.Action,
@@ -88,6 +90,7 @@ defmodule Loomkin.Tools.TeamSpawn do
     purpose = param!(params, :purpose)
     project_path = param(params, :project_path) || param(context, :project_path)
     parent_team_id = param(context, :parent_team_id)
+    requester_team_id = param(context, :team_id) || parent_team_id
     session_id = param(context, :session_id)
     model = param(context, :model)
     vault_id = param(context, :vault_id)
@@ -100,11 +103,43 @@ defmodule Loomkin.Tools.TeamSpawn do
         roles,
         project_path,
         parent_team_id,
+        requester_team_id,
         session_id,
         model,
         vault_id,
         agent_name
       )
+    end
+  end
+
+  @doc false
+  def bootstrap_spawned_team(team_id, work_order, opts \\ [])
+      when is_binary(team_id) and is_binary(work_order) do
+    from = opts[:from] || "system"
+
+    case pick_bootstrap_agent(team_id) do
+      nil ->
+        Logger.warning("[Kin:team_spawn] bootstrap skipped team=#{team_id} reason=no_agents")
+        {:error, :no_agents}
+
+      %{name: agent_name, role: role} = agent ->
+        case Manager.find_agent(team_id, agent_name) do
+          {:ok, pid} ->
+            Agent.peer_message(pid, from, work_order)
+
+            Logger.info(
+              "[Kin:team_spawn] bootstrap team=#{team_id} target=#{agent_name} role=#{role} from=#{from}"
+            )
+
+            {:ok, agent}
+
+          :error ->
+            Logger.warning(
+              "[Kin:team_spawn] bootstrap skipped team=#{team_id} reason=agent_not_found target=#{agent_name}"
+            )
+
+            {:error, :agent_not_found}
+        end
     end
   end
 
@@ -154,13 +189,12 @@ defmodule Loomkin.Tools.TeamSpawn do
          roles,
          project_path,
          parent_team_id,
+         requester_team_id,
          session_id,
          model,
          vault_id,
          agent_name
        ) do
-    require Logger
-
     Logger.info(
       "[Kin:team_spawn] team=#{team_name} roles=#{inspect(roles)} parent=#{inspect(parent_team_id)}"
     )
@@ -186,11 +220,11 @@ defmodule Loomkin.Tools.TeamSpawn do
           purpose,
           roles,
           project_path,
+          requester_team_id,
           session_id,
           model,
           vault_id,
-          agent_name,
-          parent_team_id
+          agent_name
         )
     end
   end
@@ -201,14 +235,12 @@ defmodule Loomkin.Tools.TeamSpawn do
          purpose,
          roles,
          project_path,
+         requester_team_id,
          session_id,
          model,
          vault_id,
-         requesting_agent,
-         parent_team_id
+         requesting_agent
        ) do
-    require Logger
-
     spawn_opts =
       [project_path: project_path]
       |> then(fn opts -> if session_id, do: [{:session_id, session_id} | opts], else: opts end)
@@ -271,7 +303,7 @@ defmodule Loomkin.Tools.TeamSpawn do
           purpose,
           other_agents,
           requesting_agent,
-          parent_team_id
+          requester_team_id
         )
 
       case Manager.find_agent(team_id, spawned_name) do
@@ -301,7 +333,7 @@ defmodule Loomkin.Tools.TeamSpawn do
          purpose,
          teammates,
          requesting_agent,
-         parent_team_id
+         requester_team_id
        ) do
     teammate_lines =
       teammates
@@ -312,12 +344,13 @@ defmodule Loomkin.Tools.TeamSpawn do
       |> Enum.join("\n")
 
     requester_section =
-      if requesting_agent && parent_team_id do
+      if requesting_agent && requester_team_id do
         """
 
-        **Spawned by:** #{requesting_agent} (in parent team #{parent_team_id}).
-        Report your results back to #{requesting_agent} via cross_team_query or peer_complete_task.
-        If you need clarification on your task, ask #{requesting_agent} directly.
+        **Spawned by:** #{requesting_agent} (team #{requester_team_id}).
+        Start working immediately. Send progress and final findings back to #{requesting_agent}
+        using `peer_message` with `team_id: "#{requester_team_id}"` and `to: "#{requesting_agent}"`.
+        If you complete a tracked task, also use `peer_complete_task` with structured findings.
         """
       else
         ""
@@ -336,6 +369,11 @@ defmodule Loomkin.Tools.TeamSpawn do
 
   defp communication_hint(:lead), do: " — your team lead"
   defp communication_hint(_), do: ""
+
+  defp pick_bootstrap_agent(team_id) do
+    agents = Manager.list_agents(team_id)
+    Enum.find(agents, fn agent -> agent.role == :lead end) || List.first(agents)
+  end
 
   # Resolve a role string to either a built-in role atom or a custom role description.
   # Returns {:built_in, atom} for known roles, {:custom, string} for unknown descriptions.

--- a/loomkin-server/lib/loomkin/tools/team_spawn.ex
+++ b/loomkin-server/lib/loomkin/tools/team_spawn.ex
@@ -11,7 +11,8 @@ defmodule Loomkin.Tools.TeamSpawn do
         "reviewer (code review), tester (run tests), lead (coordination), " <>
         "concierge (user-facing orchestration). " <>
         "You can also specify custom specialist roles by description (e.g. 'database-migration-specialist'). " <>
-        "You MUST provide a roles list with name and role for each agent. " <>
+        "Provide a roles list with name and role for each agent. " <>
+        "If spawn_type is 'research' and roles are omitted, Loomkin will infer a minimal research team. " <>
         "Returns a team status summary with team_id and agent list.",
     schema: [
       team_name: [type: :string, required: true, doc: "Human-readable team name"],
@@ -23,16 +24,16 @@ defmodule Loomkin.Tools.TeamSpawn do
       ],
       roles: [
         type: {:list, :map},
-        required: true,
+        required: false,
         doc:
           "List of %{name, role} maps. role can be a standard role or a custom specialist description"
       ],
       project_path: [type: :string, doc: "Path to the project for agents to work on"],
       spawn_type: [
-        type: :atom,
+        type: :string,
         required: false,
         doc:
-          "Optional spawn type. Use :research for auto-approved research sub-teams (skips human gate, budget check still runs)."
+          "Optional spawn type. Use 'research' for auto-approved research sub-teams (skips human gate, budget check still runs)."
       ]
     ]
 
@@ -41,6 +42,45 @@ defmodule Loomkin.Tools.TeamSpawn do
   alias Loomkin.Teams.Agent
   alias Loomkin.Teams.Manager
   alias Loomkin.Teams.Role
+
+  @doc false
+  def resolve_roles(params, context \\ %{}) when is_map(params) and is_map(context) do
+    team_name = param!(params, :team_name)
+    purpose = param!(params, :purpose)
+    roles = param(params, :roles)
+    inferred_research? = research_spawn?(params, context)
+
+    cond do
+      is_list(roles) and roles != [] ->
+        {:ok, roles}
+
+      inferred_research? ->
+        {:ok, inferred_research_roles(team_name, purpose)}
+
+      true ->
+        {:error, "team_spawn requires a non-empty roles list unless spawn_type is 'research'"}
+    end
+  end
+
+  @doc false
+  def research_spawn?(params, context \\ %{}) when is_map(params) and is_map(context) do
+    spawn_type = normalize_spawn_type(param(params, :spawn_type))
+    roles = param(params, :roles)
+
+    cond do
+      spawn_type == :research ->
+        true
+
+      is_list(roles) and roles != [] ->
+        false
+
+      inferred_research_context?(context) ->
+        true
+
+      true ->
+        false
+    end
+  end
 
   @impl true
   def run(params, context) do
@@ -53,20 +93,60 @@ defmodule Loomkin.Tools.TeamSpawn do
     vault_id = param(context, :vault_id)
     agent_name = param(context, :agent_name) || "architect"
 
-    roles = param!(params, :roles)
-
-    spawn_from_roles(
-      team_name,
-      purpose,
-      roles,
-      project_path,
-      parent_team_id,
-      session_id,
-      model,
-      vault_id,
-      agent_name
-    )
+    with {:ok, roles} <- resolve_roles(params, context) do
+      spawn_from_roles(
+        team_name,
+        purpose,
+        roles,
+        project_path,
+        parent_team_id,
+        session_id,
+        model,
+        vault_id,
+        agent_name
+      )
+    end
   end
+
+  defp normalize_spawn_type(spawn_type) when spawn_type in [:research, "research"], do: :research
+  defp normalize_spawn_type(_spawn_type), do: nil
+
+  defp inferred_research_context?(context) do
+    role = param(context, :role)
+    role in [:concierge, "concierge", :lead, "lead"]
+  end
+
+  defp inferred_research_roles(team_name, purpose) do
+    researcher_name =
+      case infer_agent_name(team_name) do
+        nil -> "researcher-1"
+        name -> name
+      end
+
+    [
+      %{
+        name: researcher_name,
+        role: "researcher",
+        focus: purpose
+      }
+    ]
+  end
+
+  defp infer_agent_name(team_name) when is_binary(team_name) do
+    slug =
+      team_name
+      |> String.downcase()
+      |> String.replace(~r/[^a-z0-9]+/u, "-")
+      |> String.trim("-")
+
+    if slug == "" do
+      nil
+    else
+      "#{slug}-researcher"
+    end
+  end
+
+  defp infer_agent_name(_), do: nil
 
   defp spawn_from_roles(
          team_name,

--- a/loomkin-server/lib/loomkin/tools/team_spawn.ex
+++ b/loomkin-server/lib/loomkin/tools/team_spawn.ex
@@ -195,7 +195,7 @@ defmodule Loomkin.Tools.TeamSpawn do
         )
 
       case Manager.find_agent(team_id, spawned_name) do
-        {:ok, pid} -> Agent.peer_message(pid, "system", personal_manifest)
+        {:ok, pid} -> Agent.add_briefing(pid, personal_manifest)
         _ -> :ok
       end
     end)

--- a/loomkin-server/lib/loomkin_web/channels/session_channel.ex
+++ b/loomkin-server/lib/loomkin_web/channels/session_channel.ex
@@ -538,7 +538,7 @@ defmodule LoomkinWeb.SessionChannel do
     if sig.data[:team_id] == socket.assigns[:team_id] do
       push(socket, "agent_error", %{
         agent_name: sig.data[:agent_name],
-        error: to_string(sig.data[:error] || sig.data[:message] || "unknown")
+        error: format_agent_error(sig.data)
       })
     end
 
@@ -847,6 +847,32 @@ defmodule LoomkinWeb.SessionChannel do
   def handle_info(%Jido.Signal{}, socket), do: {:noreply, socket}
 
   # --- Serialization ---
+
+  defp format_agent_error(data) do
+    payload = data[:payload]
+
+    cond do
+      present_string?(data[:error]) ->
+        to_string(data[:error])
+
+      present_string?(data[:message]) ->
+        to_string(data[:message])
+
+      is_map(payload) && is_integer(payload[:max]) ->
+        "Exceeded max iterations (#{payload[:max]})"
+
+      is_map(payload) && present_string?(payload[:reason]) ->
+        to_string(payload[:reason])
+
+      is_map(payload) && present_string?(payload[:error]) ->
+        to_string(payload[:error])
+
+      true ->
+        "unknown"
+    end
+  end
+
+  defp present_string?(value), do: is_binary(value) and String.trim(value) != ""
 
   defp ensure_session_started(session) do
     opts =

--- a/loomkin-server/lib/loomkin_web/channels/session_channel.ex
+++ b/loomkin-server/lib/loomkin_web/channels/session_channel.ex
@@ -420,11 +420,15 @@ defmodule LoomkinWeb.SessionChannel do
         {:stream_start, _sid} ->
           push(socket, "stream_start", %{})
 
-        {:stream_delta, _sid, %{content: content}} when is_binary(content) ->
-          push(socket, "stream_token", %{token: content})
-
         {:stream_delta, _sid, %{tool_call: tool_call}} ->
           push(socket, "tool_call_started", %{tool_call: tool_call})
+
+        {:stream_delta, _sid, payload} when is_map(payload) ->
+          content = payload[:content] || payload[:text]
+
+          if is_binary(content) do
+            push(socket, "stream_token", %{token: content})
+          end
 
         {:stream_end, _sid} ->
           push(socket, "stream_end", %{})
@@ -489,89 +493,117 @@ defmodule LoomkinWeb.SessionChannel do
   # --- Agent signal forwarding (filtered by team_id) ---
 
   def handle_info(%Jido.Signal{type: "agent.status"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "agent_status", %{
-        agent_name: sig.data[:agent_name],
-        status: to_string(sig.data[:status]),
-        previous_status: to_string(sig.data[:previous_status] || ""),
-        pause_queued: sig.data[:pause_queued] || false
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_status", %{
+          agent_name: sig.data[:agent_name],
+          status: to_string(sig.data[:status]),
+          previous_status: to_string(sig.data[:previous_status] || ""),
+          pause_queued: sig.data[:pause_queued] || false
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.role.changed"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "agent_role_changed", %{
-        agent_name: sig.data[:agent_name],
-        old_role: to_string(sig.data[:old_role]),
-        new_role: to_string(sig.data[:new_role])
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_role_changed", %{
+          agent_name: sig.data[:agent_name],
+          old_role: to_string(sig.data[:old_role]),
+          new_role: to_string(sig.data[:new_role])
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.tool.executing"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "agent_tool_executing", %{
-        agent_name: sig.data[:agent_name],
-        tool_name: sig.data[:tool_name]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_tool_executing", %{
+          agent_name: sig.data[:agent_name],
+          tool_name: sig.data[:tool_name]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.tool.complete"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "agent_tool_complete", %{
-        agent_name: sig.data[:agent_name],
-        tool_name: sig.data[:tool_name]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_tool_complete", %{
+          agent_name: sig.data[:agent_name],
+          tool_name: sig.data[:tool_name]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.error"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "agent_error", %{
-        agent_name: sig.data[:agent_name],
-        error: format_agent_error(sig.data)
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_error", %{
+          agent_name: sig.data[:agent_name],
+          error: format_agent_error(sig.data)
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.usage"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "agent_usage", %{
-        agent_name: sig.data[:agent_name],
-        tokens_used: sig.data[:tokens_used],
-        cost_usd: sig.data[:cost_usd]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_usage", %{
+          agent_name: sig.data[:agent_name],
+          tokens_used: sig.data[:tokens_used],
+          cost_usd: sig.data[:cost_usd]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "context.offloaded"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      payload = sig.data[:payload] || %{}
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        payload = sig.data[:payload] || %{}
 
-      push(socket, "agent_findings_published", %{
-        agent_name: sig.data[:agent_name],
-        team_id: sig.data[:team_id],
-        topic: payload[:topic] || payload["topic"],
-        source: to_string(payload[:source] || payload["source"] || "context_offload"),
-        task_id: payload[:task_id] || payload["task_id"]
-      })
+        push(socket, "agent_findings_published", %{
+          agent_name: sig.data[:agent_name],
+          team_id: sig.data[:team_id],
+          topic: payload[:topic] || payload["topic"],
+          source: to_string(payload[:source] || payload["source"] || "context_offload"),
+          task_id: payload[:task_id] || payload["task_id"]
+        })
+
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
     end
-
-    {:noreply, socket}
   end
 
   def handle_info(%Jido.Signal{type: "team.task." <> _} = sig, socket) do
@@ -594,6 +626,23 @@ defmodule LoomkinWeb.SessionChannel do
     })
 
     {:noreply, socket}
+  end
+
+  def handle_info(%Jido.Signal{type: "team.child.created"} = sig, socket) do
+    case team_event_socket(socket, sig.data[:parent_team_id]) do
+      {:ok, socket} ->
+        push(socket, "child_team_created", %{
+          child_team_id: sig.data[:team_id],
+          parent_team_id: sig.data[:parent_team_id],
+          team_name: sig.data[:team_name] || "",
+          depth: sig.data[:depth] || 0
+        })
+
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "team.dissolved"} = sig, socket) do
@@ -682,182 +731,263 @@ defmodule LoomkinWeb.SessionChannel do
   # --- Agent streaming signals — forwarded to CLI/mobile clients ---
 
   def handle_info(%Jido.Signal{type: "agent.stream.start"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "stream_start", %{})
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_stream_start", %{
+          agent_name: sig.data[:agent_name],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        if sig.data[:team_id] == current_root_team_id(socket) do
+          push(socket, "stream_start", %{})
+        end
+
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.stream.delta"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      token = get_in(sig.data, [:payload, :text]) || ""
-      if token != "", do: push(socket, "stream_token", %{token: token})
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        token = get_in(sig.data, [:payload, :text]) || ""
 
-    {:noreply, socket}
+        if token != "" do
+          push(socket, "agent_stream_delta", %{
+            agent_name: sig.data[:agent_name],
+            team_id: sig.data[:team_id],
+            token: token
+          })
+
+          if sig.data[:team_id] == current_root_team_id(socket) do
+            push(socket, "stream_token", %{token: token})
+          end
+        end
+
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.stream.end"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "stream_end", %{})
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "agent_stream_end", %{
+          agent_name: sig.data[:agent_name],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        if sig.data[:team_id] == current_root_team_id(socket) do
+          push(socket, "stream_end", %{})
+        end
+
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   # --- Conversation turn-level signals (filtered by team_id) ---
 
   def handle_info(%Jido.Signal{type: "collaboration.conversation.turn"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "conversation_turn", %{
-        conversation_id: sig.data[:conversation_id],
-        speaker: sig.data[:speaker],
-        content: sig.data[:content],
-        round: sig.data[:round],
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "conversation_turn", %{
+          conversation_id: sig.data[:conversation_id],
+          speaker: sig.data[:speaker],
+          content: sig.data[:content],
+          round: sig.data[:round],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "collaboration.conversation.reaction"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "conversation_reaction", %{
-        conversation_id: sig.data[:conversation_id],
-        agent_name: sig.data[:agent_name],
-        reaction_type: to_string(sig.data[:reaction_type] || ""),
-        brief: sig.data[:brief] || "",
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "conversation_reaction", %{
+          conversation_id: sig.data[:conversation_id],
+          agent_name: sig.data[:agent_name],
+          reaction_type: to_string(sig.data[:reaction_type] || ""),
+          brief: sig.data[:brief] || "",
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "collaboration.conversation.yield"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "conversation_yield", %{
-        conversation_id: sig.data[:conversation_id],
-        agent_name: sig.data[:agent_name],
-        reason: sig.data[:reason] || "",
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "conversation_yield", %{
+          conversation_id: sig.data[:conversation_id],
+          agent_name: sig.data[:agent_name],
+          reason: sig.data[:reason] || "",
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "collaboration.conversation.round_started"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "conversation_round_started", %{
-        conversation_id: sig.data[:conversation_id],
-        round: sig.data[:round],
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "conversation_round_started", %{
+          conversation_id: sig.data[:conversation_id],
+          round: sig.data[:round],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(
         %Jido.Signal{type: "collaboration.conversation.round_complete"} = sig,
         socket
       ) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "conversation_round_complete", %{
-        conversation_id: sig.data[:conversation_id],
-        round: sig.data[:round],
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "conversation_round_complete", %{
+          conversation_id: sig.data[:conversation_id],
+          round: sig.data[:round],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "collaboration.conversation.summarizing"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "conversation_summarizing", %{
-        conversation_id: sig.data[:conversation_id],
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "conversation_summarizing", %{
+          conversation_id: sig.data[:conversation_id],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "collaboration.conversation.budget_warning"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "conversation_budget_warning", %{
-        conversation_id: sig.data[:conversation_id],
-        tokens_used: sig.data[:tokens_used],
-        max_tokens: sig.data[:max_tokens],
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "conversation_budget_warning", %{
+          conversation_id: sig.data[:conversation_id],
+          tokens_used: sig.data[:tokens_used],
+          max_tokens: sig.data[:max_tokens],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   # --- Gate signal forwarding ---
 
   def handle_info(%Jido.Signal{type: "agent.approval.requested"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "approval_requested", %{
-        gate_id: sig.data[:gate_id],
-        agent_name: sig.data[:agent_name],
-        question: sig.data[:question] || "",
-        timeout_ms: sig.data[:timeout_ms] || 300_000,
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "approval_requested", %{
+          gate_id: sig.data[:gate_id],
+          agent_name: sig.data[:agent_name],
+          question: sig.data[:question] || "",
+          timeout_ms: sig.data[:timeout_ms] || 300_000,
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.approval.resolved"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "approval_resolved", %{
-        gate_id: sig.data[:gate_id],
-        agent_name: sig.data[:agent_name],
-        outcome: to_string(sig.data[:outcome] || ""),
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "approval_resolved", %{
+          gate_id: sig.data[:gate_id],
+          agent_name: sig.data[:agent_name],
+          outcome: to_string(sig.data[:outcome] || ""),
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.spawn.gate.requested"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "spawn_gate_requested", %{
-        gate_id: sig.data[:gate_id],
-        agent_name: sig.data[:agent_name],
-        team_name: sig.data[:team_name] || "",
-        roles: sig.data[:roles] || [],
-        estimated_cost: sig.data[:estimated_cost] || 0,
-        purpose: sig.data[:purpose],
-        timeout_ms: sig.data[:timeout_ms] || 300_000,
-        limit_warning: sig.data[:limit_warning],
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "spawn_gate_requested", %{
+          gate_id: sig.data[:gate_id],
+          agent_name: sig.data[:agent_name],
+          team_name: sig.data[:team_name] || "",
+          roles: sig.data[:roles] || [],
+          estimated_cost: sig.data[:estimated_cost] || 0,
+          purpose: sig.data[:purpose],
+          timeout_ms: sig.data[:timeout_ms] || 300_000,
+          limit_warning: sig.data[:limit_warning],
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(%Jido.Signal{type: "agent.spawn.gate.resolved"} = sig, socket) do
-    if sig.data[:team_id] == socket.assigns[:team_id] do
-      push(socket, "spawn_gate_resolved", %{
-        gate_id: sig.data[:gate_id],
-        agent_name: sig.data[:agent_name],
-        outcome: to_string(sig.data[:outcome] || ""),
-        team_id: sig.data[:team_id]
-      })
-    end
+    case team_event_socket(socket, sig.data[:team_id]) do
+      {:ok, socket} ->
+        push(socket, "spawn_gate_resolved", %{
+          gate_id: sig.data[:gate_id],
+          agent_name: sig.data[:agent_name],
+          outcome: to_string(sig.data[:outcome] || ""),
+          team_id: sig.data[:team_id]
+        })
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   # Catch-all for unhandled signals
@@ -890,6 +1020,68 @@ defmodule LoomkinWeb.SessionChannel do
   end
 
   defp present_string?(value), do: is_binary(value) and String.trim(value) != ""
+
+  defp team_event_socket(socket, signal_team_id)
+       when is_binary(signal_team_id) and signal_team_id != "" do
+    root_team_id = current_root_team_id(socket)
+
+    cond do
+      is_nil(root_team_id) ->
+        :error
+
+      signal_team_id == root_team_id ->
+        {:ok, assign_root_team_id(socket, root_team_id)}
+
+      signal_team_id in descendant_team_ids(root_team_id) ->
+        {:ok, assign_root_team_id(socket, root_team_id)}
+
+      true ->
+        :error
+    end
+  end
+
+  defp team_event_socket(_socket, _signal_team_id), do: :error
+
+  defp current_root_team_id(socket) do
+    persisted_session_team_id(socket) || socket.assigns[:team_id]
+  end
+
+  defp assign_root_team_id(socket, root_team_id) do
+    if socket.assigns[:team_id] == root_team_id do
+      socket
+    else
+      assign(socket, :team_id, root_team_id)
+    end
+  end
+
+  defp descendant_team_ids(root_team_id) when is_binary(root_team_id) and root_team_id != "" do
+    collect_descendant_team_ids([root_team_id], MapSet.new())
+    |> MapSet.delete(root_team_id)
+    |> MapSet.to_list()
+  end
+
+  defp descendant_team_ids(_root_team_id), do: []
+
+  defp collect_descendant_team_ids([], seen), do: seen
+
+  defp collect_descendant_team_ids([team_id | rest], seen) do
+    if MapSet.member?(seen, team_id) do
+      collect_descendant_team_ids(rest, seen)
+    else
+      children = Loomkin.Teams.Manager.get_child_teams(team_id)
+      collect_descendant_team_ids(rest ++ children, MapSet.put(seen, team_id))
+    end
+  end
+
+  defp persisted_session_team_id(%{assigns: %{session_id: session_id}})
+       when is_binary(session_id) and session_id != "" do
+    case Persistence.get_session(session_id) do
+      %{team_id: team_id} when is_binary(team_id) and team_id != "" -> team_id
+      _ -> nil
+    end
+  end
+
+  defp persisted_session_team_id(_socket), do: nil
 
   defp ensure_session_started(session) do
     opts =

--- a/loomkin-server/lib/loomkin_web/channels/session_channel.ex
+++ b/loomkin-server/lib/loomkin_web/channels/session_channel.ex
@@ -32,6 +32,7 @@ defmodule LoomkinWeb.SessionChannel do
         Session.subscribe(session_id)
         Loomkin.Signals.subscribe("team.**")
         Loomkin.Signals.subscribe("agent.**")
+        Loomkin.Signals.subscribe("context.**")
         Loomkin.Signals.subscribe("collaboration.**")
 
         {:ok, %{model: session.model},

--- a/loomkin-server/lib/loomkin_web/channels/session_channel.ex
+++ b/loomkin-server/lib/loomkin_web/channels/session_channel.ex
@@ -590,10 +590,12 @@ defmodule LoomkinWeb.SessionChannel do
   # --- Collaboration signals ---
 
   def handle_info(%Jido.Signal{type: "collaboration.peer.message"} = sig, socket) do
+    {from, content} = serialize_peer_message(sig.data)
+
     push(socket, "peer_message", %{
-      from: sig.data[:from] || sig.data[:agent_name],
-      to: sig.data[:to],
-      content: sig.data[:content],
+      from: from,
+      to: sig.data[:target] || sig.data[:to],
+      content: content,
       team_id: sig.data[:team_id]
     })
 
@@ -919,10 +921,28 @@ defmodule LoomkinWeb.SessionChannel do
           "The user manually spawned agent \"#{agent_name}\" (role: #{role}) via the CLI. " <>
             "This agent is now available in your team. You may delegate #{role}-related tasks to it."
 
-        Loomkin.Teams.Agent.peer_message(pid, "system", message)
+        Loomkin.Teams.Agent.add_briefing(pid, message)
 
       [] ->
         :ok
+    end
+  end
+
+  defp serialize_peer_message(data) do
+    fallback_from = data[:from] || data[:agent_name]
+
+    case data[:message] do
+      {:peer_message, sender, text} when is_binary(text) ->
+        {sender || fallback_from, text}
+
+      text when is_binary(text) ->
+        {fallback_from, text}
+
+      nil ->
+        {fallback_from, data[:content]}
+
+      other ->
+        {fallback_from, inspect(other)}
     end
   end
 

--- a/loomkin-server/lib/loomkin_web/channels/session_channel.ex
+++ b/loomkin-server/lib/loomkin_web/channels/session_channel.ex
@@ -557,6 +557,22 @@ defmodule LoomkinWeb.SessionChannel do
     {:noreply, socket}
   end
 
+  def handle_info(%Jido.Signal{type: "context.offloaded"} = sig, socket) do
+    if sig.data[:team_id] == socket.assigns[:team_id] do
+      payload = sig.data[:payload] || %{}
+
+      push(socket, "agent_findings_published", %{
+        agent_name: sig.data[:agent_name],
+        team_id: sig.data[:team_id],
+        topic: payload[:topic] || payload["topic"],
+        source: to_string(payload[:source] || payload["source"] || "context_offload"),
+        task_id: payload[:task_id] || payload["task_id"]
+      })
+    end
+
+    {:noreply, socket}
+  end
+
   def handle_info(%Jido.Signal{type: "team.task." <> _} = sig, socket) do
     push(socket, "team_task_update", %{
       type: sig.type,

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -500,6 +500,68 @@ defmodule Loomkin.AgentLoopTest do
     end
   end
 
+  describe "research loop detection" do
+    test "research-only tool sets are detected" do
+      assert AgentLoop.research_scan_only_tool_calls?([
+               %{name: "file_search", arguments: %{"pattern" => "AgentLoop"}},
+               %{name: "file_read", arguments: %{"file_path" => "lib/foo.ex"}}
+             ])
+
+      refute AgentLoop.research_scan_only_tool_calls?([
+               %{name: "file_search", arguments: %{"pattern" => "AgentLoop"}},
+               %{name: "peer_discovery", arguments: %{"discoveries" => ["x"]}}
+             ])
+    end
+
+    test "warns researchers after repeated scan-only iterations" do
+      Process.put(:loomkin_research_scan_streak, 0)
+      test_pid = self()
+
+      config = %{
+        role: :researcher,
+        agent_name: "researcher-1",
+        team_id: "team-123",
+        on_event: fn event_name, payload ->
+          send(test_pid, {:event, event_name, payload})
+          :ok
+        end
+      }
+
+      tools = [%{name: "file_search", arguments: %{"pattern" => "AgentLoop"}}]
+
+      assert [] == AgentLoop.maybe_inject_research_warning([], tools, config)
+      assert [] == AgentLoop.maybe_inject_research_warning([], tools, config)
+
+      messages = AgentLoop.maybe_inject_research_warning([], tools, config)
+      assert [%{role: :user, content: content}] = messages
+      assert content =~ "You are a researcher"
+      assert content =~ "context_offload"
+      assert content =~ "peer_complete_task"
+
+      assert_received {:event, :research_loop_detected, %{streak: 3, tools: ["file_search"]}}
+    end
+
+    test "resets research scan streak when the researcher starts publishing" do
+      Process.put(:loomkin_research_scan_streak, 2)
+
+      config = %{
+        role: :researcher,
+        agent_name: "researcher-1",
+        team_id: "team-123",
+        on_event: fn _, _ -> :ok end
+      }
+
+      assert [] ==
+               AgentLoop.maybe_inject_research_warning(
+                 [],
+                 [%{name: "peer_discovery", arguments: %{"discoveries" => ["x"]}}],
+                 config
+               )
+
+      assert Process.get(:loomkin_research_scan_streak) == 0
+    end
+  end
+
   describe "max_iterations" do
     test "config includes max_iterations with default of 25" do
       # Build config through run — verify it wires up correctly

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -2,6 +2,8 @@ defmodule Loomkin.AgentLoopTest do
   use ExUnit.Case, async: true
 
   alias Loomkin.AgentLoop
+  alias ReqLLM.Message
+  alias ReqLLM.Response
 
   describe "format_tool_result/1" do
     test "extracts text from {:ok, %{result: text}}" do
@@ -28,6 +30,47 @@ defmodule Loomkin.AgentLoopTest do
     test "inspects other errors" do
       result = AgentLoop.format_tool_result({:error, :timeout})
       assert result == "Error: :timeout"
+    end
+  end
+
+  describe "assistant_message_from_response/2" do
+    test "preserves response metadata for tool-call turns" do
+      classified = %{
+        type: :tool_calls,
+        text: "",
+        tool_calls: [%{id: "call_123", name: "echo", arguments: %{"text" => "hi"}}]
+      }
+
+      response = %Response{
+        id: "resp_123",
+        model: "openai:gpt-5.4",
+        context: ReqLLM.Context.new([]),
+        message: %Message{
+          role: :assistant,
+          content: [],
+          metadata: %{response_id: "resp_123"}
+        }
+      }
+
+      assistant_msg = AgentLoop.assistant_message_from_response(classified, response)
+
+      assert assistant_msg.metadata[:response_id] == "resp_123"
+      assert [%{id: "call_123"}] = assistant_msg.tool_calls
+    end
+  end
+
+  describe "to_req_message/1" do
+    test "preserves assistant metadata and tool call ids" do
+      req_message =
+        AgentLoop.to_req_message(%{
+          role: :assistant,
+          content: "",
+          tool_calls: [%{id: "call_123", name: "echo", arguments: %{"text" => "hi"}}],
+          metadata: %{response_id: "resp_123"}
+        })
+
+      assert req_message.metadata[:response_id] == "resp_123"
+      assert [%ReqLLM.ToolCall{id: "call_123"}] = req_message.tool_calls
     end
   end
 

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -424,6 +424,8 @@ defmodule Loomkin.AgentLoopTest do
       assert [%{role: :user, content: content}] = messages
       assert content =~ "Stay available for the human"
       assert content =~ "spawn a specialist or team"
+      assert content =~ "do NOT ask what they want next"
+      assert content =~ "do NOT ask them to restate the task"
     end
 
     test "resets coordination streak when non-coordination work appears" do

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -402,6 +402,24 @@ defmodule Loomkin.AgentLoopTest do
                        %{streak: 2, tools: ["decision_query"]}}
     end
 
+    test "concierge gets the stronger warning after a single repeated coordination turn" do
+      Process.put(:loomkin_coordination_streak, 0)
+
+      config = %{
+        role: :concierge,
+        agent_name: "concierge",
+        team_id: "team-123",
+        on_event: fn _, _ -> :ok end
+      }
+
+      tools = [%{name: "decision_query", arguments: %{"query_type" => "pulse"}}]
+
+      messages = AgentLoop.maybe_inject_coordination_warning([], tools, config)
+      assert [%{role: :user, content: content}] = messages
+      assert content =~ "Stay available for the human"
+      assert content =~ "spawn a specialist or team"
+    end
+
     test "resets coordination streak when non-coordination work appears" do
       Process.put(:loomkin_coordination_streak, 1)
 
@@ -449,6 +467,30 @@ defmodule Loomkin.AgentLoopTest do
       assert usage.input_tokens == 10
 
       assert_received {:event, :coordination_loop_stopped, %{streak: 4}}
+    end
+
+    test "concierge stops earlier than other roles" do
+      Process.put(:loomkin_coordination_streak, 3)
+
+      config = %{
+        role: :concierge,
+        agent_name: "concierge",
+        team_id: "team-123",
+        on_event: fn _, _ -> :ok end
+      }
+
+      response = %Response{
+        id: "resp_123",
+        model: "openai:gpt-5.4",
+        context: ReqLLM.Context.new([]),
+        usage: %{input_tokens: 10, output_tokens: 20, total_cost: 0.12}
+      }
+
+      assert {:stop, message, _messages, _meta} =
+               AgentLoop.maybe_stop_coordination_loop([], config, response)
+
+      assert message =~ "Concierge stopped after repeated coordination-only iterations"
+      assert message =~ "staying available for the user"
     end
   end
 

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -285,7 +285,7 @@ defmodule Loomkin.AgentLoopTest do
 
       assert sig_a == sig_b
       assert length(messages) == 1
-      assert hd(messages).role == :user
+      assert hd(messages).role == :system
       assert hd(messages).content =~ "Do NOT repeat"
     end
 
@@ -352,7 +352,7 @@ defmodule Loomkin.AgentLoopTest do
 
       if prev_sig == current_sig and prev_sig != nil do
         warning_msg = %{
-          role: :user,
+          role: :system,
           content:
             "You already called the same tool(s) with identical arguments " <>
               "in the previous iteration and got the same results. Do NOT repeat " <>
@@ -401,7 +401,7 @@ defmodule Loomkin.AgentLoopTest do
       refute_received {:event, :coordination_loop_detected, _}
 
       messages = AgentLoop.maybe_inject_coordination_warning([], tools, config)
-      assert [%{role: :user, content: content}] = messages
+      assert [%{role: :system, content: content}] = messages
       assert content =~ "Stop planning and move the task forward"
 
       assert_received {:event, :coordination_loop_detected,
@@ -421,7 +421,7 @@ defmodule Loomkin.AgentLoopTest do
       tools = [%{name: "decision_query", arguments: %{"query_type" => "pulse"}}]
 
       messages = AgentLoop.maybe_inject_coordination_warning([], tools, config)
-      assert [%{role: :user, content: content}] = messages
+      assert [%{role: :system, content: content}] = messages
       assert content =~ "Stay available for the human"
       assert content =~ "spawn a specialist or team"
       assert content =~ "do NOT ask what they want next"
@@ -556,7 +556,7 @@ defmodule Loomkin.AgentLoopTest do
       assert [] == AgentLoop.maybe_inject_research_warning([], tools, config)
 
       messages = AgentLoop.maybe_inject_research_warning([], tools, config)
-      assert [%{role: :user, content: content}] = messages
+      assert [%{role: :system, content: content}] = messages
       assert content =~ "You are a researcher"
       assert content =~ "context_offload"
       assert content =~ "peer_complete_task"

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -253,10 +253,6 @@ defmodule Loomkin.AgentLoopTest do
     end
 
     test "tool_call_signature produces deterministic, order-independent signatures" do
-      # Access the private function indirectly by testing the process dict behavior.
-      # We verify that the signature mechanism works by running two loops and
-      # checking the process dictionary state.
-
       # Two calls with same tools in different order should produce same signature
       calls_a = [
         %{name: "file_read", arguments: %{"path" => "/a.txt"}},
@@ -275,12 +271,12 @@ defmodule Loomkin.AgentLoopTest do
       config = %{on_event: fn _, _ -> :ok end}
 
       # First call sets the signature
-      messages = apply_cycle_check(calls_a, [], config)
+      messages = AgentLoop.maybe_inject_cycle_warning([], calls_a, config)
       sig_a = Process.get(:loomkin_prev_tool_signature)
       assert messages == []
 
       # Second call with reordered tools should detect a cycle
-      messages = apply_cycle_check(calls_b, [], config)
+      messages = AgentLoop.maybe_inject_cycle_warning([], calls_b, config)
       sig_b = Process.get(:loomkin_prev_tool_signature)
 
       assert sig_a == sig_b
@@ -294,16 +290,16 @@ defmodule Loomkin.AgentLoopTest do
       config = %{on_event: fn _, _ -> :ok end}
 
       _messages =
-        apply_cycle_check(
-          [%{name: "file_read", arguments: %{"path" => "/a.txt"}}],
+        AgentLoop.maybe_inject_cycle_warning(
           [],
+          [%{name: "file_read", arguments: %{"path" => "/a.txt"}}],
           config
         )
 
       messages =
-        apply_cycle_check(
-          [%{name: "file_read", arguments: %{"path" => "/b.txt"}}],
+        AgentLoop.maybe_inject_cycle_warning(
           [],
+          [%{name: "file_read", arguments: %{"path" => "/b.txt"}}],
           config
         )
 
@@ -324,48 +320,45 @@ defmodule Loomkin.AgentLoopTest do
       calls = [%{name: "grep", arguments: %{"pattern" => "foo"}}]
 
       # First call — no cycle
-      apply_cycle_check(calls, [], config)
+      AgentLoop.maybe_inject_cycle_warning([], calls, config)
       refute_received {:event, :cycle_detected, _}
 
       # Second call — cycle detected
-      apply_cycle_check(calls, [], config)
+      AgentLoop.maybe_inject_cycle_warning([], calls, config)
       assert_received {:event, :cycle_detected, %{signature: sig}}
       assert is_binary(sig)
       assert sig =~ "grep"
     end
 
-    # Helper that mirrors the private maybe_inject_cycle_warning logic
-    defp apply_cycle_check(tool_calls, messages, config) do
-      prev_sig = Process.get(:loomkin_prev_tool_signature)
+    test "cycle warning preserves existing history instead of replacing it" do
+      Process.put(:loomkin_prev_tool_signature, nil)
 
-      current_sig =
-        tool_calls
-        |> Enum.map(fn tc ->
-          name = tc[:name] || tc["name"] || ""
-          args = tc[:arguments] || tc["arguments"] || %{}
-          "#{name}:#{inspect(args)}"
-        end)
-        |> Enum.sort()
-        |> Enum.join("|")
+      existing_messages = [
+        %{role: :user, content: "Please investigate vault ingestion"},
+        %{
+          role: :assistant,
+          content: "",
+          tool_calls: [%{id: "call_1", name: "search_keepers", arguments: %{}}]
+        },
+        %{role: :tool, content: "found prior work", tool_call_id: "call_1"}
+      ]
 
-      Process.put(:loomkin_prev_tool_signature, current_sig)
+      repeated_tools = [
+        %{name: "search_keepers", arguments: %{"query" => "vault ingestion"}}
+      ]
 
-      if prev_sig == current_sig and prev_sig != nil do
-        warning_msg = %{
-          role: :system,
-          content:
-            "You already called the same tool(s) with identical arguments " <>
-              "in the previous iteration and got the same results. Do NOT repeat " <>
-              "the same calls. Either use the results you already have to form a " <>
-              "final answer, or try a different approach."
-        }
+      config = %{on_event: fn _, _ -> :ok end}
 
-        config.on_event.(:cycle_detected, %{signature: current_sig})
-        config.on_event.(:new_message, warning_msg)
-        messages ++ [warning_msg]
-      else
-        messages
-      end
+      assert existing_messages ==
+               AgentLoop.maybe_inject_cycle_warning(existing_messages, repeated_tools, config)
+
+      updated_messages =
+        AgentLoop.maybe_inject_cycle_warning(existing_messages, repeated_tools, config)
+
+      assert length(updated_messages) == length(existing_messages) + 1
+      assert Enum.take(updated_messages, length(existing_messages)) == existing_messages
+      assert List.last(updated_messages).role == :system
+      assert List.last(updated_messages).content =~ "Do NOT repeat"
     end
   end
 

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -420,6 +420,36 @@ defmodule Loomkin.AgentLoopTest do
 
       assert Process.get(:loomkin_coordination_streak) == 0
     end
+
+    test "stops the loop after too many consecutive coordination-only iterations" do
+      Process.put(:loomkin_coordination_streak, 4)
+      test_pid = self()
+
+      config = %{
+        agent_name: "concierge",
+        team_id: "team-123",
+        on_event: fn event_name, payload ->
+          send(test_pid, {:event, event_name, payload})
+          :ok
+        end
+      }
+
+      response = %Response{
+        id: "resp_123",
+        model: "openai:gpt-5.4",
+        context: ReqLLM.Context.new([]),
+        usage: %{input_tokens: 10, output_tokens: 20, total_cost: 0.12}
+      }
+
+      assert {:stop, message, messages, %{usage: usage}} =
+               AgentLoop.maybe_stop_coordination_loop([], config, response)
+
+      assert message =~ "Agent stopped after repeated coordination-only iterations"
+      assert [%{role: :assistant, content: ^message}] = messages
+      assert usage.input_tokens == 10
+
+      assert_received {:event, :coordination_loop_stopped, %{streak: 4}}
+    end
   end
 
   describe "max_iterations" do

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -72,6 +72,12 @@ defmodule Loomkin.AgentLoopTest do
       assert req_message.metadata[:response_id] == "resp_123"
       assert [%ReqLLM.ToolCall{id: "call_123"}] = req_message.tool_calls
     end
+
+    test "returns nil for malformed messages instead of crashing" do
+      assert AgentLoop.to_req_message(nil) == nil
+      assert AgentLoop.to_req_message(%{content: "missing role"}) == nil
+      assert AgentLoop.to_req_message("not a map") == nil
+    end
   end
 
   describe "run/2 option validation" do
@@ -440,7 +446,7 @@ defmodule Loomkin.AgentLoopTest do
     end
 
     test "stops the loop after too many consecutive coordination-only iterations" do
-      Process.put(:loomkin_coordination_streak, 4)
+      Process.put(:loomkin_coordination_streak, 6)
       test_pid = self()
 
       config = %{
@@ -466,11 +472,11 @@ defmodule Loomkin.AgentLoopTest do
       assert [%{role: :assistant, content: ^message}] = messages
       assert usage.input_tokens == 10
 
-      assert_received {:event, :coordination_loop_stopped, %{streak: 4}}
+      assert_received {:event, :coordination_loop_stopped, %{streak: 6}}
     end
 
     test "concierge stops earlier than other roles" do
-      Process.put(:loomkin_coordination_streak, 3)
+      Process.put(:loomkin_coordination_streak, 5)
 
       config = %{
         role: :concierge,

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -586,6 +586,28 @@ defmodule Loomkin.AgentLoopTest do
       assert tool_call.arguments == %{"team_name" => "vault-ingestion-assessment"}
     end
 
+    test "rebuilds orphan tool-call maps into a synthetic assistant when a tool result exists" do
+      messages = [
+        %{role: :user, content: "Please assess vault ingestion"},
+        %{id: "call_123", name: "team_spawn", arguments: %{"team_name" => "vault"}},
+        %{id: "call_456", name: "decision_log", arguments: %{"title" => "Delegate"}},
+        %{role: :tool, content: "spawn failed", tool_call_id: "call_123"},
+        %{role: :tool, content: "logged", tool_call_id: "call_456"}
+      ]
+
+      assert [
+               %{role: :user},
+               %{role: :assistant, tool_calls: [first_call, second_call]},
+               %{role: :tool, tool_call_id: "call_123"},
+               %{role: :tool, tool_call_id: "call_456"}
+             ] = AgentLoop.normalize_history_messages(messages)
+
+      assert first_call.id == "call_123"
+      assert first_call.name == "team_spawn"
+      assert second_call.id == "call_456"
+      assert second_call.name == "decision_log"
+    end
+
     test "drops unrepairable orphan tool-call maps" do
       messages = [
         %{id: "call_123", name: "team_spawn", arguments: %{"team_name" => "vault"}}

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -363,6 +363,65 @@ defmodule Loomkin.AgentLoopTest do
     end
   end
 
+  describe "coordination loop detection" do
+    test "coordination-only tool sets are detected" do
+      assert AgentLoop.coordination_only_tool_calls?([
+               %{name: "decision_query", arguments: %{"query_type" => "pulse"}},
+               %{name: "query_backlog", arguments: %{"query_type" => "summary"}}
+             ])
+
+      refute AgentLoop.coordination_only_tool_calls?([
+               %{name: "decision_query", arguments: %{"query_type" => "pulse"}},
+               %{name: "team_spawn", arguments: %{"roles" => []}}
+             ])
+    end
+
+    test "injects a warning after consecutive coordination-only iterations" do
+      Process.put(:loomkin_coordination_streak, 0)
+      test_pid = self()
+
+      config = %{
+        agent_name: "concierge",
+        team_id: "team-123",
+        on_event: fn event_name, payload ->
+          send(test_pid, {:event, event_name, payload})
+          :ok
+        end
+      }
+
+      tools = [%{name: "decision_query", arguments: %{"query_type" => "pulse"}}]
+
+      assert [] == AgentLoop.maybe_inject_coordination_warning([], tools, config)
+      refute_received {:event, :coordination_loop_detected, _}
+
+      messages = AgentLoop.maybe_inject_coordination_warning([], tools, config)
+      assert [%{role: :user, content: content}] = messages
+      assert content =~ "Stop planning and move the task forward"
+
+      assert_received {:event, :coordination_loop_detected,
+                       %{streak: 2, tools: ["decision_query"]}}
+    end
+
+    test "resets coordination streak when non-coordination work appears" do
+      Process.put(:loomkin_coordination_streak, 1)
+
+      config = %{
+        agent_name: "concierge",
+        team_id: "team-123",
+        on_event: fn _, _ -> :ok end
+      }
+
+      assert [] ==
+               AgentLoop.maybe_inject_coordination_warning(
+                 [],
+                 [%{name: "team_spawn", arguments: %{"roles" => []}}],
+                 config
+               )
+
+      assert Process.get(:loomkin_coordination_streak) == 0
+    end
+  end
+
   describe "max_iterations" do
     test "config includes max_iterations with default of 25" do
       # Build config through run — verify it wires up correctly

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -562,6 +562,39 @@ defmodule Loomkin.AgentLoopTest do
     end
   end
 
+  describe "history normalization" do
+    test "reattaches orphan tool-call maps to the previous assistant message" do
+      messages = [
+        %{role: :user, content: "Please assess vault ingestion"},
+        %{role: :assistant, content: ""},
+        %{
+          id: "call_123",
+          name: "team_spawn",
+          arguments: %{"team_name" => "vault-ingestion-assessment"}
+        },
+        %{role: :tool, content: "spawned", tool_call_id: "call_123"}
+      ]
+
+      assert [
+               %{role: :user},
+               %{role: :assistant, tool_calls: [tool_call]},
+               %{role: :tool, tool_call_id: "call_123"}
+             ] = AgentLoop.normalize_history_messages(messages)
+
+      assert tool_call.id == "call_123"
+      assert tool_call.name == "team_spawn"
+      assert tool_call.arguments == %{"team_name" => "vault-ingestion-assessment"}
+    end
+
+    test "drops unrepairable orphan tool-call maps" do
+      messages = [
+        %{id: "call_123", name: "team_spawn", arguments: %{"team_name" => "vault"}}
+      ]
+
+      assert [] == AgentLoop.normalize_history_messages(messages)
+    end
+  end
+
   describe "max_iterations" do
     test "config includes max_iterations with default of 25" do
       # Build config through run — verify it wires up correctly

--- a/loomkin-server/test/loomkin/agent_loop_test.exs
+++ b/loomkin-server/test/loomkin/agent_loop_test.exs
@@ -477,8 +477,29 @@ defmodule Loomkin.AgentLoopTest do
       assert_received {:event, :coordination_loop_stopped, %{streak: 6}}
     end
 
-    test "concierge stops earlier than other roles" do
-      Process.put(:loomkin_coordination_streak, 5)
+    test "concierge gets more room before the hard stop" do
+      Process.put(:loomkin_coordination_streak, 6)
+
+      config = %{
+        role: :concierge,
+        agent_name: "concierge",
+        team_id: "team-123",
+        on_event: fn _, _ -> :ok end
+      }
+
+      response = %Response{
+        id: "resp_123",
+        model: "openai:gpt-5.4",
+        context: ReqLLM.Context.new([]),
+        usage: %{input_tokens: 10, output_tokens: 20, total_cost: 0.12}
+      }
+
+      assert {:continue, []} =
+               AgentLoop.maybe_stop_coordination_loop([], config, response)
+    end
+
+    test "concierge still stops after an extended coordination streak" do
+      Process.put(:loomkin_coordination_streak, 7)
 
       config = %{
         role: :concierge,

--- a/loomkin-server/test/loomkin/conversations/agent_test.exs
+++ b/loomkin-server/test/loomkin/conversations/agent_test.exs
@@ -100,6 +100,70 @@ defmodule Loomkin.Conversations.AgentTest do
     end
   end
 
+  describe "build_messages/4" do
+    test "seeds an opening user turn when history is empty", ctx do
+      state = %Agent{
+        conversation_id: ctx.conv_id,
+        team_id: ctx.team_id,
+        name: @persona.name,
+        persona: @persona,
+        model: "openai:gpt-5.4-mini",
+        topic: "Test topic"
+      }
+
+      messages = Agent.build_messages([], "Test topic", "Background", state)
+
+      assert Enum.at(messages, 0) == %{
+               role: "system",
+               content: Persona.system_prompt(@persona, "Test topic", "Background")
+             }
+
+      assert Enum.at(messages, 1).role == "user"
+      assert Enum.at(messages, 1).content =~ "It is your turn to open the discussion"
+    end
+
+    test "maps prior conversation entries into assistant and user messages", ctx do
+      state = %Agent{
+        conversation_id: ctx.conv_id,
+        team_id: ctx.team_id,
+        name: @persona.name,
+        persona: @persona,
+        model: "openai:gpt-5.4-mini",
+        topic: "Test topic"
+      }
+
+      history = [
+        %{speaker: "Expert", content: "My point", type: :speech},
+        %{speaker: "Critic", content: "Counterpoint", type: :speech},
+        %{speaker: "Critic", content: "yielded", type: :yield},
+        %{speaker: "Observer", content: "ignore me", type: :reaction}
+      ]
+
+      messages = Agent.build_messages(history, "Test topic", nil, state)
+
+      assert Enum.at(messages, 1) == %{role: "assistant", content: "My point"}
+      assert Enum.at(messages, 2) == %{role: "user", content: "[Critic]: Counterpoint"}
+      assert Enum.at(messages, 3) == %{role: "user", content: "[Critic]: yielded"}
+      assert length(messages) == 4
+    end
+  end
+
+  describe "extract_tool_calls/1" do
+    test "extracts tool calls from ReqLLM.Response" do
+      response = %ReqLLM.Response{
+        id: "resp_123",
+        model: "openai:gpt-5.4-mini",
+        context: ReqLLM.Context.new([]),
+        message:
+          ReqLLM.Context.assistant("",
+            tool_calls: [{"speak", %{content: "hello"}, id: "call_123"}]
+          )
+      }
+
+      assert Agent.extract_tool_calls(response) == [{"speak", %{"content" => "hello"}}]
+    end
+  end
+
   describe "turn handling" do
     test "agent receives turn notification and yields on llm error", ctx do
       # Start agent first so it's subscribed before the server emits :your_turn

--- a/loomkin-server/test/loomkin/decisions/graph_test.exs
+++ b/loomkin-server/test/loomkin/decisions/graph_test.exs
@@ -2,9 +2,16 @@ defmodule Loomkin.Decisions.GraphTest do
   use Loomkin.DataCase, async: false
 
   alias Loomkin.Decisions.Graph
+  alias Loomkin.Schemas.Session
 
   defp node_attrs(overrides \\ %{}) do
     Map.merge(%{node_type: :goal, title: "Test goal"}, overrides)
+  end
+
+  defp create_session do
+    %Session{}
+    |> Session.changeset(%{model: "test-model", project_path: "/tmp/test"})
+    |> Repo.insert!()
   end
 
   describe "add_node/1" do
@@ -128,7 +135,7 @@ defmodule Loomkin.Decisions.GraphTest do
     end
   end
 
-  describe "active_goals/0" do
+  describe "active_goals/1" do
     test "returns only active goals" do
       {:ok, _} = Graph.add_node(node_attrs(%{node_type: :goal, status: :active}))
 
@@ -141,9 +148,23 @@ defmodule Loomkin.Decisions.GraphTest do
       assert length(goals) == 1
       assert hd(goals).node_type == :goal
     end
+
+    test "supports team_id scoping" do
+      team_a = Ecto.UUID.generate()
+      team_b = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{title: "Team A goal", metadata: %{"team_id" => team_a}}))
+
+      {:ok, _} =
+        Graph.add_node(node_attrs(%{title: "Team B goal", metadata: %{"team_id" => team_b}}))
+
+      goals = Graph.active_goals(team_id: team_a)
+      assert Enum.map(goals, & &1.title) == ["Team A goal"]
+    end
   end
 
-  describe "recent_decisions/1" do
+  describe "recent_decisions/2" do
     test "returns recent decision and option nodes" do
       {:ok, _} = Graph.add_node(node_attrs(%{node_type: :decision, title: "D1"}))
       {:ok, _} = Graph.add_node(node_attrs(%{node_type: :option, title: "O1"}))
@@ -161,6 +182,24 @@ defmodule Loomkin.Decisions.GraphTest do
       end
 
       assert length(Graph.recent_decisions(3)) == 3
+    end
+
+    test "supports session_id scoping" do
+      session_a = create_session()
+      session_b = create_session()
+
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{node_type: :decision, title: "Session A", session_id: session_a.id})
+        )
+
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{node_type: :decision, title: "Session B", session_id: session_b.id})
+        )
+
+      results = Graph.recent_decisions(10, session_id: session_a.id)
+      assert Enum.map(results, & &1.title) == ["Session A"]
     end
   end
 

--- a/loomkin-server/test/loomkin/decisions/pulse_test.exs
+++ b/loomkin-server/test/loomkin/decisions/pulse_test.exs
@@ -75,6 +75,37 @@ defmodule Loomkin.Decisions.PulseTest do
       assert length(report_default.low_confidence) == 0
       assert length(report_high.low_confidence) == 1
     end
+
+    test "scopes report content to the requested team" do
+      team_a = Ecto.UUID.generate()
+      team_b = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Graph.add_node(
+          node_attrs(%{node_type: :goal, title: "Team A goal", metadata: %{"team_id" => team_a}})
+        )
+
+      {:ok, goal_b} =
+        Graph.add_node(
+          node_attrs(%{node_type: :goal, title: "Team B goal", metadata: %{"team_id" => team_b}})
+        )
+
+      {:ok, action_b} =
+        Graph.add_node(
+          node_attrs(%{
+            node_type: :action,
+            title: "Team B action",
+            metadata: %{"team_id" => team_b}
+          })
+        )
+
+      {:ok, _} = Graph.add_edge(goal_b.id, action_b.id, :leads_to)
+
+      report = Pulse.generate(team_id: team_b)
+
+      assert Enum.map(report.active_goals, & &1.title) == ["Team B goal"]
+      assert report.coverage_gaps == []
+    end
   end
 
   describe "compute_health/1" do

--- a/loomkin-server/test/loomkin/llm_test.exs
+++ b/loomkin-server/test/loomkin/llm_test.exs
@@ -2,6 +2,7 @@ defmodule Loomkin.LLMTest do
   use ExUnit.Case, async: true
 
   alias Loomkin.LLM
+  alias Loomkin.Providers.OpenAIOAuth
 
   describe "oauth_providers/0" do
     test "returns a map of base provider to oauth provider" do
@@ -31,6 +32,16 @@ defmodule Loomkin.LLMTest do
       # In test, TokenStore may or may not have tokens
       result = LLM.oauth_active?("anthropic")
       assert is_boolean(result)
+    end
+  end
+
+  describe "stream_backed_generate?/1" do
+    test "uses stream-backed generate for openai codex oauth" do
+      assert LLM.stream_backed_generate?(OpenAIOAuth)
+    end
+
+    test "does not force stream-backed generate for other providers" do
+      refute LLM.stream_backed_generate?(ReqLLM.Providers.OpenAI)
     end
   end
 end

--- a/loomkin-server/test/loomkin/models_test.exs
+++ b/loomkin-server/test/loomkin/models_test.exs
@@ -1,0 +1,68 @@
+defmodule Loomkin.ModelsTest do
+  use Loomkin.DataCase, async: false
+
+  alias Loomkin.Auth.TokenStore
+  alias Loomkin.Models
+
+  describe "all_providers_enriched/0" do
+    test "surfaces gpt-5.4 for openai api key listings" do
+      previous = System.get_env("OPENAI_API_KEY")
+      System.put_env("OPENAI_API_KEY", "test-openai-key")
+
+      on_exit(fn ->
+        if previous do
+          System.put_env("OPENAI_API_KEY", previous)
+        else
+          System.delete_env("OPENAI_API_KEY")
+        end
+      end)
+
+      {_provider, _name, {:set, "OPENAI_API_KEY"}, models} =
+        Enum.find(Models.all_providers_enriched(), fn {provider, _name, _status, _models} ->
+          provider == :openai
+        end)
+
+      matching =
+        Enum.filter(models, fn {_label, id, _context} ->
+          id == "openai:gpt-5.4"
+        end)
+
+      assert length(matching) == 1
+    end
+
+    test "uses codex-visible openai models for oauth listings" do
+      Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), Process.whereis(TokenStore))
+
+      previous = System.get_env("OPENAI_API_KEY")
+      System.delete_env("OPENAI_API_KEY")
+
+      on_exit(fn ->
+        if previous do
+          System.put_env("OPENAI_API_KEY", previous)
+        else
+          System.delete_env("OPENAI_API_KEY")
+        end
+
+        TokenStore.revoke_tokens(:openai)
+      end)
+
+      :ok =
+        TokenStore.store_tokens(:openai, %{
+          access_token: "test-openai-token",
+          refresh_token: "test-openai-refresh",
+          expires_in: 3600,
+          account_id: "acct_test",
+          scopes: "openid profile email offline_access"
+        })
+
+      {_provider, _name, {:oauth, :connected}, models} =
+        Enum.find(Models.all_providers_enriched(), fn {provider, _name, _status, _models} ->
+          provider == :openai
+        end)
+
+      assert Enum.any?(models, fn {_label, id, _context} -> id == "openai:gpt-5.4" end)
+      assert Enum.any?(models, fn {_label, id, _context} -> id == "openai:gpt-5.3-codex" end)
+      refute Enum.any?(models, fn {_label, id, _context} -> id == "openai:gpt-4o" end)
+    end
+  end
+end

--- a/loomkin-server/test/loomkin/providers/oauth_adapters_test.exs
+++ b/loomkin-server/test/loomkin/providers/oauth_adapters_test.exs
@@ -9,7 +9,7 @@ defmodule Loomkin.Providers.OAuthAdaptersTest do
   use Loomkin.DataCase, async: false
 
   alias Loomkin.Auth.TokenStore
-  alias Loomkin.Providers.{AnthropicOAuth, OpenAIOAuth, GoogleOAuth}
+  alias Loomkin.Providers.{AnthropicOAuth, OpenAICodexModels, OpenAIOAuth, GoogleOAuth}
 
   setup do
     # Ensure no stale tokens leak between tests
@@ -146,6 +146,144 @@ defmodule Loomkin.Providers.OAuthAdaptersTest do
   end
 
   describe "OpenAIOAuth codex request shaping" do
+    test "builds a request for gpt-5.4 when ReqLLM catalog is stale" do
+      store_test_token(:openai, "test-openai-token")
+
+      assert {:ok, %Req.Request{} = request} =
+               OpenAIOAuth.prepare_request(:chat, "openai:gpt-5.4", "hello", [])
+
+      assert request.options[:model] == "gpt-5.4"
+      assert request.options[:base_url] == "https://chatgpt.com/backend-api"
+    end
+
+    test "falls back to stored account id when token claims are unavailable" do
+      store_test_token(:openai, "test-openai-token")
+
+      assert {:ok, %Req.Request{} = request} =
+               OpenAIOAuth.prepare_request(:chat, "openai:gpt-5.4", "hello", [])
+
+      assert request.headers["chatgpt-account-id"] == ["test-account-openai"]
+    end
+
+    test "replays tool call and output without previous_response_id for codex resume flow" do
+      store_test_token(:openai, "test-openai-token")
+
+      messages = [
+        ReqLLM.Context.assistant("",
+          tool_calls: [{"echo", %{text: "hi"}, id: "call_123"}],
+          metadata: %{response_id: "resp_123"}
+        ),
+        ReqLLM.Context.tool_result("call_123", "done")
+      ]
+
+      assert {:ok, %Req.Request{} = request} =
+               OpenAIOAuth.prepare_request(:chat, "openai:gpt-5.4", messages, [])
+
+      encoded = OpenAIOAuth.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+
+      assert Enum.any?(body["input"], fn item ->
+               item["type"] == "function_call" and item["call_id"] == "call_123" and
+                 item["name"] == "echo"
+             end)
+
+      assert Enum.any?(body["input"], fn item ->
+               item["type"] == "function_call_output" and item["call_id"] == "call_123" and
+                 item["output"] == "done"
+             end)
+    end
+
+    test "stream requests also drop previous_response_id for codex resume flow" do
+      store_test_token(:openai, "test-openai-token")
+
+      messages = [
+        ReqLLM.Context.assistant("",
+          tool_calls: [{"echo", %{text: "hi"}, id: "call_123"}],
+          metadata: %{response_id: "resp_123"}
+        ),
+        ReqLLM.Context.tool_result("call_123", "done")
+      ]
+
+      {:ok, model} = OpenAICodexModels.resolve_model("openai:gpt-5.4")
+
+      context = ReqLLM.Context.new(messages)
+
+      assert {:ok, %Finch.Request{body: body}} =
+               OpenAIOAuth.attach_stream(model, context, [], nil)
+
+      decoded = Jason.decode!(body)
+
+      refute Map.has_key?(decoded, "previous_response_id")
+
+      assert Enum.any?(decoded["input"], fn item ->
+               item["type"] == "function_call" and item["call_id"] == "call_123"
+             end)
+
+      assert Enum.any?(decoded["input"], fn item ->
+               item["type"] == "function_call_output" and item["call_id"] == "call_123"
+             end)
+    end
+
+    test "drops stale historical function calls on follow-up turns" do
+      store_test_token(:openai, "test-openai-token")
+
+      messages = [
+        ReqLLM.Context.user("first question"),
+        ReqLLM.Context.assistant("",
+          tool_calls: [{"echo", %{text: "hi"}, id: "call_123"}],
+          metadata: %{response_id: "resp_123"}
+        ),
+        ReqLLM.Context.tool_result("call_123", "done"),
+        ReqLLM.Context.assistant("All set.", metadata: %{response_id: "resp_124"}),
+        ReqLLM.Context.user("second question")
+      ]
+
+      assert {:ok, %Req.Request{} = request} =
+               OpenAIOAuth.prepare_request(:chat, "openai:gpt-5.4", messages, [])
+
+      encoded = OpenAIOAuth.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Enum.any?(body["input"], &(&1["type"] == "function_call"))
+      refute Enum.any?(body["input"], &(&1["type"] == "function_call_output"))
+
+      assert Enum.any?(body["input"], fn item ->
+               item["role"] == "user"
+             end)
+    end
+
+    test "stream follow-up turns also drop stale historical function calls" do
+      store_test_token(:openai, "test-openai-token")
+
+      messages = [
+        ReqLLM.Context.user("first question"),
+        ReqLLM.Context.assistant("",
+          tool_calls: [{"echo", %{text: "hi"}, id: "call_123"}],
+          metadata: %{response_id: "resp_123"}
+        ),
+        ReqLLM.Context.tool_result("call_123", "done"),
+        ReqLLM.Context.assistant("All set.", metadata: %{response_id: "resp_124"}),
+        ReqLLM.Context.user("second question")
+      ]
+
+      {:ok, model} = OpenAICodexModels.resolve_model("openai:gpt-5.4")
+      context = ReqLLM.Context.new(messages)
+
+      assert {:ok, %Finch.Request{body: body}} =
+               OpenAIOAuth.attach_stream(model, context, [], nil)
+
+      decoded = Jason.decode!(body)
+
+      refute Enum.any?(decoded["input"], &(&1["type"] == "function_call"))
+      refute Enum.any?(decoded["input"], &(&1["type"] == "function_call_output"))
+
+      assert Enum.any?(decoded["input"], fn item ->
+               item["role"] == "user"
+             end)
+    end
+
     test "moves system input text into instructions" do
       body = %{
         "input" => [

--- a/loomkin-server/test/loomkin/providers/openai_codex_models_test.exs
+++ b/loomkin-server/test/loomkin/providers/openai_codex_models_test.exs
@@ -1,0 +1,126 @@
+defmodule Loomkin.Providers.OpenAICodexModelsTest do
+  use ExUnit.Case, async: false
+
+  alias Loomkin.Providers.OpenAICodexModels
+
+  setup do
+    previous = Application.get_env(:loomkin, OpenAICodexModels)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:loomkin, OpenAICodexModels, previous)
+      else
+        Application.delete_env(:loomkin, OpenAICodexModels)
+      end
+    end)
+
+    :ok
+  end
+
+  test "lists only codex-visible api-supported models from cache" do
+    path =
+      write_cache!(%{
+        "models" => [
+          %{
+            "slug" => "gpt-5.4",
+            "display_name" => "gpt-5.4",
+            "visibility" => "list",
+            "supported_in_api" => true,
+            "context_window" => 272_000
+          },
+          %{
+            "slug" => "gpt-5.1",
+            "display_name" => "gpt-5.1",
+            "visibility" => "hide",
+            "supported_in_api" => true,
+            "context_window" => 272_000
+          },
+          %{
+            "slug" => "gpt-5.3-codex-spark",
+            "display_name" => "GPT-5.3-Codex-Spark",
+            "visibility" => "list",
+            "supported_in_api" => false,
+            "context_window" => 128_000
+          }
+        ]
+      })
+
+    Application.put_env(:loomkin, OpenAICodexModels, cache_path: path)
+
+    assert Enum.map(OpenAICodexModels.list_models(), & &1.id) == [
+             "gpt-5.4",
+             "gpt-5.4-mini",
+             "gpt-5.3-codex",
+             "gpt-5.2"
+           ]
+  end
+
+  test "resolves supported cache models into llmdb models" do
+    path =
+      write_cache!(%{
+        "models" => [
+          %{
+            "slug" => "gpt-5.4",
+            "display_name" => "gpt-5.4",
+            "visibility" => "list",
+            "supported_in_api" => true,
+            "context_window" => 272_000,
+            "input_modalities" => ["text", "image"]
+          }
+        ]
+      })
+
+    Application.put_env(:loomkin, OpenAICodexModels, cache_path: path)
+
+    assert {:ok, model} = OpenAICodexModels.resolve_model("openai:gpt-5.4")
+    assert model.id == "gpt-5.4"
+    assert model.provider == :openai
+    assert model.name == "gpt-5.4"
+    assert model.limits.context == 272_000
+    assert :image in model.modalities.input
+    assert get_in(model.extra, [:wire, :protocol]) == "openai_responses"
+  end
+
+  test "rejects cache models marked unsupported in api" do
+    path =
+      write_cache!(%{
+        "models" => [
+          %{
+            "slug" => "gpt-5.3-codex-spark",
+            "display_name" => "GPT-5.3-Codex-Spark",
+            "visibility" => "list",
+            "supported_in_api" => false,
+            "context_window" => 128_000
+          }
+        ]
+      })
+
+    Application.put_env(:loomkin, OpenAICodexModels, cache_path: path)
+
+    assert {:error, :not_found} = OpenAICodexModels.resolve_model("openai:gpt-5.3-codex-spark")
+  end
+
+  test "falls back to built-in gpt-5.4 when cache is unavailable" do
+    missing =
+      Path.join(
+        System.tmp_dir!(),
+        "missing-codex-cache-#{System.unique_integer([:positive])}.json"
+      )
+
+    Application.put_env(:loomkin, OpenAICodexModels, cache_path: missing)
+
+    assert {:ok, model} = OpenAICodexModels.resolve_model("openai:gpt-5.4")
+    assert model.id == "gpt-5.4"
+  end
+
+  defp write_cache!(payload) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "openai-codex-models-#{System.unique_integer([:positive])}.json"
+      )
+
+    File.write!(path, Jason.encode!(payload))
+    path
+  end
+end

--- a/loomkin-server/test/loomkin/session/context_window_test.exs
+++ b/loomkin-server/test/loomkin/session/context_window_test.exs
@@ -130,6 +130,21 @@ defmodule Loomkin.Session.ContextWindowTest do
       assert hd(result).role == :system
     end
 
+    test "retains the latest non-system message even when budget is exhausted" do
+      messages = [%{role: :user, content: "digest this repo into the vault"}]
+
+      result =
+        ContextWindow.build_messages(
+          messages,
+          String.duplicate("system context ", 200),
+          max_tokens: 20,
+          reserved_output: 10
+        )
+
+      assert [%{role: :system}, %{role: :user, content: "digest this repo into the vault"}] =
+               result
+    end
+
     test "respects reserved_output option" do
       messages = [%{role: :user, content: String.duplicate("a", 4000)}]
 

--- a/loomkin-server/test/loomkin/teams/agent_test.exs
+++ b/loomkin-server/test/loomkin/teams/agent_test.exs
@@ -157,6 +157,20 @@ defmodule Loomkin.Teams.AgentTest do
     end
   end
 
+  describe "add_briefing/2" do
+    test "stores a system message without waking an idle agent" do
+      %{pid: pid} = start_agent()
+
+      Agent.add_briefing(pid, "Team briefing")
+      Process.sleep(50)
+
+      state = :sys.get_state(pid)
+      assert state.status == :idle
+      assert state.wake_ref == nil
+      assert [%{role: :system, content: "Team briefing"}] = state.messages
+    end
+  end
+
   describe "assign_task/2" do
     test "stores the task in state" do
       %{pid: pid} = start_agent()

--- a/loomkin-server/test/loomkin/teams/cost_tracker_test.exs
+++ b/loomkin-server/test/loomkin/teams/cost_tracker_test.exs
@@ -224,6 +224,25 @@ defmodule Loomkin.Teams.CostTrackerTest do
       [call] = CostTracker.get_call_history(team_id, "coder")
       assert %DateTime{} = call.timestamp
     end
+
+    test "preserves trigger metadata for debugging", %{team_id: team_id} do
+      :ok =
+        CostTracker.record_call(team_id, "coder", %{
+          model: "zai:glm-5",
+          input_tokens: 100,
+          output_tokens: 50,
+          trigger_source: :peer_message,
+          trigger_from: "researcher",
+          trigger_fingerprint: 12345,
+          trigger_coalesced_count: 3
+        })
+
+      [call] = CostTracker.get_call_history(team_id, "coder")
+      assert call.trigger_source == :peer_message
+      assert call.trigger_from == "researcher"
+      assert call.trigger_fingerprint == 12345
+      assert call.trigger_coalesced_count == 3
+    end
   end
 
   describe "get_call_history/2" do

--- a/loomkin-server/test/loomkin/teams/role_test.exs
+++ b/loomkin-server/test/loomkin/teams/role_test.exs
@@ -216,6 +216,7 @@ defmodule Loomkin.Teams.RoleTest do
       {:ok, %Role{system_prompt: prompt}} = Role.get(:concierge)
       assert prompt =~ "## Convergence Discipline"
       assert prompt =~ "## Availability Contract"
+      assert prompt =~ "## Concrete Request Fast Path"
 
       assert prompt =~
                "Do NOT keep cycling through decision_query, query_backlog, search_keepers, and decision_log"
@@ -223,6 +224,11 @@ defmodule Loomkin.Teams.RoleTest do
       assert prompt =~ "spawn a specialist instead of doing more coordination scans yourself"
       assert prompt =~ "Stay free for the user."
       assert prompt =~ "If a task looks like it could keep you busy for multiple iterations"
+      assert prompt =~ "do NOT ask \"what would you like me to move on right now?\""
+      assert prompt =~ "do NOT reply with a generic options menu"
+
+      assert prompt =~
+               "Do NOT automatically run query_backlog or decision scans at the start of every turn"
     end
   end
 

--- a/loomkin-server/test/loomkin/teams/role_test.exs
+++ b/loomkin-server/test/loomkin/teams/role_test.exs
@@ -194,11 +194,30 @@ defmodule Loomkin.Teams.RoleTest do
       assert prompt =~ "team_dissolve"
     end
 
+    test "lead prompt emphasizes convergence over repeated coordination scans" do
+      {:ok, %Role{system_prompt: prompt}} = Role.get(:lead)
+      assert prompt =~ "## Convergence Discipline"
+      assert prompt =~ "Do one quick coordination pass, then delegate or answer."
+
+      assert prompt =~
+               "Do NOT keep alternating between decision_query, query_backlog, search_keepers, or decision_log"
+    end
+
     test "researcher role system_prompt contains structured findings format" do
       {:ok, %Role{system_prompt: prompt}} = Role.get(:researcher)
       assert prompt =~ "## Research Findings"
       assert prompt =~ "## Recommendation"
       assert prompt =~ "peer_message"
+    end
+
+    test "concierge prompt emphasizes convergence over coordination loops" do
+      {:ok, %Role{system_prompt: prompt}} = Role.get(:concierge)
+      assert prompt =~ "## Convergence Discipline"
+
+      assert prompt =~
+               "Do NOT keep cycling through decision_query, query_backlog, search_keepers, and decision_log"
+
+      assert prompt =~ "spawn a specialist instead of doing more coordination scans yourself"
     end
   end
 

--- a/loomkin-server/test/loomkin/teams/role_test.exs
+++ b/loomkin-server/test/loomkin/teams/role_test.exs
@@ -208,6 +208,8 @@ defmodule Loomkin.Teams.RoleTest do
       assert prompt =~ "## Research Findings"
       assert prompt =~ "## Recommendation"
       assert prompt =~ "peer_message"
+      assert prompt =~ "## Research Budget Discipline"
+      assert prompt =~ "Persist before you disappear"
     end
 
     test "concierge prompt emphasizes convergence over coordination loops" do

--- a/loomkin-server/test/loomkin/teams/role_test.exs
+++ b/loomkin-server/test/loomkin/teams/role_test.exs
@@ -213,11 +213,14 @@ defmodule Loomkin.Teams.RoleTest do
     test "concierge prompt emphasizes convergence over coordination loops" do
       {:ok, %Role{system_prompt: prompt}} = Role.get(:concierge)
       assert prompt =~ "## Convergence Discipline"
+      assert prompt =~ "## Availability Contract"
 
       assert prompt =~
                "Do NOT keep cycling through decision_query, query_backlog, search_keepers, and decision_log"
 
       assert prompt =~ "spawn a specialist instead of doing more coordination scans yourself"
+      assert prompt =~ "Stay free for the user."
+      assert prompt =~ "If a task looks like it could keep you busy for multiple iterations"
     end
   end
 

--- a/loomkin-server/test/loomkin/tools/decision_log_test.exs
+++ b/loomkin-server/test/loomkin/tools/decision_log_test.exs
@@ -3,6 +3,13 @@ defmodule Loomkin.Tools.DecisionLogTest do
 
   alias Loomkin.Tools.DecisionLog
   alias Loomkin.Decisions.Graph
+  alias Loomkin.Schemas.Session
+
+  defp create_session do
+    %Session{}
+    |> Session.changeset(%{model: "test-model", project_path: "/tmp/test"})
+    |> Repo.insert!()
+  end
 
   test "action metadata is correct" do
     assert DecisionLog.name() == "decision_log"
@@ -40,6 +47,30 @@ defmodule Loomkin.Tools.DecisionLogTest do
 
     assert {:ok, %{result: msg}} = DecisionLog.run(params, %{})
     assert msg =~ "decision: Use JWT"
+  end
+
+  test "reuses an existing active goal for the same team" do
+    team_id = Ecto.UUID.generate()
+    session = create_session()
+
+    params = %{"node_type" => "goal", "title" => "Build auth system"}
+    context = %{team_id: team_id, session_id: session.id}
+
+    assert {:ok, %{result: first_msg}} = DecisionLog.run(params, context)
+    assert first_msg =~ "Logged goal: Build auth system"
+
+    assert {:ok, %{result: second_msg}} = DecisionLog.run(params, context)
+    assert second_msg =~ "Reused active goal: Build auth system"
+
+    nodes =
+      Graph.list_nodes(
+        node_type: :goal,
+        status: :active,
+        title: "Build auth system",
+        team_id: team_id
+      )
+
+    assert length(nodes) == 1
   end
 
   test "returns error for invalid node_type" do

--- a/loomkin-server/test/loomkin/tools/decision_query_test.exs
+++ b/loomkin-server/test/loomkin/tools/decision_query_test.exs
@@ -36,9 +36,57 @@ defmodule Loomkin.Tools.DecisionQueryTest do
     assert result =~ "Use Ecto"
   end
 
+  test "active_goals is scoped to the current team" do
+    team_a = Ecto.UUID.generate()
+    team_b = Ecto.UUID.generate()
+
+    {:ok, _} =
+      Graph.add_node(node_attrs(%{title: "Team A goal", metadata: %{"team_id" => team_a}}))
+
+    {:ok, _} =
+      Graph.add_node(node_attrs(%{title: "Team B goal", metadata: %{"team_id" => team_b}}))
+
+    assert {:ok, %{result: result}} =
+             DecisionQuery.run(%{"query_type" => "active_goals"}, %{team_id: team_a})
+
+    assert result =~ "Team A goal"
+    refute result =~ "Team B goal"
+  end
+
   test "pulse returns summary" do
     assert {:ok, %{result: result}} = DecisionQuery.run(%{"query_type" => "pulse"}, %{})
     assert result =~ "Pulse:"
+  end
+
+  test "pulse is scoped to the current team" do
+    team_a = Ecto.UUID.generate()
+    team_b = Ecto.UUID.generate()
+
+    {:ok, _} =
+      Graph.add_node(
+        node_attrs(%{node_type: :goal, title: "Team A gap", metadata: %{"team_id" => team_a}})
+      )
+
+    {:ok, goal_b} =
+      Graph.add_node(
+        node_attrs(%{node_type: :goal, title: "Team B goal", metadata: %{"team_id" => team_b}})
+      )
+
+    {:ok, action_b} =
+      Graph.add_node(
+        node_attrs(%{
+          node_type: :action,
+          title: "Team B action",
+          metadata: %{"team_id" => team_b}
+        })
+      )
+
+    {:ok, _} = Graph.add_edge(goal_b.id, action_b.id, :leads_to)
+
+    assert {:ok, %{result: result}} =
+             DecisionQuery.run(%{"query_type" => "pulse"}, %{team_id: team_b})
+
+    assert result =~ "0 coverage gap(s)"
   end
 
   test "search finds matching nodes" do
@@ -50,6 +98,36 @@ defmodule Loomkin.Tools.DecisionQueryTest do
 
     assert result =~ "Authentication module"
     refute result =~ "Database schema"
+  end
+
+  test "search is case-insensitive and scoped to the current team" do
+    team_a = Ecto.UUID.generate()
+    team_b = Ecto.UUID.generate()
+
+    {:ok, _} =
+      Graph.add_node(
+        node_attrs(%{title: "Authentication module", metadata: %{"team_id" => team_a}})
+      )
+
+    {:ok, _} =
+      Graph.add_node(
+        node_attrs(%{title: "Authentication module", metadata: %{"team_id" => team_b}})
+      )
+
+    assert {:ok, %{result: result}} =
+             DecisionQuery.run(
+               %{"query_type" => "search", "search_term" => "auth"},
+               %{team_id: team_a}
+             )
+
+    assert result =~ "Authentication module"
+
+    matches =
+      result
+      |> String.split("\n")
+      |> Enum.count(&String.contains?(&1, "Authentication module"))
+
+    assert matches == 1
   end
 
   test "search with no matches returns none" do

--- a/loomkin-server/test/loomkin/tools/peer_complete_task_test.exs
+++ b/loomkin-server/test/loomkin/tools/peer_complete_task_test.exs
@@ -1,7 +1,24 @@
 defmodule Loomkin.Tools.PeerCompleteTaskTest do
-  use ExUnit.Case, async: true
+  use Loomkin.DataCase, async: false
 
+  alias Loomkin.Teams.{Manager, Tasks}
   alias Loomkin.Tools.PeerCompleteTask
+
+  setup do
+    {:ok, team_id} = Manager.create_team(name: "peer-complete-task-test")
+    Loomkin.Signals.subscribe("context.offloaded")
+
+    on_exit(fn ->
+      DynamicSupervisor.which_children(Loomkin.Teams.AgentSupervisor)
+      |> Enum.each(fn {_, pid, _, _} ->
+        DynamicSupervisor.terminate_child(Loomkin.Teams.AgentSupervisor, pid)
+      end)
+
+      Loomkin.Teams.TableRegistry.delete_table(team_id)
+    end)
+
+    %{team_id: team_id}
+  end
 
   describe "verify_files_changed/2" do
     test "returns empty list when no files claimed" do
@@ -59,6 +76,78 @@ defmodule Loomkin.Tools.PeerCompleteTaskTest do
     test "filters out empty strings and nils" do
       tmp_dir = System.tmp_dir!()
       assert PeerCompleteTask.verify_files_changed(["", nil], tmp_dir) == []
+    end
+  end
+
+  describe "run/2 researcher publication" do
+    test "auto-offloads researcher findings before task completion", %{team_id: team_id} do
+      {:ok, task} = Tasks.create_task(team_id, %{title: "Audit vault indexing"})
+
+      params = %{
+        team_id: team_id,
+        task_id: task.id,
+        result: "Reviewed the vault indexing path and identified the current ingestion gaps.",
+        actions_taken: [
+          "Read vault ingestion modules",
+          "Compared current flow to desired repo indexing flow"
+        ],
+        discoveries: ["Vault currently lacks a code-repo ingestion entry point"],
+        open_questions: ["Should repo ingestion create one keeper per file or per subsystem?"]
+      }
+
+      context = %{
+        team_id: team_id,
+        agent_name: "researcher-1",
+        role: :researcher,
+        publication_state: %{offloaded: false}
+      }
+
+      task_id = task.id
+
+      assert {:ok, %{result: result, task_id: ^task_id}} =
+               PeerCompleteTask.run(params, context)
+
+      assert result =~ "Findings published: research: Audit vault indexing"
+      assert length(Manager.list_keepers(team_id)) == 1
+
+      assert_receive {:signal,
+                      %Jido.Signal{
+                        type: "context.offloaded",
+                        data: %{
+                          agent_name: "researcher-1",
+                          team_id: ^team_id,
+                          payload: %{
+                            topic: "research: Audit vault indexing",
+                            source: "peer_complete_task"
+                          }
+                        }
+                      }}
+    end
+
+    test "does not auto-offload when findings were already offloaded in this loop", %{
+      team_id: team_id
+    } do
+      {:ok, task} = Tasks.create_task(team_id, %{title: "Summarize current cli layout"})
+
+      params = %{
+        team_id: team_id,
+        task_id: task.id,
+        result: "Summarized the current layout issues around crowded panes and command input.",
+        actions_taken: ["Read the cli layout components"],
+        discoveries: ["Status and prompt areas are competing for the same vertical space"]
+      }
+
+      context = %{
+        team_id: team_id,
+        agent_name: "researcher-1",
+        role: :researcher,
+        publication_state: %{offloaded: true}
+      }
+
+      assert {:ok, %{result: result}} = PeerCompleteTask.run(params, context)
+      refute result =~ "Findings published:"
+      assert Manager.list_keepers(team_id) == []
+      refute_receive {:signal, %Jido.Signal{type: "context.offloaded"}}, 200
     end
   end
 end

--- a/loomkin-server/test/loomkin/tools/search_keepers_test.exs
+++ b/loomkin-server/test/loomkin/tools/search_keepers_test.exs
@@ -103,5 +103,19 @@ defmodule Loomkin.Tools.SearchKeepersTest do
       assert first_entry =~ "relevance=2"
       assert second_entry =~ "relevance=1"
     end
+
+    test "prefers the context team id over a hallucinated param team id", %{team_id: team_id} do
+      %{id: keeper_id} =
+        spawn_keeper(team_id,
+          topic: "vault repo ingestion notes",
+          source_agent: "researcher"
+        )
+
+      params = %{query: "vault repo", team_id: "concierge"}
+      assert {:ok, %{result: result}} = SearchKeepers.run(params, context(team_id))
+
+      assert result =~ "Keeper:#{keeper_id}"
+      refute result =~ "No keepers found"
+    end
   end
 end

--- a/loomkin-server/test/loomkin/tools/team_spawn_test.exs
+++ b/loomkin-server/test/loomkin/tools/team_spawn_test.exs
@@ -103,6 +103,76 @@ defmodule Loomkin.Tools.TeamSpawnTest do
 
       on_exit(fn -> Manager.dissolve_team(parent_team_id) end)
     end
+
+    test "resolve_roles infers a minimal research team when spawn_type is research" do
+      params = %{
+        team_name: "vault-ingestion-assessment",
+        purpose: "Assess current vault ingestion support",
+        spawn_type: "research"
+      }
+
+      assert {:ok, [%{name: name, role: "researcher", focus: focus}]} =
+               TeamSpawn.resolve_roles(params)
+
+      assert name == "vault-ingestion-assessment-researcher"
+      assert focus == "Assess current vault ingestion support"
+    end
+
+    test "TeamSpawn.run/2 accepts research spawn without explicit roles" do
+      {:ok, parent_team_id} = Manager.create_team(name: "research-infer-parent")
+
+      params = %{
+        team_name: "vault-ingestion-assessment",
+        purpose: "Assess current vault ingestion support",
+        spawn_type: "research"
+      }
+
+      context = %{
+        parent_team_id: parent_team_id,
+        project_path: nil,
+        session_id: nil,
+        model: nil,
+        agent_name: "test-agent"
+      }
+
+      {:ok, result} = TeamSpawn.run(params, context)
+      assert result.result =~ "vault-ingestion-assessment-researcher (researcher): spawned"
+
+      on_exit(fn -> Manager.dissolve_team(parent_team_id) end)
+    end
+
+    test "research_spawn? infers research delegation for concierge when roles are omitted" do
+      params = %{
+        team_name: "vault-ingestion-assessment",
+        purpose: "Assess current vault ingestion support"
+      }
+
+      assert TeamSpawn.research_spawn?(params, %{role: :concierge})
+      refute TeamSpawn.research_spawn?(params, %{role: :coder})
+    end
+
+    test "TeamSpawn.run/2 infers a research spawn for concierge without explicit roles" do
+      {:ok, parent_team_id} = Manager.create_team(name: "research-infer-concierge-parent")
+
+      params = %{
+        team_name: "vault-ingestion-assessment",
+        purpose: "Assess current vault ingestion support"
+      }
+
+      context = %{
+        parent_team_id: parent_team_id,
+        project_path: nil,
+        session_id: nil,
+        model: nil,
+        agent_name: "concierge",
+        role: :concierge
+      }
+
+      {:ok, result} = TeamSpawn.run(params, context)
+      assert result.result =~ "vault-ingestion-assessment-researcher (researcher): spawned"
+
+      on_exit(fn -> Manager.dissolve_team(parent_team_id) end)
+    end
   end
 
   describe "team manifest" do

--- a/loomkin-server/test/loomkin/tools/team_spawn_test.exs
+++ b/loomkin-server/test/loomkin/tools/team_spawn_test.exs
@@ -176,7 +176,7 @@ defmodule Loomkin.Tools.TeamSpawnTest do
   end
 
   describe "team manifest" do
-    test "spawning agents sends peer_message briefing to each" do
+    test "spawning agents sends a system briefing to each" do
       {:ok, parent_team_id} = Manager.create_team(name: "manifest-parent")
 
       params = %{
@@ -200,22 +200,104 @@ defmodule Loomkin.Tools.TeamSpawnTest do
       {:ok, result} = TeamSpawn.run(params, context)
       team_id = result.team_id
 
-      # Give peer_messages time to be delivered (they are casts)
+      # Give briefings time to be delivered (they are casts)
       Process.sleep(200)
 
-      # Check each agent received a manifest via peer_message in their messages
+      # Check each agent received a manifest briefing in their messages
       for agent_name <- ["r1", "c1", "w1"] do
         {:ok, pid} = Manager.find_agent(team_id, agent_name)
         state = :sys.get_state(pid)
 
         manifest_msgs =
           Enum.filter(state.messages, fn msg ->
-            msg.role == :user and String.contains?(msg.content, "[Team Briefing]")
+            msg.role == :system and String.contains?(msg.content, "[Team Briefing]")
           end)
 
         assert length(manifest_msgs) >= 1,
-               "Expected #{agent_name} to receive a team manifest peer_message"
+               "Expected #{agent_name} to receive a team manifest briefing"
       end
+
+      on_exit(fn -> Manager.dissolve_team(parent_team_id) end)
+    end
+
+    test "manifest tells spawned agents exactly how to report back to the requester" do
+      {:ok, parent_team_id} = Manager.create_team(name: "manifest-reporting-parent")
+
+      params = %{
+        team_name: "reporting-test",
+        roles: [%{name: "alice", role: "researcher"}],
+        purpose: "investigate the vault pipeline"
+      }
+
+      context = %{
+        parent_team_id: parent_team_id,
+        team_id: "requester-team-123",
+        project_path: nil,
+        session_id: nil,
+        model: nil,
+        agent_name: "lead-1"
+      }
+
+      {:ok, result} = TeamSpawn.run(params, context)
+      {:ok, alice_pid} = Manager.find_agent(result.team_id, "alice")
+
+      Process.sleep(50)
+
+      alice_state = :sys.get_state(alice_pid)
+
+      manifest =
+        Enum.find(alice_state.messages, fn msg ->
+          msg.role == :system and String.contains?(msg.content, "[Team Briefing]")
+        end)
+
+      assert manifest
+      assert manifest.content =~ "team requester-team-123"
+      assert manifest.content =~ "peer_message"
+      assert manifest.content =~ ~s(team_id: "requester-team-123")
+      assert manifest.content =~ ~s(to: "lead-1")
+
+      on_exit(fn -> Manager.dissolve_team(parent_team_id) end)
+    end
+
+    test "bootstrap_spawned_team queues a wake-up work order for the spawned team" do
+      {:ok, parent_team_id} = Manager.create_team(name: "bootstrap-helper-parent")
+
+      params = %{
+        team_name: "bootstrap-helper-test",
+        roles: [%{name: "researcher-1", role: "researcher"}],
+        purpose: "inspect the streaming pipeline"
+      }
+
+      context = %{
+        parent_team_id: parent_team_id,
+        team_id: "requester-team-456",
+        project_path: nil,
+        session_id: nil,
+        model: nil,
+        agent_name: "lead-2"
+      }
+
+      {:ok, result} = TeamSpawn.run(params, context)
+
+      assert {:ok, %{name: "researcher-1"}} =
+               TeamSpawn.bootstrap_spawned_team(
+                 result.team_id,
+                 "Start working now and report back with peer_message.",
+                 from: "lead-2"
+               )
+
+      {:ok, researcher_pid} = Manager.find_agent(result.team_id, "researcher-1")
+      Process.sleep(50)
+      researcher_state = :sys.get_state(researcher_pid)
+
+      peer_messages =
+        Enum.filter(researcher_state.messages, fn msg ->
+          msg.role == :user and String.contains?(msg.content, "[Peer lead-2]")
+        end)
+
+      assert length(peer_messages) == 1
+      assert Enum.any?(peer_messages, &String.contains?(&1.content, "Start working now"))
+      assert researcher_state.wake_ref != nil
 
       on_exit(fn -> Manager.dissolve_team(parent_team_id) end)
     end
@@ -251,7 +333,7 @@ defmodule Loomkin.Tools.TeamSpawnTest do
 
       alice_manifest =
         Enum.find(alice_state.messages, fn msg ->
-          msg.role == :user and String.contains?(msg.content, "[Team Briefing]")
+          msg.role == :system and String.contains?(msg.content, "[Team Briefing]")
         end)
 
       assert alice_manifest.content =~ "bob"
@@ -266,7 +348,7 @@ defmodule Loomkin.Tools.TeamSpawnTest do
 
       bob_manifest =
         Enum.find(bob_state.messages, fn msg ->
-          msg.role == :user and String.contains?(msg.content, "[Team Briefing]")
+          msg.role == :system and String.contains?(msg.content, "[Team Briefing]")
         end)
 
       assert bob_manifest.content =~ "alice"

--- a/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
+++ b/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
@@ -20,6 +20,27 @@ defmodule LoomkinWeb.SessionChannelTest do
     {:ok, user: user, scope: scope}
   end
 
+  defp runtime_team_id(session_id, fallback_team_id, attempts \\ 20)
+
+  defp runtime_team_id(_session_id, fallback_team_id, 0), do: fallback_team_id
+
+  defp runtime_team_id(session_id, fallback_team_id, attempts) do
+    team_id =
+      session_id
+      |> Persistence.get_session()
+      |> case do
+        %{team_id: team_id} when is_binary(team_id) and team_id != "" -> team_id
+        _ -> fallback_team_id
+      end
+
+    if team_id != fallback_team_id do
+      team_id
+    else
+      Process.sleep(10)
+      runtime_team_id(session_id, fallback_team_id, attempts - 1)
+    end
+  end
+
   test "forwards peer_message content from signal data message field", %{user: user, scope: scope} do
     {:ok, session} =
       Persistence.create_session(%{
@@ -66,11 +87,13 @@ defmodule LoomkinWeb.SessionChannelTest do
   end
 
   test "formats max-iteration agent errors for cli consumers", %{user: user, scope: scope} do
+    initial_team_id = "team-123"
+
     {:ok, session} =
       Persistence.create_session(%{
         model: "anthropic:claude-sonnet-4-5",
         project_path: "/tmp",
-        team_id: "team-123",
+        team_id: initial_team_id,
         user_id: user.id
       })
 
@@ -85,10 +108,12 @@ defmodule LoomkinWeb.SessionChannelTest do
       0 -> :ok
     end
 
+    team_id = runtime_team_id(session.id, initial_team_id)
+
     signal =
       Loomkin.Signals.Agent.Error.new!(%{
         agent_name: "concierge",
-        team_id: "team-123"
+        team_id: team_id
       })
 
     signal = %{
@@ -99,23 +124,29 @@ defmodule LoomkinWeb.SessionChannelTest do
           })
     }
 
-    send(socket.channel_pid, signal)
+    send(socket.channel_pid, {:signal, signal})
 
-    assert_push "agent_error", %{
-      agent_name: "concierge",
-      error: "Exceeded max iterations (30)"
-    }
+    assert_push(
+      "agent_error",
+      %{
+        agent_name: "concierge",
+        error: "Exceeded max iterations (30)"
+      },
+      500
+    )
   end
 
   test "forwards findings publication events for cli agent indicators", %{
     user: user,
     scope: scope
   } do
+    initial_team_id = "team-123"
+
     {:ok, session} =
       Persistence.create_session(%{
         model: "anthropic:claude-sonnet-4-5",
         project_path: "/tmp",
-        team_id: "team-123",
+        team_id: initial_team_id,
         user_id: user.id
       })
 
@@ -130,10 +161,12 @@ defmodule LoomkinWeb.SessionChannelTest do
       0 -> :ok
     end
 
+    team_id = runtime_team_id(session.id, initial_team_id)
+
     signal =
       Loomkin.Signals.Context.Offloaded.new!(%{
         agent_name: "researcher-1",
-        team_id: "team-123"
+        team_id: team_id
       })
 
     signal = %{
@@ -148,14 +181,18 @@ defmodule LoomkinWeb.SessionChannelTest do
           })
     }
 
-    send(socket.channel_pid, signal)
+    send(socket.channel_pid, {:signal, signal})
 
-    assert_push "agent_findings_published", %{
-      agent_name: "researcher-1",
-      team_id: "team-123",
-      topic: "research: cli layout audit",
-      source: "peer_complete_task",
-      task_id: "task-123"
-    }
+    assert_push(
+      "agent_findings_published",
+      %{
+        agent_name: "researcher-1",
+        team_id: ^team_id,
+        topic: "research: cli layout audit",
+        source: "peer_complete_task",
+        task_id: "task-123"
+      },
+      500
+    )
   end
 end

--- a/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
+++ b/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
@@ -106,4 +106,56 @@ defmodule LoomkinWeb.SessionChannelTest do
       error: "Exceeded max iterations (30)"
     }
   end
+
+  test "forwards findings publication events for cli agent indicators", %{
+    user: user,
+    scope: scope
+  } do
+    {:ok, session} =
+      Persistence.create_session(%{
+        model: "anthropic:claude-sonnet-4-5",
+        project_path: "/tmp",
+        team_id: "team-123",
+        user_id: user.id
+      })
+
+    socket = socket(LoomkinWeb.UserSocket, "user_socket:#{user.id}", %{current_scope: scope})
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, SessionChannel, "session:#{session.id}")
+
+    receive do
+      {:email, _email} -> :ok
+    after
+      0 -> :ok
+    end
+
+    signal =
+      Loomkin.Signals.Context.Offloaded.new!(%{
+        agent_name: "researcher-1",
+        team_id: "team-123"
+      })
+
+    signal = %{
+      signal
+      | data:
+          Map.merge(signal.data, %{
+            payload: %{
+              topic: "research: cli layout audit",
+              source: "peer_complete_task",
+              task_id: "task-123"
+            }
+          })
+    }
+
+    send(socket.channel_pid, signal)
+
+    assert_push "agent_findings_published", %{
+      agent_name: "researcher-1",
+      team_id: "team-123",
+      topic: "research: cli layout audit",
+      source: "peer_complete_task",
+      task_id: "task-123"
+    }
+  end
 end

--- a/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
+++ b/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
@@ -1,0 +1,61 @@
+defmodule LoomkinWeb.SessionChannelTest do
+  use ExUnit.Case, async: false
+  import Phoenix.ChannelTest
+
+  import Loomkin.AccountsFixtures
+
+  alias Loomkin.Accounts.Scope
+  alias Loomkin.Session.Persistence
+  alias LoomkinWeb.SessionChannel
+
+  @endpoint LoomkinWeb.Endpoint
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Loomkin.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Loomkin.Repo, {:shared, self()})
+
+    user = user_fixture()
+    scope = Scope.for_user(user)
+
+    {:ok, user: user, scope: scope}
+  end
+
+  test "forwards peer_message content from signal data message field", %{user: user, scope: scope} do
+    {:ok, session} =
+      Persistence.create_session(%{
+        model: "anthropic:claude-sonnet-4-5",
+        project_path: "/tmp",
+        team_id: "team-123",
+        user_id: user.id
+      })
+
+    socket = socket(LoomkinWeb.UserSocket, "user_socket:#{user.id}", %{current_scope: scope})
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, SessionChannel, "session:#{session.id}")
+
+    signal =
+      Loomkin.Signals.Collaboration.PeerMessage.new!(%{
+        from: "system",
+        team_id: "team-123"
+      })
+
+    signal = %{
+      signal
+      | data:
+          Map.merge(signal.data, %{
+            target: "concierge",
+            message: {:peer_message, "system", "spawned researcher"}
+          })
+    }
+
+    send(socket.channel_pid, signal)
+
+    assert_push "peer_message", %{
+      from: "system",
+      to: "concierge",
+      content: "spawned researcher",
+      team_id: "team-123"
+    }
+  end
+end

--- a/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
+++ b/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
@@ -136,6 +136,42 @@ defmodule LoomkinWeb.SessionChannelTest do
     )
   end
 
+  test "forwards architect stream deltas that use text payloads", %{user: user, scope: scope} do
+    {:ok, session} =
+      Persistence.create_session(%{
+        model: "anthropic:claude-sonnet-4-5",
+        project_path: "/tmp",
+        team_id: "team-architect",
+        user_id: user.id
+      })
+
+    socket = socket(LoomkinWeb.UserSocket, "user_socket:#{user.id}", %{current_scope: scope})
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, SessionChannel, "session:#{session.id}")
+
+    receive do
+      {:email, _email} -> :ok
+    after
+      0 -> :ok
+    end
+
+    signal =
+      Loomkin.Signals.Session.StatusChanged.new!(%{
+        session_id: session.id,
+        status: :streaming
+      })
+      |> Map.put(:data, %{
+        session_id: session.id,
+        status: :streaming,
+        raw_event: {:stream_delta, session.id, %{text: "architect chunk"}}
+      })
+
+    send(socket.channel_pid, {:signal, signal})
+
+    assert_push("stream_token", %{token: "architect chunk"}, 500)
+  end
+
   test "forwards findings publication events for cli agent indicators", %{
     user: user,
     scope: scope
@@ -194,5 +230,133 @@ defmodule LoomkinWeb.SessionChannelTest do
       },
       500
     )
+  end
+
+  test "forwards child team creation events for cli activity visibility", %{
+    user: user,
+    scope: scope
+  } do
+    initial_team_id = "team-123"
+
+    {:ok, session} =
+      Persistence.create_session(%{
+        model: "anthropic:claude-sonnet-4-5",
+        project_path: "/tmp",
+        team_id: initial_team_id,
+        user_id: user.id
+      })
+
+    socket = socket(LoomkinWeb.UserSocket, "user_socket:#{user.id}", %{current_scope: scope})
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, SessionChannel, "session:#{session.id}")
+
+    receive do
+      {:email, _email} -> :ok
+    after
+      0 -> :ok
+    end
+
+    team_id = runtime_team_id(session.id, initial_team_id)
+
+    signal =
+      Loomkin.Signals.Team.ChildTeamCreated.new!(%{
+        team_id: "child-team-456",
+        parent_team_id: team_id,
+        team_name: "vault-ingestion-team",
+        depth: 1
+      })
+
+    send(socket.channel_pid, {:signal, signal})
+
+    assert_push(
+      "child_team_created",
+      %{
+        child_team_id: "child-team-456",
+        parent_team_id: ^team_id,
+        team_name: "vault-ingestion-team",
+        depth: 1
+      },
+      500
+    )
+  end
+
+  test "forwards child team stream activity without merging it into the root stream", %{
+    user: user,
+    scope: scope
+  } do
+    {:ok, initial_team_id} =
+      Loomkin.Teams.Manager.create_team(name: "session-channel-parent", project_path: "/tmp")
+
+    {:ok, session} =
+      Persistence.create_session(%{
+        model: "anthropic:claude-sonnet-4-5",
+        project_path: "/tmp",
+        team_id: initial_team_id,
+        user_id: user.id
+      })
+
+    socket = socket(LoomkinWeb.UserSocket, "user_socket:#{user.id}", %{current_scope: scope})
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, SessionChannel, "session:#{session.id}")
+
+    receive do
+      {:email, _email} -> :ok
+    after
+      0 -> :ok
+    end
+
+    team_id = runtime_team_id(session.id, initial_team_id)
+
+    {:ok, child_team_id} =
+      Loomkin.Teams.Manager.create_sub_team(team_id, "concierge",
+        name: "vault-ingestion-team",
+        project_path: "/tmp"
+      )
+
+    start_signal =
+      Loomkin.Signals.Agent.StreamStart.new!(%{
+        agent_name: "vault-ingestion-team-researcher",
+        team_id: child_team_id
+      })
+
+    delta_signal =
+      Loomkin.Signals.Agent.StreamDelta.new!(%{
+        agent_name: "vault-ingestion-team-researcher",
+        team_id: child_team_id
+      })
+      |> Map.put(:data, %{
+        agent_name: "vault-ingestion-team-researcher",
+        team_id: child_team_id,
+        payload: %{text: "Inspecting /vault ingestion flow"}
+      })
+
+    send(socket.channel_pid, {:signal, start_signal})
+
+    assert_push(
+      "agent_stream_start",
+      %{
+        agent_name: "vault-ingestion-team-researcher",
+        team_id: ^child_team_id
+      },
+      500
+    )
+
+    refute_push "stream_start", %{}, 100
+
+    send(socket.channel_pid, {:signal, delta_signal})
+
+    assert_push(
+      "agent_stream_delta",
+      %{
+        agent_name: "vault-ingestion-team-researcher",
+        team_id: ^child_team_id,
+        token: "Inspecting /vault ingestion flow"
+      },
+      500
+    )
+
+    refute_push "stream_token", %{token: "Inspecting /vault ingestion flow"}, 100
   end
 end

--- a/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
+++ b/loomkin-server/test/loomkin_web/channels/session_channel_test.exs
@@ -34,6 +34,12 @@ defmodule LoomkinWeb.SessionChannelTest do
     {:ok, _, socket} =
       subscribe_and_join(socket, SessionChannel, "session:#{session.id}")
 
+    receive do
+      {:email, _email} -> :ok
+    after
+      0 -> :ok
+    end
+
     signal =
       Loomkin.Signals.Collaboration.PeerMessage.new!(%{
         from: "system",
@@ -56,6 +62,48 @@ defmodule LoomkinWeb.SessionChannelTest do
       to: "concierge",
       content: "spawned researcher",
       team_id: "team-123"
+    }
+  end
+
+  test "formats max-iteration agent errors for cli consumers", %{user: user, scope: scope} do
+    {:ok, session} =
+      Persistence.create_session(%{
+        model: "anthropic:claude-sonnet-4-5",
+        project_path: "/tmp",
+        team_id: "team-123",
+        user_id: user.id
+      })
+
+    socket = socket(LoomkinWeb.UserSocket, "user_socket:#{user.id}", %{current_scope: scope})
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, SessionChannel, "session:#{session.id}")
+
+    receive do
+      {:email, _email} -> :ok
+    after
+      0 -> :ok
+    end
+
+    signal =
+      Loomkin.Signals.Agent.Error.new!(%{
+        agent_name: "concierge",
+        team_id: "team-123"
+      })
+
+    signal = %{
+      signal
+      | data:
+          Map.merge(signal.data, %{
+            payload: %{iterations: 30, max: 30}
+          })
+    }
+
+    send(socket.channel_pid, signal)
+
+    assert_push "agent_error", %{
+      agent_name: "concierge",
+      error: "Exceeded max iterations (30)"
     }
   end
 end


### PR DESCRIPTION
## summary
- fix cli/session channel handling for kin collaboration messages and add agent wake/usage logging to surface duplicated or fanout-heavy request paths
- make openai codex oauth work reliably for current codex models, including gpt-5.4, streamed responses, resume/tool-call replay, and spawned conversation agents
- improve the cli model picker navigation by separating selectable model rows from provider headers and covering the new state helpers with tests

## testing
- `cd apps/cli && bun test src/components/modelPickerState.test.ts 2>&1 | tee /tmp/loomkin_cli_modelpicker_test.log`
- `cd apps/cli && bun run typecheck 2>&1 | tee /tmp/loomkin_cli_typecheck.log`
- `cd loomkin-server && ~/.local/bin/mise exec -- mix test test/loomkin/agent_loop_test.exs test/loomkin/conversations/agent_test.exs test/loomkin/llm_test.exs test/loomkin/models_test.exs test/loomkin/providers/openai_codex_models_test.exs test/loomkin/providers/oauth_adapters_test.exs test/loomkin/teams/agent_test.exs test/loomkin/teams/cost_tracker_test.exs test/loomkin_web/channels/session_channel_test.exs 2>&1 | tee /tmp/loomkin_pr_tests.log`

## notes
- targeted tests passed locally; the run still emits existing warnings around notifier typing, sandbox ownership, and missing anthropic test credentials
